### PR TITLE
Add general union validation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,6 +28,7 @@ This repository contains the TOML Schema Definition (TOSD) specification/proposa
 - Reusable definitions live under `[types.<name>]` and are referenced from `[elements]` or nested type definitions rather than duplicating structures.
 - Prefer canonical `typeof` and `collection` in schema examples. The Java implementation still accepts legacy aliases `typeref` and `table-collection` for compatibility.
 - Use `itemtype = "types.<name>"` on `type = "array"` definitions when array items need structural validation, including TOML arrays of tables (`[[name]]`) and arrays of inline tables.
+- Use `oneof` for exactly-one alternative type validation and `anyof` for at-least-one validation; both reference reusable `[types]` definitions and can apply to fields or array item types.
 - Use `[...children]` with inline table entries for literal dotted, quoted, empty, or built-in-colliding TOML keys, e.g. `"google.com" = { type = "boolean" }`.
 - Optionality defaults to required behavior. Only mark a schema node optional with `optional = true` when the TOML document may omit that structure.
 - Tables with no defined child structure are intentionally open-ended; tables with defined child properties are intended to validate exactly against those children.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ The schema format follows the TOML specification, meaning that a TOML Schema is 
         - [Array Item Schemas and Arrays of Tables](#array-item-schemas-and-arrays-of-tables)
       - [Collection of Elements for Dynamic Keys](#collection-of-elements-for-dynamic-keys)
     - [Type Reference](#type-reference)
-    - [Optionality - `optional`](#optionality---optional)
+      - [Alternative Types - `oneof` and `anyof`](#alternative-types---oneof-and-anyof)
+      - [Optionality - `optional`](#optionality---optional)
     - [Pattern - `pattern`](#pattern---pattern)
 - [Parsers](#parsers)
   - [Java Reference Implementation](#java-reference-implementation)
@@ -190,6 +191,8 @@ type = "<simple-type> | array | table | collection"
 typeof = "<full-name-of-a-defined-type>"
 arraytype = "<simple-type> | array | table"
 itemtype = "<full-name-of-a-defined-type>"
+oneof = [ "<full-name-of-a-defined-type>", ... ]
+anyof = [ "<full-name-of-a-defined-type>", ... ]
 allowedvalues = [ <array-with-enumeration-of-allowed-values> ]
 pattern = "<string-regex-for-string-validation>"
 optional = true|false
@@ -489,6 +492,28 @@ A type may be referenced to inherit the defined rules existent in given type. Bo
         [elements.datacenter.servers]
         type = "collection"
         typeof = "types.serverType"
+```
+
+### Alternative Types - `oneof` and `anyof`
+
+Use `oneof` or `anyof` when a value may validate against alternative reusable type definitions.
+
+- `oneof`: exactly one referenced type must validate.
+- `anyof`: at least one referenced type must validate.
+
+These properties can be used anywhere a schema definition can appear, including an `[elements]` field, a reusable `[types]` definition, and a type referenced through `itemtype` for array items.
+
+```toml
+[types.stringId]
+type = "string"
+pattern = "^[a-z]+$"
+
+[types.integerId]
+type = "integer"
+min = 1
+
+[elements.id]
+anyof = [ "types.stringId", "types.integerId" ]
 ```
 
 ### Optionality - `optional`

--- a/src/main/java/io/github/brunoborges/tomlschema/SchemaDefinition.java
+++ b/src/main/java/io/github/brunoborges/tomlschema/SchemaDefinition.java
@@ -17,10 +17,14 @@ record SchemaDefinition(
         Object max,
         Integer minLength,
         Integer maxLength,
+        List<String> oneOf,
+        List<String> anyOf,
         Map<String, SchemaDefinition> children
 ) {
     SchemaDefinition {
         allowedValues = List.copyOf(allowedValues);
+        oneOf = List.copyOf(oneOf);
+        anyOf = List.copyOf(anyOf);
         children = Map.copyOf(children);
     }
 

--- a/src/main/java/io/github/brunoborges/tomlschema/SchemaLoader.java
+++ b/src/main/java/io/github/brunoborges/tomlschema/SchemaLoader.java
@@ -115,6 +115,11 @@ final class SchemaLoader {
             maxLength = maxOccurs;
         }
         List<Object> allowedValues = getArrayValues(table, "allowedvalues");
+        List<String> oneOf = getStringArrayValues(table, "oneof");
+        List<String> anyOf = getStringArrayValues(table, "anyof");
+        if (!oneOf.isEmpty() && !anyOf.isEmpty()) {
+            throw new SchemaException(name + " cannot define both oneof and anyof");
+        }
 
         Map<String, SchemaDefinition> children = new LinkedHashMap<>();
         TomlTable explicitChildren = table.getTable("children");
@@ -144,8 +149,8 @@ final class SchemaLoader {
                 throw new SchemaException(name + " contains unsupported property: " + key);
             }
         }
-        if (type == null && normalizedReference == null) {
-            throw new SchemaException(name + " must define type, typeof, or typeref");
+        if (type == null && normalizedReference == null && oneOf.isEmpty() && anyOf.isEmpty()) {
+            throw new SchemaException(name + " must define type, typeof, typeref, oneof, or anyof");
         }
         if (type != SchemaType.ARRAY && arrayType != null) {
             throw new SchemaException(name + " can only define arraytype when type is array");
@@ -166,6 +171,8 @@ final class SchemaLoader {
                 table.get("max"),
                 minLength,
                 maxLength,
+                oneOf.stream().map(this::normalizeReference).toList(),
+                anyOf.stream().map(this::normalizeReference).toList(),
                 children
         );
     }
@@ -242,6 +249,18 @@ final class SchemaLoader {
             values.add(array.get(i));
         }
         return values;
+    }
+
+    private List<String> getStringArrayValues(TomlTable table, String key) {
+        List<Object> values = getArrayValues(table, key);
+        List<String> strings = new ArrayList<>();
+        for (Object value : values) {
+            if (!(value instanceof String stringValue)) {
+                throw new SchemaException("Expected " + key + " to contain only strings");
+            }
+            strings.add(stringValue);
+        }
+        return strings;
     }
 
     private String normalizeReference(String reference) {

--- a/src/main/java/io/github/brunoborges/tomlschema/TomlSchemaValidator.java
+++ b/src/main/java/io/github/brunoborges/tomlschema/TomlSchemaValidator.java
@@ -50,6 +50,10 @@ final class TomlSchemaValidator {
 
     private void validateValue(String path, Object value, SchemaDefinition definition) {
         SchemaDefinition resolved = resolve(definition, new HashSet<>());
+        if (!resolved.oneOf().isEmpty() || !resolved.anyOf().isEmpty()) {
+            validateUnion(path, value, resolved);
+            return;
+        }
         SchemaType type = resolved.type() == null ? SchemaType.ANY : resolved.type();
         validateType(path, value, type);
         if (!isType(value, type)) {
@@ -63,6 +67,26 @@ final class TomlSchemaValidator {
             default -> {
             }
         }
+    }
+
+    private void validateUnion(String path, Object value, SchemaDefinition definition) {
+        List<String> alternatives = definition.oneOf().isEmpty() ? definition.anyOf() : definition.oneOf();
+        long matches = alternatives.stream()
+                .map(reference -> validateAgainst(path, value, resolveReference(reference, new HashSet<>())))
+                .filter(List::isEmpty)
+                .count();
+        if (!definition.oneOf().isEmpty() && matches != 1) {
+            add(path, "expected exactly one matching type from oneof but found " + matches);
+        }
+        if (!definition.anyOf().isEmpty() && matches == 0) {
+            add(path, "expected at least one matching type from anyof");
+        }
+    }
+
+    private List<ValidationError> validateAgainst(String path, Object value, SchemaDefinition definition) {
+        TomlSchemaValidator validator = new TomlSchemaValidator(schema);
+        validator.validateValue(path, value, definition);
+        return validator.errors;
     }
 
     private void validateTableValue(String path, TomlTable table, SchemaDefinition definition) {
@@ -237,6 +261,8 @@ final class TomlSchemaValidator {
                 definition.max() == null ? referenced.max() : definition.max(),
                 definition.minLength() == null ? referenced.minLength() : definition.minLength(),
                 definition.maxLength() == null ? referenced.maxLength() : definition.maxLength(),
+                definition.oneOf().isEmpty() ? referenced.oneOf() : definition.oneOf(),
+                definition.anyOf().isEmpty() ? referenced.anyOf() : definition.anyOf(),
                 children
         );
     }

--- a/src/test/java/io/github/brunoborges/tomlschema/TomlSchemaTest.java
+++ b/src/test/java/io/github/brunoborges/tomlschema/TomlSchemaTest.java
@@ -207,6 +207,89 @@ class TomlSchemaTest {
     }
 
     @Test
+    void validatesAnyOfAndOneOfDefinitions() throws IOException {
+        Path schema = write("unions.tosd", """
+                [toml-schema]
+                version = "1"
+
+                [types.stringId]
+                type = "string"
+                pattern = "^[a-z]+$"
+
+                [types.intId]
+                type = "integer"
+                min = 1
+
+                [types.named]
+                type = "table"
+
+                    [types.named.name]
+                    type = "string"
+
+                [types.numbered]
+                type = "table"
+
+                    [types.numbered.id]
+                    type = "integer"
+
+                [elements.id]
+                anyof = [ "types.stringId", "types.intId" ]
+
+                [elements.entries]
+                type = "array"
+                arraytype = "table"
+                itemtype = "types.namedOrNumbered"
+
+                [types.namedOrNumbered]
+                oneof = [ "types.named", "types.numbered" ]
+                """);
+        Path document = write("unions.toml", """
+                id = "abc"
+                entries = [
+                  { name = "alpha" },
+                  { id = 1 }
+                ]
+                """);
+
+        ValidationResult result = TomlSchema.load(schema).validate(document);
+
+        assertTrue(result.isValid(), () -> result.errors().toString());
+    }
+
+    @Test
+    void reportsUnionValidationFailures() throws IOException {
+        Path schema = write("union-failure.tosd", """
+                [toml-schema]
+                version = "1"
+
+                [types.named]
+                type = "table"
+
+                    [types.named.name]
+                    type = "string"
+
+                [types.numbered]
+                type = "table"
+
+                    [types.numbered.id]
+                    type = "integer"
+
+                [elements.entry]
+                oneof = [ "types.named", "types.numbered" ]
+                """);
+        Path document = write("union-failure.toml", """
+                [entry]
+                name = "alpha"
+                id = 1
+                """);
+
+        ValidationResult result = TomlSchema.load(schema).validate(document);
+
+        assertFalse(result.isValid());
+        assertTrue(result.errors().stream().anyMatch(error -> error.message().contains("exactly one")));
+    }
+
+    @Test
     void cliLocatesSchemaFromDocumentMetadata() throws IOException {
         write("schema.tosd", """
                 [toml-schema]


### PR DESCRIPTION
## Summary
- implement oneof and anyof validation for schema definitions
- support union validation for fields and array item types
- document union semantics and add tests

## Testing
- mvn test