### PR TITLE
docs: enhance project documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,7 +15,8 @@ No separate lint command is defined.
 This repository contains the TOML Schema Definition (TOSD) specification/proposal plus a Java reference implementation.
 
 - `SPEC.md` is the primary human-readable specification. It defines the TOML schema language, validation semantics, parser expectations, file extension, MIME types, and schema-reference metadata.
-- `README.md` is the project overview and quickstart. Keep it concise and link to `SPEC.md` for detailed language semantics.
+- `README.md` is the project overview and quickstart. Keep it concise and link to `SPEC.md` for detailed language semantics and `REFERENCE_IMPLEMENTATIONS.md` for implementation usage.
+- `REFERENCE_IMPLEMENTATIONS.md` tracks reference implementation status, Java CLI/library usage, and cross-implementation conformance expectations.
 - `toml-schema.abnf` is the formal TOSD-layer grammar companion for schema vocabulary and document shape. The Java tests include an ABNF conformance guard to prevent vocabulary drift.
 - `toml-schema.tosd` is a TOML schema for schema documents themselves. It models allowed schema metadata, reusable type definitions, and top-level elements.
 - `config.tosd` and `config.toml` are the worked example pair: `config.toml` declares `[toml-schema] location = "config.tosd"`, and `config.tosd` describes the allowed document shape.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # TOML Schema Definition (TOSD)
 
