### PR TITLE
Document root schema metadata behavior

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,6 +31,7 @@ This repository contains the TOML Schema Definition (TOSD) specification/proposa
 - Use `oneof` for exactly-one alternative type validation and `anyof` for at-least-one validation; both reference reusable `[types]` definitions and can apply to fields or array item types.
 - `min`/`max` are inclusive and only valid for numeric/date-time types, or arrays with comparable `arraytype`; NaN is not a valid boundary.
 - Use `[...children]` with inline table entries for literal dotted, quoted, empty, or built-in-colliding TOML keys, e.g. `"google.com" = { type = "boolean" }`.
+- Root `[toml-schema]` in TOML documents is reserved metadata and ignored during application validation unless the schema explicitly defines `[elements.toml-schema]`.
 - Optionality defaults to required behavior. Only mark a schema node optional with `optional = true` when the TOML document may omit that structure.
 - Tables with no defined child structure are intentionally open-ended; tables with defined child properties are intended to validate exactly against those children.
 - `pattern` applies to string validation, and the README specifies Perl/PCRE-compatible regular expressions for parsers.

--- a/README.md
+++ b/README.md
@@ -599,7 +599,11 @@ location = "<uri>"
 
 Where `<uri>` can be a remote URL (e.g. https) or a local file.
 
-Only simple *built-in types* are **allowed**.
+The root `[toml-schema]` table is reserved for schema metadata. Validators should use it to locate schema information and should not treat it as application data unless the schema explicitly defines `[elements.toml-schema]`.
+
+When `[elements.toml-schema]` is omitted, validators should ignore the reserved metadata table during application-data validation. When `[elements.toml-schema]` is present, validators must validate the metadata table like any other table.
+
+Only simple *built-in types* are **allowed** in this metadata table.
 
 # Discussion
 

--- a/src/test/java/io/github/brunoborges/tomlschema/TomlSchemaTest.java
+++ b/src/test/java/io/github/brunoborges/tomlschema/TomlSchemaTest.java
@@ -346,6 +346,61 @@ class TomlSchemaTest {
     }
 
     @Test
+    void ignoresReservedTomlSchemaMetadataUnlessSchemaDefinesIt() throws IOException {
+        Path schema = write("metadata-ignored.tosd", """
+                [toml-schema]
+                version = "1"
+
+                [elements.title]
+                type = "string"
+                """);
+        Path document = write("metadata-ignored.toml", """
+                title = "Example"
+
+                [toml-schema]
+                version = 1
+                location = "metadata-ignored.tosd"
+                extra = "ignored"
+                """);
+
+        ValidationResult result = TomlSchema.load(schema).validate(document);
+
+        assertTrue(result.isValid(), () -> result.errors().toString());
+    }
+
+    @Test
+    void validatesReservedTomlSchemaMetadataWhenSchemaDefinesIt() throws IOException {
+        Path schema = write("metadata-defined.tosd", """
+                [toml-schema]
+                version = "1"
+
+                [elements.toml-schema]
+                type = "table"
+
+                    [elements.toml-schema.version]
+                    type = "string"
+
+                    [elements.toml-schema.location]
+                    type = "string"
+
+                [elements.title]
+                type = "string"
+                """);
+        Path document = write("metadata-defined.toml", """
+                title = "Example"
+
+                [toml-schema]
+                version = 1
+                location = "metadata-defined.tosd"
+                """);
+
+        ValidationResult result = TomlSchema.load(schema).validate(document);
+
+        assertFalse(result.isValid());
+        assertTrue(result.errors().stream().anyMatch(error -> error.path().equals("$.toml-schema.version")));
+    }
+
+    @Test
     void cliLocatesSchemaFromDocumentMetadata() throws IOException {
         write("schema.tosd", """
                 [toml-schema]


### PR DESCRIPTION
## Summary
- clarify reserved root [toml-schema] metadata handling
- test default ignore behavior and explicit metadata validation
- update Copilot instructions

## Testing
- mvn test