### PR TITLE
Support special TOML key schema paths

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,7 +28,7 @@ This repository contains the TOML Schema Definition (TOSD) specification/proposa
 - Reusable definitions live under `[types.<name>]` and are referenced from `[elements]` or nested type definitions rather than duplicating structures.
 - Prefer canonical `typeof` and `collection` in schema examples. The Java implementation still accepts legacy aliases `typeref` and `table-collection` for compatibility.
 - Use `itemtype = "types.<name>"` on `type = "array"` definitions when array items need structural validation, including TOML arrays of tables (`[[name]]`) and arrays of inline tables.
-- Use `[...children.<name>]` in schema documents when defining a child whose name collides with built-in schema properties like `type`, `typeof`, or `optional`; `toml-schema.tosd` uses this for the self-schema.
+- Use `[...children]` with inline table entries for literal dotted, quoted, empty, or built-in-colliding TOML keys, e.g. `"google.com" = { type = "boolean" }`.
 - Optionality defaults to required behavior. Only mark a schema node optional with `optional = true` when the TOML document may omit that structure.
 - Tables with no defined child structure are intentionally open-ended; tables with defined child properties are intended to validate exactly against those children.
 - `pattern` applies to string validation, and the README specifies Perl/PCRE-compatible regular expressions for parsers.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The schema format follows the TOML specification, meaning that a TOML Schema is 
     - [Supported Properties](#supported-properties)
   - [Elements table - `[elements]`](#elements-table---elements)
   - [Types table - `[types]`](#types-table---types)
+    - [Keys That Need Escaping](#keys-that-need-escaping)
     - [Simple Types - `<simple-type>`](#simple-types---simple-type)
       - [Allowed Values for Simple Types - `allowedvalues`](#allowed-values-for-simple-types---allowedvalues)
     - [Minimum Value / Maximum Value - `min` and `max`](#minimum-value--maximum-value---min-and-max)
@@ -196,6 +197,32 @@ min = <any>
 max = <any>
 minlength = <integer>
 maxlength = <integer>
+```
+
+### Keys That Need Escaping
+
+Schema child definitions usually use nested TOML tables, but TOML keys can be quoted, empty, contain dots, or collide with built-in schema property names such as `type`, `typeof`, and `optional`. Use a `children` table to define those keys unambiguously.
+
+Example TOML document:
+
+```toml
+"" = "blank"
+
+[site]
+"google.com" = true
+```
+
+Schema:
+
+```toml
+[elements.children]
+"" = { type = "string" }
+
+[elements.site]
+type = "table"
+
+    [elements.site.children]
+    "google.com" = { type = "boolean" }
 ```
 
 ### Simple Types - `<simple-type>`

--- a/src/main/java/io/github/brunoborges/tomlschema/SchemaLoader.java
+++ b/src/main/java/io/github/brunoborges/tomlschema/SchemaLoader.java
@@ -73,7 +73,17 @@ final class SchemaLoader {
         }
         Map<String, SchemaDefinition> definitions = new LinkedHashMap<>();
         for (String key : table.keySet()) {
-            Object value = table.get(key);
+            Object value = table.get(List.of(key));
+            if (key.equals("children") && value instanceof TomlTable childrenTable && !hasDefinitionMarker(childrenTable)) {
+                for (String childKey : childrenTable.keySet()) {
+                    Object childValue = childrenTable.get(List.of(childKey));
+                    if (!(childValue instanceof TomlTable childDefinitionTable)) {
+                        throw new SchemaException("[" + prefix + ".children] entry must be a table: " + childKey);
+                    }
+                    definitions.put(childKey, parseDefinition(prefix + "." + childKey, childDefinitionTable));
+                }
+                continue;
+            }
             if (!(value instanceof TomlTable definitionTable)) {
                 throw new SchemaException("[" + prefix + "] entry must be a table: " + key);
             }
@@ -110,7 +120,7 @@ final class SchemaLoader {
         TomlTable explicitChildren = table.getTable("children");
         if (explicitChildren != null) {
             for (String key : explicitChildren.keySet()) {
-                Object value = explicitChildren.get(key);
+                Object value = explicitChildren.get(List.of(key));
                 if (!(value instanceof TomlTable childTable)) {
                     throw new SchemaException(name + ".children." + key + " must be a table");
                 }
@@ -118,7 +128,7 @@ final class SchemaLoader {
             }
         }
         for (String key : table.keySet()) {
-            Object value = table.get(key);
+            Object value = table.get(List.of(key));
             if (value instanceof TomlTable childTable) {
                 if (DEFINITION_KEYS.contains(key)) {
                     if (!key.equals("children")) {
@@ -163,6 +173,12 @@ final class SchemaLoader {
     private SchemaType getSchemaType(TomlTable table, String key) {
         String value = getString(table, key);
         return value == null ? null : SchemaType.fromSchemaName(value);
+    }
+
+    private boolean hasDefinitionMarker(TomlTable table) {
+        return table.contains(List.of("type"))
+                || table.contains(List.of("typeof"))
+                || table.contains(List.of("typeref"));
     }
 
     private String getString(TomlTable table, String key) {

--- a/src/main/java/io/github/brunoborges/tomlschema/TomlSchemaValidator.java
+++ b/src/main/java/io/github/brunoborges/tomlschema/TomlSchemaValidator.java
@@ -36,8 +36,8 @@ final class TomlSchemaValidator {
         for (Map.Entry<String, SchemaDefinition> entry : definitions.entrySet()) {
             String key = entry.getKey();
             SchemaDefinition definition = resolve(entry.getValue(), new HashSet<>());
-            Object value = table.get(key);
-            String childPath = path + "." + key;
+            Object value = table.get(List.of(key));
+            String childPath = appendPath(path, key);
             if (value == null) {
                 if (!definition.optional()) {
                     add(childPath, "required value is missing");
@@ -72,7 +72,7 @@ final class TomlSchemaValidator {
         validateTable(path, table, definition.children());
         for (String key : table.keySet()) {
             if (!definition.children().containsKey(key)) {
-                add(path + "." + key, "unexpected key");
+                add(appendPath(path, key), "unexpected key");
             }
         }
     }
@@ -81,7 +81,7 @@ final class TomlSchemaValidator {
         int dynamicEntries = 0;
         for (Map.Entry<String, Object> entry : table.entrySet()) {
             String key = entry.getKey();
-            String childPath = path + "." + key;
+            String childPath = appendPath(path, key);
             SchemaDefinition fixedChild = definition.children().get(key);
             if (fixedChild != null) {
                 validateValue(childPath, entry.getValue(), fixedChild);
@@ -97,8 +97,8 @@ final class TomlSchemaValidator {
         }
         validateLength(path, dynamicEntries, definition);
         for (Map.Entry<String, SchemaDefinition> entry : definition.children().entrySet()) {
-            if (!table.contains(entry.getKey()) && !resolve(entry.getValue(), new HashSet<>()).optional()) {
-                add(path + "." + entry.getKey(), "required value is missing");
+            if (!table.contains(List.of(entry.getKey())) && !resolve(entry.getValue(), new HashSet<>()).optional()) {
+                add(appendPath(path, entry.getKey()), "required value is missing");
             }
         }
     }
@@ -284,6 +284,17 @@ final class TomlSchemaValidator {
             return "table";
         }
         return value == null ? "null" : value.getClass().getSimpleName();
+    }
+
+    private String appendPath(String path, String key) {
+        return path + "." + formatKey(key);
+    }
+
+    private String formatKey(String key) {
+        if (key.matches("[A-Za-z0-9_-]+")) {
+            return key;
+        }
+        return "\"" + key.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
     }
 
     private void add(String path, String message) {

--- a/src/test/java/io/github/brunoborges/tomlschema/TomlSchemaTest.java
+++ b/src/test/java/io/github/brunoborges/tomlschema/TomlSchemaTest.java
@@ -157,6 +157,56 @@ class TomlSchemaTest {
     }
 
     @Test
+    void supportsQuotedDottedAndEmptyTomlKeysWithChildrenTable() throws IOException {
+        Path schema = write("special-keys.tosd", """
+                [toml-schema]
+                version = "1"
+
+                [elements.site]
+                type = "table"
+
+                    [elements.site.children]
+                    "google.com" = { type = "boolean" }
+
+                [elements.children]
+                "" = { type = "string" }
+                """);
+        Path document = write("special-keys.toml", """
+                "" = "blank"
+
+                [site]
+                "google.com" = true
+                """);
+
+        ValidationResult result = TomlSchema.load(schema).validate(document);
+
+        assertTrue(result.isValid(), () -> result.errors().toString());
+    }
+
+    @Test
+    void quotesSpecialKeysInValidationErrorPaths() throws IOException {
+        Path schema = write("special-key-error.tosd", """
+                [toml-schema]
+                version = "1"
+
+                [elements.site]
+                type = "table"
+
+                    [elements.site.children]
+                    "google.com" = { type = "boolean" }
+                """);
+        Path document = write("special-key-error.toml", """
+                [site]
+                "google.com" = "yes"
+                """);
+
+        ValidationResult result = TomlSchema.load(schema).validate(document);
+
+        assertFalse(result.isValid());
+        assertTrue(result.errors().stream().anyMatch(error -> error.path().equals("$.site.\"google.com\"")));
+    }
+
+    @Test
     void cliLocatesSchemaFromDocumentMetadata() throws IOException {
         write("schema.tosd", """
                 [toml-schema]


### PR DESCRIPTION
## Summary
- support literal dotted and empty keys via children tables
- preserve literal key lookups instead of dotted lookup expansion
- quote special keys in validation error paths

## Testing
- mvn test