### PR TITLE
ci: cancel superseded reference implementation runs

### DIFF
--- a/.github/workflows/reference-implementations.yml
+++ b/.github/workflows/reference-implementations.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   java:
     name: Java reference implementation


### PR DESCRIPTION
## Summary
- Add workflow-level concurrency for reference implementation validation
- Cancel superseded runs for the same pull request or branch ref

## Validation
- YAML-only workflow update