### PR TITLE
spec: formalize TOSD versioning

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,6 +27,7 @@ This repository contains the TOML Schema Definition (TOSD) specification/proposa
 ## Key conventions
 
 - Schema documents are intended to be valid TOML documents. The required top-level tables are `[toml-schema]` and `[elements]`; `[types]` is optional and exists for reusable definitions.
+- Use full SemVer strings for `[toml-schema].version`; the current TOSD version is `1.0.0`, and shorthand values like `"1"` or `"1.0"` are invalid.
 - Custom metadata belongs under `[toml-schema.meta]`; do not add arbitrary keys or subtables directly under `[toml-schema]`.
 - Reusable definitions live under `[types.<name>]` and are referenced from `[elements]` or nested type definitions rather than duplicating structures.
 - Prefer canonical `typeof` and `collection` in schema examples. The Java implementation still accepts legacy aliases `typeref` and `table-collection` for compatibility.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ TOSD schema:
 
 ```toml
 [toml-schema]
-version = "1"
+version = "1.0.0"
 
 [elements.title]
 type = "string"
@@ -76,7 +76,7 @@ A TOML document can point to a schema with reserved metadata:
 
 ```toml
 [toml-schema]
-version = "1"
+version = "1.0.0"
 location = "config.tosd"
 ```
 

--- a/REFERENCE_IMPLEMENTATIONS.md
+++ b/REFERENCE_IMPLEMENTATIONS.md
@@ -177,6 +177,7 @@ Every reference implementation should:
 
 1. Parse TOML documents with a TOML 1.0-compliant parser rather than reimplementing TOML parsing.
 1. Treat `.tosd` schemas as valid TOML documents.
+1. Require `[toml-schema].version` to be a SemVer string compatible with the implementation's supported TOSD version.
 1. Validate the checked-in `config.toml` document against `config.tosd`.
 1. Support schema lookup through `[toml-schema].location`.
 1. Validate `config.tosd` against `toml-schema.tosd`.

--- a/SPEC.md
+++ b/SPEC.md
@@ -18,6 +18,7 @@ The schema format follows the TOML specification, meaning that a TOML Schema is 
   - [Top-level Structure Conditions](#top-level-structure-conditions)
 - [Metadata Table - `[toml-schema]`](#metadata-table---toml-schema)
   - [Supported Properties](#supported-properties)
+  - [Schema Versioning](#schema-versioning)
 - [Elements table - `[elements]`](#elements-table---elements)
 - [Types table - `[types]`](#types-table---types)
   - [Keys That Need Escaping](#keys-that-need-escaping)
@@ -29,7 +30,7 @@ The schema format follows the TOML specification, meaning that a TOML Schema is 
   - [Block Types](#block-types)
     - [Tables](#tables)
     - [Arrays](#arrays)
-      - [Tuple / Positional Array Validation - `items`](#tuple--positional-array-validation---items)
+      - [Tuple / Positional Array Validation - `items`](#tuple-positional-array-validation---items)
     - [Collection of Elements for Dynamic Keys](#collection-of-elements-for-dynamic-keys)
   - [Type Reference](#type-reference)
   - [Alternative Types - `oneof` and `anyof`](#alternative-types---oneof-and-anyof)
@@ -78,7 +79,7 @@ Example of a TOML Schema that validates the TOML document above:
 ```toml
 # This is a TOML Schema document
 [toml-schema]
-version = "1"
+version = "1.0.0"
 
 [types.serverType]
 type="table"
