### PR TITLE
Add array item schema support

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,6 +27,7 @@ This repository contains the TOML Schema Definition (TOSD) specification/proposa
 - Custom metadata belongs under `[toml-schema.meta]`; do not add arbitrary keys or subtables directly under `[toml-schema]`.
 - Reusable definitions live under `[types.<name>]` and are referenced from `[elements]` or nested type definitions rather than duplicating structures.
 - Prefer canonical `typeof` and `collection` in schema examples. The Java implementation still accepts legacy aliases `typeref` and `table-collection` for compatibility.
+- Use `itemtype = "types.<name>"` on `type = "array"` definitions when array items need structural validation, including TOML arrays of tables (`[[name]]`) and arrays of inline tables.
 - Use `[...children.<name>]` in schema documents when defining a child whose name collides with built-in schema properties like `type`, `typeof`, or `optional`; `toml-schema.tosd` uses this for the self-schema.
 - Optionality defaults to required behavior. Only mark a schema node optional with `optional = true` when the TOML document may omit that structure.
 - Tables with no defined child structure are intentionally open-ended; tables with defined child properties are intended to validate exactly against those children.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The schema format follows the TOML specification, meaning that a TOML Schema is 
       - [Tables](#tables)
       - [Arrays](#arrays)
         - [Observations on Conditions to Arrays](#observations-on-conditions-to-arrays)
+        - [Array Item Schemas and Arrays of Tables](#array-item-schemas-and-arrays-of-tables)
       - [Collection of Elements for Dynamic Keys](#collection-of-elements-for-dynamic-keys)
     - [Type Reference](#type-reference)
     - [Optionality - `optional`](#optionality---optional)
@@ -186,7 +187,8 @@ The `[types]` table is for use when there is a need for custom, reusable types o
 [types.<typename>]
 type = "<simple-type> | array | table | collection"
 typeof = "<full-name-of-a-defined-type>"
-arraytype = "<simple-type>"
+arraytype = "<simple-type> | array | table"
+itemtype = "<full-name-of-a-defined-type>"
 allowedvalues = [ <array-with-enumeration-of-allowed-values> ]
 pattern = "<string-regex-for-string-validation>"
 optional = true|false
@@ -261,7 +263,8 @@ If a property of type `table` has no defined property and/or structure, the pars
 
 Arrays can be defined by mixing the following properties:
 
- - `arraytype`: the type of the value in the array (e.g. string).
+ - `arraytype`: the built-in type of each value in the array (e.g. string, array, or table).
+ - `itemtype`: a reusable `[types]` definition used to validate each item in the array.
  - `minlength`: the minimum length of the array (e.g. no less than 2 elements).
  - `maxlength`: the maximum length of the array (e.g. no more than 2 elements).
  - `minvalue`: the minimum value of the array (e.g. 80).
@@ -295,6 +298,67 @@ If `allowedvalues` does not match the conditions of `minlength`, `maxlength`, `m
 If `arraytype` is not defined, then the type of array elements is `any`, and any data type can be used and mixed together.
 
 If `type` is `array` and `arraytype` is of type `array`, then automatically any data type can be used and mixed together.
+
+##### Array Item Schemas and Arrays of Tables
+
+Use `itemtype` when each array item must be validated against a reusable schema definition. This is required for TOML arrays of tables and arrays of inline tables, because both parse as arrays whose items are table values.
+
+Example with TOML arrays of tables:
+
+```toml
+[[products]]
+name = "Hammer"
+sku = 738594937
+
+[[products]]
+name = "Nail"
+sku = 284758393
+```
+
+Schema:
+
+```toml
+[types.productType]
+type = "table"
+
+    [types.productType.name]
+    type = "string"
+
+    [types.productType.sku]
+    type = "integer"
+
+[elements.products]
+type = "array"
+arraytype = "table"
+itemtype = "types.productType"
+```
+
+Example with TOML arrays of inline tables:
+
+```toml
+points = [
+  { x = 1, y = 2 },
+  { x = 3, y = 4 }
+]
+```
+
+Schema:
+
+```toml
+[types.pointType]
+type = "table"
+
+    [types.pointType.x]
+    type = "integer"
+
+    [types.pointType.y]
+    type = "integer"
+
+[elements.points]
+type = "array"
+arraytype = "table"
+itemtype = "types.pointType"
+```
 
 #### Collection of Elements for Dynamic Keys
 

--- a/config.toml
+++ b/config.toml
@@ -75,8 +75,23 @@ hosts = [
   "omega"
 ]
 
+points = [
+  { x = 1, y = 2, z = 3 },
+  { x = 7, y = 8, z = 9 },
+  { x = 2, y = 4 }
+]
+
 # This element is a 'table-collection' of type 'libraryType'
 # and each library can be expressed with an inline table
 [libraries]
 lib1 = { name = "gcc", version = "10.2" }
 lib2 = { name = "make", version = "4.0" }
+
+[[products]]
+name = "Hammer"
+sku = 738594937
+
+[[products]]
+name = "Nail"
+sku = 284758393
+color = "gray"

--- a/config.tosd
+++ b/config.tosd
@@ -84,6 +84,32 @@ version = "1"
         [types.libraryType.version]
         type = "string"
 
+    [types.productType]
+    type = "table"
+
+        [types.productType.name]
+        type = "string"
+
+        [types.productType.sku]
+        type = "integer"
+
+        [types.productType.color]
+        type = "string"
+        optional = true
+
+    [types.pointType]
+    type = "table"
+
+        [types.pointType.x]
+        type = "integer"
+
+        [types.pointType.y]
+        type = "integer"
+
+        [types.pointType.z]
+        type = "integer"
+        optional = true
+
 [elements]
 
     [elements.title]
@@ -115,6 +141,17 @@ version = "1"
         type = "array"
         arraytype = "string"
 
+        [elements.clients.points]
+        type = "array"
+        arraytype = "table"
+        itemtype = "types.pointType"
+
     [elements.libraries]
     type = "collection"
     typeof = "types.libraryType"
+
+    [elements.products]
+    type = "array"
+    arraytype = "table"
+    itemtype = "types.productType"
+    minlength = 1

--- a/src/main/java/io/github/brunoborges/tomlschema/SchemaDefinition.java
+++ b/src/main/java/io/github/brunoborges/tomlschema/SchemaDefinition.java
@@ -2,7 +2,6 @@ package io.github.brunoborges.tomlschema;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.regex.Pattern;
 
 record SchemaDefinition(
@@ -10,6 +9,7 @@ record SchemaDefinition(
         SchemaType type,
         String reference,
         SchemaType arrayType,
+        String itemReference,
         boolean optional,
         List<Object> allowedValues,
         Pattern pattern,
@@ -24,7 +24,4 @@ record SchemaDefinition(
         children = Map.copyOf(children);
     }
 
-    Optional<String> referenceName() {
-        return Optional.ofNullable(reference);
-    }
 }

--- a/src/main/java/io/github/brunoborges/tomlschema/SchemaLoader.java
+++ b/src/main/java/io/github/brunoborges/tomlschema/SchemaLoader.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 final class SchemaLoader {
     private static final Set<String> TOP_LEVEL_KEYS = Set.of("toml-schema", "types", "elements");
     private static final Set<String> DEFINITION_KEYS = Set.of(
-            "type", "typeof", "typeref", "arraytype", "allowedvalues", "pattern",
+            "type", "typeof", "typeref", "arraytype", "itemtype", "allowedvalues", "pattern",
             "optional", "default", "min", "max", "minlength", "maxlength", "minoccurs", "maxoccurs",
             "oneof", "anyof", "children"
     );
@@ -91,6 +91,7 @@ final class SchemaLoader {
         }
         String normalizedReference = normalizeReference(reference != null ? reference : legacyReference);
         SchemaType arrayType = getSchemaType(table, "arraytype");
+        String itemReference = normalizeReference(getString(table, "itemtype"));
         Boolean optional = getBoolean(table, "optional");
         Pattern pattern = getPattern(name, table);
         Integer minLength = getInteger(table, "minlength");
@@ -139,11 +140,15 @@ final class SchemaLoader {
         if (type != SchemaType.ARRAY && arrayType != null) {
             throw new SchemaException(name + " can only define arraytype when type is array");
         }
+        if (type != SchemaType.ARRAY && itemReference != null) {
+            throw new SchemaException(name + " can only define itemtype when type is array");
+        }
         return new SchemaDefinition(
                 name,
                 type,
                 normalizedReference,
                 arrayType,
+                itemReference,
                 optional != null && optional,
                 allowedValues,
                 pattern,

--- a/src/main/java/io/github/brunoborges/tomlschema/TomlSchemaValidator.java
+++ b/src/main/java/io/github/brunoborges/tomlschema/TomlSchemaValidator.java
@@ -106,18 +106,29 @@ final class TomlSchemaValidator {
     private void validateArray(String path, TomlArray array, SchemaDefinition definition) {
         validateLength(path, array.size(), definition);
         SchemaType arrayType = definition.arrayType() == null ? SchemaType.ANY : definition.arrayType();
-        if (arrayType == SchemaType.ANY) {
+        SchemaDefinition itemDefinition = definition.itemReference() == null
+                ? null
+                : resolveReference(definition.itemReference(), new HashSet<>());
+        if (arrayType == SchemaType.ANY && itemDefinition == null) {
             return;
         }
         for (int i = 0; i < array.size(); i++) {
             Object item = array.get(i);
             String itemPath = path + "[" + i + "]";
-            validateType(itemPath, item, arrayType);
-            if (!isType(item, arrayType)) {
+            boolean matchesArrayType = true;
+            if (arrayType != SchemaType.ANY) {
+                validateType(itemPath, item, arrayType);
+                matchesArrayType = isType(item, arrayType);
+            }
+            if (!matchesArrayType) {
                 continue;
             }
-            validateAllowedValues(itemPath, item, definition);
-            validateRange(itemPath, item, definition);
+            if (itemDefinition == null) {
+                validateAllowedValues(itemPath, item, definition);
+                validateRange(itemPath, item, definition);
+            } else {
+                validateValue(itemPath, item, itemDefinition);
+            }
         }
     }
 
@@ -218,6 +229,7 @@ final class TomlSchemaValidator {
                 type,
                 reference,
                 definition.arrayType() == null ? referenced.arrayType() : definition.arrayType(),
+                definition.itemReference() == null ? referenced.itemReference() : definition.itemReference(),
                 definition.optional() || referenced.optional(),
                 definition.allowedValues().isEmpty() ? referenced.allowedValues() : definition.allowedValues(),
                 definition.pattern() == null ? referenced.pattern() : definition.pattern(),

--- a/src/test/java/io/github/brunoborges/tomlschema/TomlSchemaTest.java
+++ b/src/test/java/io/github/brunoborges/tomlschema/TomlSchemaTest.java
@@ -89,6 +89,74 @@ class TomlSchemaTest {
     }
 
     @Test
+    void validatesArrayOfTablesWithItemSchema() throws IOException {
+        Path schema = write("products.tosd", """
+                [toml-schema]
+                version = "1"
+
+                [types.product]
+                type = "table"
+
+                    [types.product.name]
+                    type = "string"
+
+                    [types.product.sku]
+                    type = "integer"
+
+                [elements.products]
+                type = "array"
+                arraytype = "table"
+                itemtype = "types.product"
+                minlength = 2
+                """);
+        Path document = write("products.toml", """
+                [[products]]
+                name = "Hammer"
+                sku = 738594937
+
+                [[products]]
+                name = "Nail"
+                sku = 284758393
+                """);
+
+        ValidationResult result = TomlSchema.load(schema).validate(document);
+
+        assertTrue(result.isValid(), () -> result.errors().toString());
+    }
+
+    @Test
+    void validatesArraysOfInlineTablesWithItemSchema() throws IOException {
+        Path schema = write("points.tosd", """
+                [toml-schema]
+                version = "1"
+
+                [types.point]
+                type = "table"
+
+                    [types.point.x]
+                    type = "integer"
+
+                    [types.point.y]
+                    type = "integer"
+
+                [elements.points]
+                type = "array"
+                arraytype = "table"
+                itemtype = "types.point"
+                """);
+        Path document = write("points.toml", """
+                points = [
+                  { x = 1, y = 2 },
+                  { x = 3, y = 4 }
+                ]
+                """);
+
+        ValidationResult result = TomlSchema.load(schema).validate(document);
+
+        assertTrue(result.isValid(), () -> result.errors().toString());
+    }
+
+    @Test
     void cliLocatesSchemaFromDocumentMetadata() throws IOException {
         write("schema.tosd", """
                 [toml-schema]

--- a/toml-schema.abnf
+++ b/toml-schema.abnf
@@ -11,11 +11,13 @@ types-table = table-open "types" table-close ws-comment-newline 0*elementdef
 elements-table = table-open "elements" table-close ws-comment-newline 0*elementdef
 
 ;; Built-in properties
-version = ws "version" keyval-sep integer ws-comment-newline
+version = ws "version" keyval-sep basic-string ws-comment-newline
 
 type = ws "type" keyval-sep built-in-type ws-comment-newline
+typeof = ws "typeof" keyval-sep basic-string ws-comment-newline
 typeref = ws "typeref" keyval-sep basic-string ws-comment-newline
 arraytype =  ws "arraytype" keyval-sep built-in-type ws-comment-newline
+itemtype = ws "itemtype" keyval-sep basic-string ws-comment-newline
 optional = ws "optional" keyval-sep boolean ws-comment-newline
 default = ws "default" keyval-sep val ws-comment-newline
 minlength = ws "minlength" keyval-sep integer ws-comment-newline
@@ -27,8 +29,10 @@ allowedvalues = ws "allowedvalues" keyval-sep array ws-comment-newline
 
 elementdef = table ws-comment-newline
 [ type ws-comment-newline ]
+[ typeof ws-comment-newline ]
 [ typeref ws-comment-newline ]
 [ arraytype ws-comment-newline ]
+[ itemtype ws-comment-newline ]
 [ optional ws-comment-newline ]
 [ default ws-comment-newline ]
 [ minlength ws-comment-newline ]
@@ -152,6 +156,7 @@ built-in-type =/ offsetdatetimetype
 built-in-type =/ arraytype
 built-in-type =/ tabletype
 ;; built-in-type =/ inlinetabletype
+built-in-type =/ collectiontype
 built-in-type =/ tablecollectiontype
 
 ;; Simple Types
@@ -169,6 +174,7 @@ offsetdatetimetype = %x6f.66.66.73.65.74.2d.64.61.74.65.2d.74.69.6d.65 ; offset-
 arraytype          = %x61.72.72.61.79                            ; array
 tabletype          = %x74.61.62.6c.65                            ; table
 ;; inlinetabletype    = %x69.6e.6c.69.6e.65.2d.74.61.62.6c.65       ; inline-table
+collectiontype     = %x63.6f.6c.6c.65.63.74.69.6f.6e             ; collection
 tablecollectiontype  = %x74.61.62.6c.65.2d.63.6f.6c.6c.65.63.74.69.6f.6e ; table-collection
 
 ;; Boolean

--- a/toml-schema.tosd
+++ b/toml-schema.tosd
@@ -27,6 +27,10 @@ version = "1"
         allowedvalues = [ "any", "string", "integer", "float", "boolean", "offset-date-time", "local-date-time", "local-date", "local-time", "array", "table" ]
         optional = true
 
+        [types.schemaDef.children.itemtype]
+        type = "string"
+        optional = true
+
         [types.schemaDef.children.allowedvalues]
         type = "array"
         arraytype = "any"


### PR DESCRIPTION
## Summary
- add itemtype support for array item schema references
- validate arrays of tables and arrays of inline tables
- update spec docs, self-schema, examples, and tests

## Testing
- mvn test