### PR TITLE
ci: add reference implementation build script

### DIFF
--- a/reference-implementations/build-all.sh
+++ b/reference-implementations/build-all.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+go_output="$script_dir/go/target/toml-schema"
+
+run_step() {
+    local label="$1"
+    shift
+
+    printf '\n==> %s\n' "$label"
+    "$@"
+}
+
+run_step "Building Java reference implementation" \
+    mvn -B -f "$script_dir/java/pom.xml" package
+
+mkdir -p "$(dirname "$go_output")"
+run_step "Building Go reference implementation" \
+    go -C "$script_dir/go" build -o "$go_output" .
+
+run_step "Building Rust reference implementation" \
+    cargo build --locked --release --manifest-path "$script_dir/rust/Cargo.toml"
+
+printf '\nAll reference implementations built successfully.\n'


### PR DESCRIPTION
## Summary
- Add a top-level helper script for building all reference implementations
- Build Java with Maven, Go to a local target binary, and Rust in release mode

## Validation
- ./reference-implementations/build-all.sh