@@ -151,7 +152,7 @@ This table is reserved for metadata regarding the TOML Schema itself.
 
 ```toml
 [toml-schema]
-version = "1.0"
+version = "1.0.0"
 # custom = "value" # *NOT allowed
 
 [toml-schema.meta]
@@ -172,6 +173,21 @@ version = "1.0"
    - **Optional**.
 
  No custom property or table may be appended under `toml-schema`, only inside `toml-schema.meta` table.
+
+### Schema Versioning
+
+TOSD follows the same version-numbering policy as the TOML specification: schema language versions use [Semantic Versioning](https://semver.org/).
+
+The `version` property MUST be a string containing a full SemVer version in `MAJOR.MINOR.PATCH` form. The current TOSD version is `1.0.0`.
+
+```toml
+[toml-schema]
+version = "1.0.0"
+```
+
+Parsers MUST reject schema documents whose `version` is missing, is not a string, or is not a valid SemVer value. Shorthand values such as `"1"` and `"1.0"` are invalid.
+
+A parser that supports TOSD version `MAJOR.MINOR.PATCH` MUST accept schema documents with the same major version and a minor version less than or equal to the parser's supported minor version. Patch versions, pre-release identifiers, and build metadata do not add schema-language features and do not affect parser compatibility. Parsers MUST reject schema documents with an unsupported major version or a greater minor version.
 
 ## Elements table - `[elements]`
 
@@ -584,7 +600,7 @@ A TOML file can include this indication to reference which schema file to use fo
 
 ```toml
 [toml-schema]
