### PR TITLE
ci: configure Copilot setup steps

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,65 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "25"
+          cache: maven
+          cache-dependency-path: reference-implementations/java/pom.xml
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: reference-implementations/go/go.mod
+          cache-dependency-path: reference-implementations/go/go.sum
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            reference-implementations/rust/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('reference-implementations/rust/Cargo.lock') }}
+
+      - name: Show tool versions
+        run: |
+          java -version
+          mvn -version
+          go version
+          rustc --version
+          cargo --version
+
+      - name: Warm Java dependencies
+        run: mvn -B -f reference-implementations/java/pom.xml dependency:go-offline
+
+      - name: Warm Go dependencies
+        run: go -C reference-implementations/go mod download
+
+      - name: Warm Rust dependencies
+        run: cargo fetch --locked --manifest-path reference-implementations/rust/Cargo.toml

--- a/README.md
+++ b/README.md
@@ -66,13 +66,7 @@ reference-implementations/rust  Rust reference implementation and CLI
 
 ## Reference implementations
 
-The Java 25 reference implementation is available as a library and CLI under `reference-implementations/java`. It validates TOML documents, reads `[toml-schema].location`, and can extract a starter schema from a sample TOML document.
-
-The Go reference implementation is available as a CLI under `reference-implementations/go`. It validates TOML documents, reads `[toml-schema].location`, and can extract a starter schema from a sample TOML document.
-
-The Rust reference implementation is available as a library and CLI under `reference-implementations/rust`. It validates TOML documents, reads `[toml-schema].location`, and can extract a starter schema from a sample TOML document.
-
-See [Reference implementations](REFERENCE_IMPLEMENTATIONS.md) for build, test, validation, extraction, and future implementation details.
+Java, Go, and Rust reference implementations live under `reference-implementations/`. See [Reference implementations](REFERENCE_IMPLEMENTATIONS.md) for implementation status, build/test commands, CLI usage, schema extraction, and conformance expectations.
 
 ## Schema reference from TOML
 


### PR DESCRIPTION
## Summary
- Add Copilot cloud-agent setup steps for this repository
- Preconfigure Java 25, Go, and Rust tooling
- Warm Maven, Go, and Cargo dependencies for the reference implementations
- Simplify the README reference-implementations overview

## Validation
- Verified workflow structure locally
- Ran Maven dependency warm-up
- Ran Go module download
- Ran Cargo fetch with the Rust lockfile