+[![Reference implementations](https://github.com/brunoborges/toml-schema/actions/workflows/reference-implementations.yml/badge.svg)](https://github.com/brunoborges/toml-schema/actions/workflows/reference-implementations.yml)
+[![License](https://img.shields.io/github/license/brunoborges/toml-schema)](LICENSE)
+[![TOML 1.0](https://img.shields.io/badge/TOML-1.0-9c4121)](https://toml.io/en/v1.0.0)
+[![Java 17](https://img.shields.io/badge/Java-17-007396)](REFERENCE_IMPLEMENTATIONS.md#java)
+
 TOML Schema Definition (TOSD) is a TOML-based schema language for describing and validating the structure, names, and value types of TOML configuration files.
 
 A TOSD schema is itself a valid TOML document. Validators can use it to catch misconfiguration before production and tooling can use it for editor validation, completion, and hints.
@@ -10,6 +15,7 @@ A TOSD schema is itself a valid TOML document. Validators can use it to catch mi
 - [ABNF grammar](toml-schema.abnf) - a compact grammar for the TOSD vocabulary and document shape, layered on top of TOML 1.0.
 - [Self-schema](toml-schema.tosd) - a TOSD schema for TOSD schema documents.
 - [Example schema](config.tosd) and [example TOML document](config.toml) - a worked example used by the reference implementation tests.
+- [Reference implementations](REFERENCE_IMPLEMENTATIONS.md) - implementation status, Java CLI/library usage, and conformance expectations.
 
 ## Quick example
 
@@ -47,55 +53,16 @@ type = "table"
 
 ```text
 SPEC.md                         Human-readable TOSD specification
+REFERENCE_IMPLEMENTATIONS.md    Reference implementation status and usage
 toml-schema.abnf                TOSD-layer ABNF grammar
 toml-schema.tosd                Self-schema for TOSD documents
 config.tosd / config.toml       Example schema and TOML document
 reference-implementations/java  Java reference implementation and CLI
 ```
 
-## Java reference implementation
+## Reference implementations
 
-The Java 17 reference implementation lives in `reference-implementations/java`. It uses Tomlj to parse TOML, validates parsed data against a `.tosd` schema, and includes an executable CLI.
-
-Run the full Java test suite:
-
-```shell
-mvn -f reference-implementations/java/pom.xml test
-```
-
-Run one test:
-
-```shell
-mvn -f reference-implementations/java/pom.xml -Dtest=TomlSchemaTest#validatesCheckedInExample test
-```
-
-Build the CLI jar:
-
-```shell
-mvn -f reference-implementations/java/pom.xml package
-```
-
-Validate with an explicit schema:
-
-```shell
-java -jar reference-implementations/java/target/toml-schema-0.1.0-SNAPSHOT.jar validate config.tosd config.toml
-```
-
-Validate using `[toml-schema].location` from the TOML document:
-
-```shell
-java -jar reference-implementations/java/target/toml-schema-0.1.0-SNAPSHOT.jar validate config.toml
-```
-
-Use the library API:
-
-```java
-ValidationResult result = TomlSchema
-    .load(Path.of("config.tosd"))
-    .validate(Path.of("config.toml"));
-```
-
-The Java test suite reads `toml-schema.abnf` as a conformance guard and checks that the implementation's supported schema properties and built-in type names match the grammar.
+The Java 17 reference implementation is available as a library and CLI under `reference-implementations/java`. See [Reference implementations](REFERENCE_IMPLEMENTATIONS.md) for build, test, validation, and future implementation details.
 
 ## Schema reference from TOML
 

--- a/REFERENCE_IMPLEMENTATIONS.md
+++ b/REFERENCE_IMPLEMENTATIONS.md
@@ -1,0 +1,91 @@
+# Reference Implementations
+
+This document tracks TOSD reference implementations and the expected validation surface for each implementation.
+
+## Status
+
+| Language | Location | Status | Notes |
+| --- | --- | --- | --- |
+| Java | [`reference-implementations/java`](reference-implementations/java) | Active reference implementation | Java 17 library and CLI using Tomlj for TOML 1.0 parsing. |
+| Other languages | `reference-implementations/<language>` | Not started | Future implementations should follow the same conformance expectations below. |
+
+## Java
+
+The Java 17 reference implementation uses [Tomlj](https://github.com/tomlj/tomlj) to parse TOML and validates the parsed data model against a `.tosd` schema. It can be used as a library or as an executable CLI.
+
+Run the full Java test suite:
+
+```shell
+mvn -f reference-implementations/java/pom.xml test
+```
+
+Run one test:
+
+```shell
+mvn -f reference-implementations/java/pom.xml -Dtest=TomlSchemaTest#validatesCheckedInExample test
+```
+
+Build the CLI jar:
+
+```shell
+mvn -f reference-implementations/java/pom.xml package
+```
+
+Validate with an explicit schema:
+
+```shell
+java -jar reference-implementations/java/target/toml-schema-0.1.0-SNAPSHOT.jar validate config.tosd config.toml
+```
+
+Validate using `[toml-schema].location` from the TOML document:
+
+```shell
+java -jar reference-implementations/java/target/toml-schema-0.1.0-SNAPSHOT.jar validate config.toml
+```
+
+Validate the example schema against the TOSD self-schema:
+
+```shell
+java -jar reference-implementations/java/target/toml-schema-0.1.0-SNAPSHOT.jar validate toml-schema.tosd config.tosd
+```
+
+Validate the TOSD self-schema against itself:
+
+```shell
+java -jar reference-implementations/java/target/toml-schema-0.1.0-SNAPSHOT.jar validate toml-schema.tosd toml-schema.tosd
+```
+
+Use the library API:
+
+```java
+ValidationResult result = TomlSchema
+    .load(Path.of("config.tosd"))
+    .validate(Path.of("config.toml"));
+```
+
+The Java test suite reads `toml-schema.abnf` as a conformance guard and checks that the implementation's supported schema properties and built-in type names match the grammar.
+
+## Conformance expectations
+
+Every reference implementation should:
+
+1. Parse TOML documents with a TOML 1.0-compliant parser rather than reimplementing TOML parsing.
+1. Treat `.tosd` schemas as valid TOML documents.
+1. Validate the checked-in `config.toml` document against `config.tosd`.
+1. Support schema lookup through `[toml-schema].location`.
+1. Validate `config.tosd` against `toml-schema.tosd`.
+1. Validate `toml-schema.tosd` against itself.
+1. Keep supported schema vocabulary aligned with `toml-schema.abnf` and `toml-schema.tosd`.
+
+The GitHub Actions workflow in `.github/workflows/reference-implementations.yml` currently enforces these expectations for Java.
+
+## Adding another implementation
+
+Future implementations should live under `reference-implementations/<language>` and include language-native build and test instructions. When a new implementation is added, update this file and extend `.github/workflows/reference-implementations.yml` with a separate job for that language.
+
+Each implementation should expose the same practical surfaces as Java where possible:
+
+1. A library API that accepts a schema path and a TOML document path.
+1. A CLI validation command suitable for automation and editor/tool integration.
+1. Tests for the checked-in example, self-schema validation, schema-location lookup, unions, arrays, collections, and key-escaping behavior.
+1. A vocabulary conformance check against `toml-schema.abnf` or an equivalent generated/derived assertion.

--- a/SPEC.md
+++ b/SPEC.md
@@ -9,6 +9,36 @@ The TOML Schema is used to validate the input of a TOML file during parsing to:
 
 The schema format follows the TOML specification, meaning that a TOML Schema is in itself a valid TOML document.
 
+## Table of Contents
+
+- [First Glance](#first-glance)
+  - [TOML example](#toml-example)
+  - [TOML Schema example](#toml-schema-example)
+- [Schema Structure Reference](#schema-structure-reference)
+  - [Top-level Structure Conditions](#top-level-structure-conditions)
+- [Metadata Table - `[toml-schema]`](#metadata-table---toml-schema)
+  - [Supported Properties](#supported-properties)
+- [Elements table - `[elements]`](#elements-table---elements)
+- [Types table - `[types]`](#types-table---types)
+  - [Keys That Need Escaping](#keys-that-need-escaping)
+  - [Simple Types - `<simple-type>`](#simple-types---simple-type)
+    - [Allowed Values for Simple Types - `allowedvalues`](#allowed-values-for-simple-types---allowedvalues)
+  - [Minimum Value / Maximum Value - `min` and `max`](#minimum-value-maximum-value---min-and-max)
+  - [Length - `minlength` and `maxlength`](#length---minlength-and-maxlength)
+  - [Conditions on `any`](#conditions-on-any)
+  - [Block Types](#block-types)
+    - [Tables](#tables)
+    - [Arrays](#arrays)
+    - [Collection of Elements for Dynamic Keys](#collection-of-elements-for-dynamic-keys)
+  - [Type Reference](#type-reference)
+  - [Alternative Types - `oneof` and `anyof`](#alternative-types---oneof-and-anyof)
+  - [Optionality - `optional`](#optionality---optional)
+  - [Pattern - `pattern`](#pattern---pattern)
+- [Parsers](#parsers)
+- [Filename Extension](#filename-extension)
+- [MIME Types](#mime-types)
+- [TOML Reference of a TOML Schema](#toml-reference-of-a-toml-schema)
+
 ## First Glance
 
 ### TOML example


### PR DESCRIPTION
## Summary
- Add README badges for CI, license, TOML 1.0, and Java 17
- Move Java reference implementation usage into REFERENCE_IMPLEMENTATIONS.md
- Document future reference implementation expectations
- Add a table of contents to SPEC.md
- Update Copilot repository instructions for the new docs structure

## Validation
- Checked README and SPEC local links
- Checked SPEC table-of-contents anchors