-version = "1"
+version = "1.0.0"
 location = "<uri>"
 ```
 

--- a/config.toml
+++ b/config.toml
@@ -3,7 +3,7 @@
 title = "TOML Example"
 
 [toml-schema]
-version = "1"
+version = "1.0.0"
 location = "config.tosd"
 
 [owner]

--- a/config.tosd
+++ b/config.tosd
@@ -1,7 +1,7 @@
 # SCHEMA: config.tosd
 
 [toml-schema]
-version = "1"
+version = "1.0.0"
 
 [types]
 

--- a/reference-implementations/go/extract.go
+++ b/reference-implementations/go/extract.go
@@ -31,7 +31,7 @@ func extract(documentPath, schemaPath string, out, errOut io.Writer) int {
 func generateSchema(document map[string]any) string {
 	var schema strings.Builder
 	schema.WriteString("[toml-schema]\n")
-	schema.WriteString("version = \"1\"\n\n")
+	fmt.Fprintf(&schema, "version = %q\n\n", currentTOSDVersion)
 	schema.WriteString("[elements]\n")
 	for _, key := range sortedKeys(document) {
 		if key == "toml-schema" {

--- a/reference-implementations/go/schema.go
+++ b/reference-implementations/go/schema.go
@@ -37,6 +37,10 @@ var definitionKeys = map[string]bool{
 	"oneof": true, "anyof": true, "children": true,
 }
 
+const currentTOSDVersion = "1.0.0"
+
+var semverPattern = regexp.MustCompile(`^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-((?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$`)
+
 type Schema struct {
 	source   string
 	types    map[string]Definition
@@ -92,8 +96,12 @@ func LoadSchema(path string) (*Schema, error) {
 		}
 	}
 	metadata := parsed["toml-schema"].(map[string]any)
-	if _, ok := metadata["version"]; !ok {
+	version, ok := metadata["version"]
+	if !ok {
 		return nil, fmt.Errorf("[toml-schema] must contain version")
+	}
+	if err := validateSchemaVersion(version); err != nil {
+		return nil, err
 	}
 	for key := range metadata {
 		if key != "version" && key != "meta" {
@@ -109,6 +117,24 @@ func LoadSchema(path string) (*Schema, error) {
 		return nil, err
 	}
 	return &Schema{source: path, types: types, elements: elements}, nil
+}
+
+func validateSchemaVersion(value any) error {
+	version, ok := value.(string)
+	if !ok {
+		return fmt.Errorf("[toml-schema].version must be a SemVer string")
+	}
+	matches := semverPattern.FindStringSubmatch(version)
+	if matches == nil {
+		return fmt.Errorf("[toml-schema].version must use SemVer MAJOR.MINOR.PATCH syntax")
+	}
+	if matches[1] != "1" {
+		return fmt.Errorf("unsupported TOSD major version: %s", version)
+	}
+	if matches[2] != "0" {
+		return fmt.Errorf("unsupported TOSD minor version: %s", version)
+	}
+	return nil
 }
 
 func (s *Schema) ValidateFile(path string) ValidationResult {

--- a/reference-implementations/go/schema_test.go
+++ b/reference-implementations/go/schema_test.go
@@ -22,11 +22,38 @@ func TestValidatesCheckedInExample(t *testing.T) {
 	}
 }
 
+func TestEnforcesSemverSchemaVersions(t *testing.T) {
+	dir := t.TempDir()
+	compatibleSchema := write(t, dir, "compatible-version.tosd", `
+[toml-schema]
+version = "1.0.1+build.1"
+
+[elements.title]
+type = "string"
+`)
+	if _, err := LoadSchema(compatibleSchema); err != nil {
+		t.Fatalf("expected compatible patch version to load: %v", err)
+	}
+
+	for _, version := range []string{"1", "1.0", "01.0.0", "1.1.0", "2.0.0"} {
+		schemaPath := write(t, dir, "invalid-version-"+strings.ReplaceAll(version, ".", "-")+".tosd", fmt.Sprintf(`
+[toml-schema]
+version = %q
+
+[elements.title]
+type = "string"
+`, version))
+		if _, err := LoadSchema(schemaPath); err == nil {
+			t.Fatalf("expected version %q to be rejected", version)
+		}
+	}
+}
+
 func TestReportsValidationErrors(t *testing.T) {
 	dir := t.TempDir()
 	schemaPath := write(t, dir, "schema.tosd", `
 [toml-schema]
-version = "1"
+version = "1.0.0"
 
 [elements.name]
 type = "string"
@@ -64,7 +91,7 @@ func TestPatternMustMatchEntireString(t *testing.T) {
 	dir := t.TempDir()
 	schemaPath := write(t, dir, "schema.tosd", `
 [toml-schema]
-version = "1"
+version = "1.0.0"
 
 [elements.id]
 type = "string"
@@ -92,7 +119,7 @@ func TestValidatesUnionsAndArrayItemSchemas(t *testing.T) {
 	dir := t.TempDir()
 	schemaPath := write(t, dir, "schema.tosd", `
 [toml-schema]
-version = "1"
+version = "1.0.0"
 
 [types.stringId]
 type = "string"
@@ -148,7 +175,7 @@ func TestValidatesTupleArraysByPosition(t *testing.T) {
 	dir := t.TempDir()
 	schemaPath := write(t, dir, "schema.tosd", `
 [toml-schema]
-version = "1"
+version = "1.0.0"
 
 [types.coordinate]
 type = "float"
@@ -183,7 +210,7 @@ func TestRejectsInvalidTupleArrays(t *testing.T) {
 	dir := t.TempDir()
 	schemaPath := write(t, dir, "schema.tosd", `
 [toml-schema]
-version = "1"
+version = "1.0.0"
 
 [types.coordinate]
 type = "float"
@@ -230,7 +257,7 @@ func TestRejectsTupleSchemaWithConflictingProperties(t *testing.T) {
 	conflicts := []string{
 		`
 [toml-schema]
-version = "1"
+version = "1.0.0"
 
 [elements.value]
 type = "array"
@@ -239,7 +266,7 @@ arraytype = "string"
 `,
 		`
 [toml-schema]
-version = "1"
+version = "1.0.0"
 
 [elements.value]
 type = "array"
@@ -259,7 +286,7 @@ func TestSupportsQuotedDottedAndEmptyKeysWithChildrenTable(t *testing.T) {
 	dir := t.TempDir()
 	schemaPath := write(t, dir, "schema.tosd", `
 [toml-schema]
-version = "1"
+version = "1.0.0"
 
 [elements.site]
 type = "table"
@@ -292,7 +319,7 @@ func TestCLILocatesSchemaFromDocumentMetadata(t *testing.T) {
 	dir := t.TempDir()
 	write(t, dir, "schema.tosd", `
 [toml-schema]
-version = "1"
+version = "1.0.0"
 
 [elements.title]
 type = "string"
@@ -301,7 +328,7 @@ type = "string"
 title = "Example"
 
 [toml-schema]
-version = "1"
+version = "1.0.0"
 location = "schema.tosd"
 `)
 	var out bytes.Buffer
@@ -331,7 +358,7 @@ name = "Alice"
 "google.com" = true
 
 [toml-schema]
-version = "1"
+version = "1.0.0"
 location = "ignored.tosd"
 `)
 	extractedSchema := filepath.Join(dir, "extract-output.tosd")
@@ -353,6 +380,7 @@ location = "ignored.tosd"
 	}
 	schemaText := string(schemaBytes)
 	for _, expected := range []string{
+		`version = "1.0.0"`,
 		"[elements.title]",
 		`type = "string"`,
 		"[elements.owner]",

--- a/reference-implementations/java/src/main/java/io/github/brunoborges/tomlschema/SchemaLoader.java
+++ b/reference-implementations/java/src/main/java/io/github/brunoborges/tomlschema/SchemaLoader.java
@@ -57,6 +57,7 @@ final class SchemaLoader {
         if (metadata == null || !metadata.contains("version")) {
             throw new SchemaException("[toml-schema] must contain version");
         }
+        TosdVersion.validate(metadata.get("version"));
         for (String key : metadata.keySet()) {
             if (!key.equals("version") && !key.equals("meta")) {
                 throw new SchemaException("Unsupported [toml-schema] key: " + key);

--- a/reference-implementations/java/src/main/java/io/github/brunoborges/tomlschema/TomlSchemaCli.java
+++ b/reference-implementations/java/src/main/java/io/github/brunoborges/tomlschema/TomlSchemaCli.java
@@ -122,7 +122,7 @@ public final class TomlSchemaCli {
     private static String generateSchema(TomlTable document) {
         StringBuilder schema = new StringBuilder();
         schema.append("[toml-schema]\n");
-        schema.append("version = \"1\"\n\n");
+        schema.append("version = \"").append(TosdVersion.CURRENT).append("\"\n\n");
         schema.append("[elements]\n");
         for (String key : document.keySet()) {
             if ("toml-schema".equals(key)) {

--- a/reference-implementations/java/src/main/java/io/github/brunoborges/tomlschema/TosdVersion.java
+++ b/reference-implementations/java/src/main/java/io/github/brunoborges/tomlschema/TosdVersion.java
@@ -1,0 +1,37 @@
+package io.github.brunoborges.tomlschema;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+final class TosdVersion {
+    static final String CURRENT = "1.0.0";
+
+    private static final String SUPPORTED_MAJOR = "1";
+    private static final String SUPPORTED_MINOR = "0";
+    private static final Pattern SEMVER = Pattern.compile(
+            "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)"
+                    + "(?:-((?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?"
+                    + "(?:\\+([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?$"
+    );
+
+    private TosdVersion() {
+    }
+
+    static void validate(Object value) {
+        if (!(value instanceof String version)) {
+            throw new SchemaException("[toml-schema].version must be a SemVer string");
+        }
+        Matcher matcher = SEMVER.matcher(version);
+        if (!matcher.matches()) {
+            throw new SchemaException("[toml-schema].version must use SemVer MAJOR.MINOR.PATCH syntax");
+        }
+        String major = matcher.group(1);
+        String minor = matcher.group(2);
+        if (!SUPPORTED_MAJOR.equals(major)) {
+            throw new SchemaException("Unsupported TOSD major version: " + version);
+        }
+        if (!SUPPORTED_MINOR.equals(minor)) {
+            throw new SchemaException("Unsupported TOSD minor version: " + version);
+        }
+    }
+}

--- a/reference-implementations/java/src/test/java/io/github/brunoborges/tomlschema/TomlSchemaTest.java
+++ b/reference-implementations/java/src/test/java/io/github/brunoborges/tomlschema/TomlSchemaTest.java
@@ -9,7 +9,9 @@ import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -35,10 +37,35 @@ class TomlSchemaTest {
     }
 
     @Test
+    void enforcesSemverSchemaVersions() throws IOException {
+        Path compatiblePatchSchema = write("compatible-version.tosd", """
+                [toml-schema]
+                version = "1.0.1+build.1"
+
+                [elements.title]
+                type = "string"
+                """);
+
+        assertDoesNotThrow(() -> TomlSchema.load(compatiblePatchSchema));
+
+        for (String version : List.of("1", "1.0", "01.0.0", "1.1.0", "2.0.0")) {
+            Path schema = write("invalid-version-" + version.replace('.', '-') + ".tosd", """
+                    [toml-schema]
+                    version = "%s"
+
+                    [elements.title]
+                    type = "string"
+                    """.formatted(version));
+
+            assertThrows(SchemaException.class, () -> TomlSchema.load(schema), version);
+        }
+    }
+
+    @Test
     void reportsValidationErrors() throws IOException {
         Path schema = write("schema.tosd", """
                 [toml-schema]
-                version = "1"
+                version = "1.0.0"
 
                 [elements.name]
                 type = "string"
@@ -67,7 +94,7 @@ class TomlSchemaTest {
     void stringLengthCountsUnicodeScalarValues() throws IOException {
         Path schema = write("unicode-length.tosd", """
                 [toml-schema]
-                version = "1"
+                version = "1.0.0"
 
                 [elements.emoji]
                 type = "string"
@@ -99,7 +126,7 @@ class TomlSchemaTest {
     void supportsLegacyReferenceAndCollectionAliases() throws IOException {
         Path schema = write("legacy.tosd", """
                 [toml-schema]
-                version = "1"
+                version = "1.0.0"
 
                 [types.item]
                 type = "table"
@@ -125,7 +152,7 @@ class TomlSchemaTest {
     void validatesArrayOfTablesWithItemSchema() throws IOException {
         Path schema = write("products.tosd", """
                 [toml-schema]
-                version = "1"
+                version = "1.0.0"
 
                 [types.product]
                 type = "table"
@@ -161,7 +188,7 @@ class TomlSchemaTest {
     void validatesArraysOfInlineTablesWithItemSchema() throws IOException {
         Path schema = write("points.tosd", """
                 [toml-schema]
-                version = "1"
+                version = "1.0.0"
 
                 [types.point]
                 type = "table"
@@ -193,7 +220,7 @@ class TomlSchemaTest {
     void validatesTupleArraysByPosition() throws IOException {
         Path schema = write("tuple-array.tosd", """
                 [toml-schema]
-                version = "1"
+                version = "1.0.0"
 
                 [types.coordinate]
                 type = "float"
@@ -228,7 +255,7 @@ class TomlSchemaTest {
     void rejectsInvalidTupleArrays() throws IOException {
         Path schema = write("tuple-array-invalid.tosd", """
                 [toml-schema]
-                version = "1"
+                version = "1.0.0"
 
                 [types.coordinate]
                 type = "float"
@@ -268,7 +295,7 @@ class TomlSchemaTest {
     void rejectsTupleArraySchemaWithConflictingProperties() throws IOException {
         Path withArrayType = write("tuple-arraytype-conflict.tosd", """
                 [toml-schema]
-                version = "1"
+                version = "1.0.0"
 
                 [elements.value]
                 type = "array"
@@ -277,7 +304,7 @@ class TomlSchemaTest {
                 """);
         Path withLength = write("tuple-length-conflict.tosd", """
                 [toml-schema]
-                version = "1"
+                version = "1.0.0"
 
                 [elements.value]
                 type = "array"
@@ -293,7 +320,7 @@ class TomlSchemaTest {
     void supportsQuotedDottedAndEmptyTomlKeysWithChildrenTable() throws IOException {
         Path schema = write("special-keys.tosd", """
                 [toml-schema]
-                version = "1"
+                version = "1.0.0"
 
                 [elements.site]
                 type = "table"
@@ -320,7 +347,7 @@ class TomlSchemaTest {
     void quotesSpecialKeysInValidationErrorPaths() throws IOException {
         Path schema = write("special-key-error.tosd", """
                 [toml-schema]
-                version = "1"
+                version = "1.0.0"
 
                 [elements.site]
                 type = "table"
@@ -343,7 +370,7 @@ class TomlSchemaTest {
     void validatesAnyOfAndOneOfDefinitions() throws IOException {
         Path schema = write("unions.tosd", """
                 [toml-schema]
-                version = "1"
+                version = "1.0.0"
 
                 [types.stringId]
                 type = "string"
@@ -393,7 +420,7 @@ class TomlSchemaTest {
     void reportsUnionValidationFailures() throws IOException {
         Path schema = write("union-failure.tosd", """
                 [toml-schema]
-                version = "1"
+                version = "1.0.0"
 
                 [types.named]
                 type = "table"
@@ -426,7 +453,7 @@ class TomlSchemaTest {
     void validatesNumericAndDateTimeBoundaries() throws IOException {
         Path schema = write("boundaries.tosd", """
                 [toml-schema]
-                version = "1"
+                version = "1.0.0"
 
                 [elements.port]
                 type = "integer"
@@ -458,7 +485,7 @@ class TomlSchemaTest {
     void rejectsMalformedBoundarySchemas() throws IOException {
         Path anySchema = write("any-min.tosd", """
                 [toml-schema]
-                version = "1"
+                version = "1.0.0"
 
                 [elements.payload]
                 type = "any"
@@ -466,7 +493,7 @@ class TomlSchemaTest {
                 """);
         Path nanSchema = write("nan-min.tosd", """
                 [toml-schema]
-                version = "1"
+                version = "1.0.0"
 
                 [elements.value]
                 type = "float"
@@ -481,7 +508,7 @@ class TomlSchemaTest {
     void ignoresReservedTomlSchemaMetadataUnlessSchemaDefinesIt() throws IOException {
         Path schema = write("metadata-ignored.tosd", """
                 [toml-schema]
-                version = "1"
+                version = "1.0.0"
 
                 [elements.title]
                 type = "string"
@@ -504,7 +531,7 @@ class TomlSchemaTest {
     void validatesReservedTomlSchemaMetadataWhenSchemaDefinesIt() throws IOException {
         Path schema = write("metadata-defined.tosd", """
                 [toml-schema]
-                version = "1"
+                version = "1.0.0"
 
                 [elements.toml-schema]
                 type = "table"
@@ -536,7 +563,7 @@ class TomlSchemaTest {
     void cliLocatesSchemaFromDocumentMetadata() throws IOException {
         write("schema.tosd", """
                 [toml-schema]
-                version = "1"
+                version = "1.0.0"
 
                 [elements.title]
                 type = "string"
@@ -545,7 +572,7 @@ class TomlSchemaTest {
                 title = "Example"
 
                 [toml-schema]
-                version = "1"
+                version = "1.0.0"
                 location = "schema.tosd"
                 """);
         ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -571,7 +598,7 @@ class TomlSchemaTest {
                 name = "Alice"
 
                 [toml-schema]
-                version = "1"
+                version = "1.0.0"
                 location = "ignored.tosd"
                 """);
         Path extractedSchema = tempDir.resolve("extract-output.tosd");
@@ -587,6 +614,7 @@ class TomlSchemaTest {
         assertTrue(out.toString(StandardCharsets.UTF_8).contains("Extracted schema to"));
 
         String schemaText = Files.readString(extractedSchema, StandardCharsets.UTF_8);
+        assertTrue(schemaText.contains("version = \"1.0.0\""));
         assertTrue(schemaText.contains("[elements.title]"));
         assertTrue(schemaText.contains("type = \"string\""));
         assertTrue(schemaText.contains("[elements.owner]"));

--- a/reference-implementations/rust/src/extract.rs
+++ b/reference-implementations/rust/src/extract.rs
@@ -6,7 +6,7 @@ use std::fmt::Write as _;
 use toml::value::Datetime;
 use toml::{Table, Value};
 
-use crate::schema::{encode_path_key, SchemaType};
+use crate::schema::{encode_path_key, SchemaType, CURRENT_TOSD_VERSION};
 
 /// Renders a TOSD schema as a TOML string from the parsed sample document. Keys
 /// are emitted in the natural order of the parsed [`Table`] (which is sorted
@@ -14,7 +14,7 @@ use crate::schema::{encode_path_key, SchemaType};
 pub fn generate_schema(document: &Table) -> String {
     let mut schema = String::new();
     schema.push_str("[toml-schema]\n");
-    schema.push_str("version = \"1\"\n\n");
+    writeln!(schema, "version = \"{CURRENT_TOSD_VERSION}\"\n").expect("write to String");
     schema.push_str("[elements]\n");
     for (key, value) in document.iter() {
         if key == "toml-schema" {

--- a/reference-implementations/rust/src/schema.rs
+++ b/reference-implementations/rust/src/schema.rs
@@ -112,6 +112,8 @@ pub const DEFINITION_KEYS: &[&str] = &[
     "children",
 ];
 
+pub const CURRENT_TOSD_VERSION: &str = "1.0.0";
+
 fn is_definition_key(key: &str) -> bool {
     DEFINITION_KEYS.contains(&key)
 }
@@ -191,9 +193,10 @@ impl Schema {
             .get("toml-schema")
             .and_then(Value::as_table)
             .expect("checked above");
-        if !metadata.contains_key("version") {
-            return Err("[toml-schema] must contain version".to_string());
-        }
+        let version = metadata
+            .get("version")
+            .ok_or_else(|| "[toml-schema] must contain version".to_string())?;
+        Self::validate_schema_version(version)?;
         for key in metadata.keys() {
             if key != "version" && key != "meta" {
                 return Err(format!("unsupported [toml-schema] key: {key}"));
@@ -213,6 +216,26 @@ impl Schema {
     /// Returns the path the schema was loaded from.
     pub fn source(&self) -> &Path {
         &self.source
+    }
+
+    fn validate_schema_version(value: &Value) -> Result<(), String> {
+        let Some(version) = value.as_str() else {
+            return Err("[toml-schema].version must be a SemVer string".to_string());
+        };
+        let semver = Regex::new(
+            r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-((?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$",
+        )
+        .expect("valid SemVer regex");
+        let Some(captures) = semver.captures(version) else {
+            return Err("[toml-schema].version must use SemVer MAJOR.MINOR.PATCH syntax".to_string());
+        };
+        if captures.get(1).map(|major| major.as_str()) != Some("1") {
+            return Err(format!("unsupported TOSD major version: {version}"));
+        }
+        if captures.get(2).map(|minor| minor.as_str()) != Some("0") {
+            return Err(format!("unsupported TOSD minor version: {version}"));
+        }
+        Ok(())
     }
 
     /// Validates the TOML document at `path` against this schema.

--- a/reference-implementations/rust/tests/integration.rs
+++ b/reference-implementations/rust/tests/integration.rs
@@ -56,6 +56,43 @@ fn validates_checked_in_example() {
 }
 
 #[test]
+fn enforces_semver_schema_versions() {
+    let directory = tempfile_dir("schema-versions");
+    let compatible_schema = write_file(
+        &directory,
+        "compatible-version.tosd",
+        r#"
+[toml-schema]
+version = "1.0.1+build.1"
+
+[elements.title]
+type = "string"
+"#,
+    );
+    Schema::load(&compatible_schema).expect("compatible patch version");
+
+    for version in ["1", "1.0", "01.0.0", "1.1.0", "2.0.0"] {
+        let schema_path = write_file(
+            &directory,
+            &format!("invalid-version-{}.tosd", version.replace('.', "-")),
+            &format!(
+                r#"
+[toml-schema]
+version = "{version}"
+
+[elements.title]
+type = "string"
+"#
+            ),
+        );
+        assert!(
+            Schema::load(&schema_path).is_err(),
+            "expected version {version:?} to be rejected"
+        );
+    }
+}
+
+#[test]
 fn validates_self_schema_against_itself() {
     let schema = Schema::load(fixture("toml-schema.tosd")).expect("load toml-schema.tosd");
     let result = schema.validate_file(fixture("toml-schema.tosd"));
@@ -85,7 +122,7 @@ fn reports_validation_errors() {
         "schema.tosd",
         r#"
 [toml-schema]
-version = "1"
+version = "1.0.0"
 
 [elements.name]
 type = "string"
@@ -129,7 +166,7 @@ fn pattern_must_match_entire_string() {
         "schema.tosd",
         r#"
 [toml-schema]
-version = "1"
+version = "1.0.0"
 
 [elements.id]
 type = "string"
@@ -162,7 +199,7 @@ fn validates_unions_and_array_item_schemas() {
         "schema.tosd",
         r#"
 [toml-schema]
-version = "1"
+version = "1.0.0"
 
 [types.stringId]
 type = "string"
@@ -226,7 +263,7 @@ fn validates_tuple_arrays_by_position() {
         "schema.tosd",
         r#"
 [toml-schema]
-version = "1"
+version = "1.0.0"
 
 [types.coordinate]
 type = "float"
@@ -268,7 +305,7 @@ fn rejects_invalid_tuple_arrays() {
         "schema.tosd",
         r#"
 [toml-schema]
-version = "1"
+version = "1.0.0"
 
 [types.coordinate]
 type = "float"
@@ -324,7 +361,7 @@ fn rejects_tuple_schema_with_conflicting_properties() {
     let conflicts = [
         r#"
 [toml-schema]
-version = "1"
+version = "1.0.0"
 
 [elements.value]
 type = "array"
@@ -333,7 +370,7 @@ arraytype = "string"
 "#,
         r#"
 [toml-schema]
-version = "1"
+version = "1.0.0"
 
 [elements.value]
 type = "array"
@@ -356,7 +393,7 @@ fn supports_quoted_dotted_and_empty_keys_with_children_table() {
         "schema.tosd",
         r#"
 [toml-schema]
-version = "1"
+version = "1.0.0"
 
 [elements.site]
 type = "table"
@@ -396,7 +433,7 @@ fn cli_locates_schema_from_document_metadata() {
         "schema.tosd",
         r#"
 [toml-schema]
-version = "1"
+version = "1.0.0"
 
 [elements.title]
 type = "string"
@@ -409,7 +446,7 @@ type = "string"
 title = "Example"
 
 [toml-schema]
-version = "1"
+version = "1.0.0"
 location = "schema.tosd"
 "#,
     );
@@ -438,7 +475,7 @@ name = "Alice"
 "google.com" = true
 
 [toml-schema]
-version = "1"
+version = "1.0.0"
 location = "ignored.tosd"
 "#,
     );
@@ -457,6 +494,7 @@ location = "ignored.tosd"
 
     let schema_text = fs::read_to_string(&extracted_schema).expect("read extracted schema");
     for expected in [
+        "version = \"1.0.0\"",
         "[elements.title]",
         "type = \"string\"",
         "[elements.owner]",

--- a/toml-schema.abnf
+++ b/toml-schema.abnf
@@ -31,7 +31,7 @@ definition-property = type / typeof / typeref / arraytype / itemtype / items / o
                     / allowedvalues / pattern / optional / default / min / max
                     / minlength / maxlength / minoccurs / maxoccurs
 
-version       = "version" keyval-sep toml-string
+version       = "version" keyval-sep semver-string
 type          = "type" keyval-sep built-in-type
 typeof        = "typeof" keyval-sep toml-string
 typeref       = "typeref" keyval-sep toml-string       ; legacy alias for typeof
@@ -76,6 +76,7 @@ tablecollectiontype = DQUOTE %x74.61.62.6c.65.2d.63.6f.6c.6c.65.63.74.69.6f.6e D
 
 ;; TOML 1.0 grammar terminals used by TOSD.
 
+semver-string                     = <TOML string containing a Semantic Versioning 2.0.0 value>
 toml-table-header-toml-schema      = <TOML 1.0 table header for [toml-schema]>
 toml-table-header-types            = <TOML 1.0 table header for [types]>
 toml-table-header-elements         = <TOML 1.0 table header for [elements]>

--- a/toml-schema.tosd
+++ b/toml-schema.tosd
@@ -1,6 +1,6 @@
 # Metadata
 [toml-schema]
-version = "1"
+version = "1.0.0"
 
 # Types
 [types]
@@ -105,7 +105,8 @@ version = "1"
     type = "table"
 
         [elements.toml-schema.version]
-        type = "any"
+        type = "string"
+        pattern = '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-((?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$'
 
         [elements.toml-schema.meta]
         type = "table"


### PR DESCRIPTION
## Summary
- Adopt SemVer for [toml-schema].version and document compatibility rules
- Canonicalize examples and generated schemas to version 1.0.0
- Enforce SemVer-compatible schema versions in Java, Go, and Rust reference implementations
- Update the self-schema and ABNF companion for SemVer version values

Closes #39

## Validation
- mvn -q -f reference-implementations/java/pom.xml test
- go -C reference-implementations/go test ./...
- cargo test --manifest-path reference-implementations/rust/Cargo.toml --locked --quiet
- Java, Go, and Rust CLI validations for config.toml/config.tosd and toml-schema.tosd