### PR TITLE
docs: rename project to TOML Schema

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,12 +12,12 @@ No separate lint command is defined.
 
 ## Architecture
 
-This repository contains the TOML Schema Definition (TOSD) specification/proposal plus a Java reference implementation.
+This repository contains the TOML Schema specification/proposal plus reference implementations.
 
 - `SPEC.md` is the primary human-readable specification. It defines the TOML schema language, validation semantics, parser expectations, file extension, MIME types, and schema-reference metadata.
 - `README.md` is the project overview and quickstart. Keep it concise and link to `SPEC.md` for detailed language semantics and `REFERENCE_IMPLEMENTATIONS.md` for implementation usage.
 - `REFERENCE_IMPLEMENTATIONS.md` tracks reference implementation status, Java CLI/library usage, and cross-implementation conformance expectations.
-- `toml-schema.abnf` is the formal TOSD-layer grammar companion for schema vocabulary and document shape. The Java tests include an ABNF conformance guard to prevent vocabulary drift.
+- `toml-schema.abnf` is the formal TOML Schema-layer grammar companion for schema vocabulary and document shape. The Java tests include an ABNF conformance guard to prevent vocabulary drift.
 - `toml-schema.tosd` is a TOML schema for schema documents themselves. It models allowed schema metadata, reusable type definitions, and top-level elements.
 - `config.tosd` and `config.toml` are the worked example pair: `config.toml` declares `[toml-schema] location = "config.tosd"`, and `config.tosd` describes the allowed document shape.
 - `reference-implementations/java/src/main/java/io/github/brunoborges/tomlschema` contains the Java reference implementation: schema loading/modeling, validation, result/error records, and `TomlSchemaCli`.
@@ -27,7 +27,7 @@ This repository contains the TOML Schema Definition (TOSD) specification/proposa
 ## Key conventions
 
 - Schema documents are intended to be valid TOML documents. The required top-level tables are `[toml-schema]` and `[elements]`; `[types]` is optional and exists for reusable definitions.
-- Use full SemVer strings for `[toml-schema].version`; the current TOSD version is `1.0.0`, and shorthand values like `"1"` or `"1.0"` are invalid.
+- Use full SemVer strings for `[toml-schema].version`; the current TOML Schema version is `1.0.0`, and shorthand values like `"1"` or `"1.0"` are invalid.
 - Custom metadata belongs under `[toml-schema.meta]`; do not add arbitrary keys or subtables directly under `[toml-schema]`.
 - Reusable definitions live under `[types.<name>]` and are referenced from `[elements]` or nested type definitions rather than duplicating structures.
 - Prefer canonical `typeof` and `collection` in schema examples. The Java implementation still accepts legacy aliases `typeref` and `table-collection` for compatibility.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TOML Schema Definition (TOSD)
+# TOML Schema
 
 [![Reference implementations](https://github.com/brunoborges/toml-schema/actions/workflows/reference-implementations.yml/badge.svg)](https://github.com/brunoborges/toml-schema/actions/workflows/reference-implementations.yml)
 [![License](https://img.shields.io/github/license/brunoborges/toml-schema)](LICENSE)
@@ -7,15 +7,15 @@
 [![Go 1.23](https://img.shields.io/badge/Go-1.23-00ADD8)](REFERENCE_IMPLEMENTATIONS.md#go)
 [![Rust 1.75](https://img.shields.io/badge/Rust-1.75-dea584)](REFERENCE_IMPLEMENTATIONS.md#rust)
 
-TOML Schema Definition (TOSD) is a TOML-based schema language for describing and validating the structure, names, and value types of TOML configuration files.
+TOML Schema is a TOML-based schema language for describing and validating the structure, names, and value types of TOML configuration files.
 
-A TOSD schema is itself a valid TOML document. Validators can use it to catch misconfiguration before production and tooling can use it for editor validation, completion, and hints.
+A TOML Schema document is itself a valid TOML document. Validators can use it to catch misconfiguration before production and tooling can use it for editor validation, completion, and hints.
 
 ## Documentation
 
-- [Specification](SPEC.md) - the TOSD language, validation semantics, file extension, MIME types, and TOML schema-reference metadata.
-- [ABNF grammar](toml-schema.abnf) - a compact grammar for the TOSD vocabulary and document shape, layered on top of TOML 1.0.
-- [Self-schema](toml-schema.tosd) - a TOSD schema for TOSD schema documents.
+- [Specification](SPEC.md) - the TOML Schema language, validation semantics, file extension, MIME type, and TOML schema-reference metadata.
+- [ABNF grammar](toml-schema.abnf) - a compact grammar for the TOML Schema vocabulary and document shape, layered on top of TOML 1.0.
+- [Self-schema](toml-schema.tosd) - a TOML Schema document for TOML Schema documents.
 - [Example schema](config.tosd) and [example TOML document](config.toml) - a worked example used by the reference implementation tests.
 - [Reference implementations](REFERENCE_IMPLEMENTATIONS.md) - implementation status, Java CLI/library usage, and conformance expectations.
 
@@ -31,7 +31,7 @@ enabled = true
 ports = [8000, 8001, 8002]
 ```
 
-TOSD schema:
+TOML Schema document:
 
 ```toml
 [toml-schema]
@@ -54,10 +54,10 @@ type = "table"
 ## Repository layout
 
 ```text
-SPEC.md                         Human-readable TOSD specification
+SPEC.md                         Human-readable TOML Schema specification
 REFERENCE_IMPLEMENTATIONS.md    Reference implementation status and usage
-toml-schema.abnf                TOSD-layer ABNF grammar
-toml-schema.tosd                Self-schema for TOSD documents
+toml-schema.abnf                TOML Schema-layer ABNF grammar
+toml-schema.tosd                Self-schema for TOML Schema documents
 config.tosd / config.toml       Example schema and TOML document
 reference-implementations/java  Java reference implementation and CLI
 reference-implementations/go    Go reference implementation and CLI
@@ -68,7 +68,7 @@ reference-implementations/rust  Rust reference implementation and CLI
 
 Java, Go, and Rust reference implementations live under `reference-implementations/`. See [Reference implementations](REFERENCE_IMPLEMENTATIONS.md) for implementation status, build/test commands, CLI usage, schema extraction, and conformance expectations.
 
-For array tuple/positional validation (`items`), see [SPEC.md: Tuple / Positional Array Validation](SPEC.md#tuple--positional-array-validation---items).
+For array tuple/positional validation (`items`), see [SPEC.md: Tuple / Positional Array Validation](SPEC.md#tuple-positional-array-validation---items).
 
 ## Schema reference from TOML
 
@@ -94,4 +94,4 @@ Thanks to my friends!
 
 ## License
 
-TOSD is licensed under the [MIT License](LICENSE).
+TOML Schema is licensed under the [MIT License](LICENSE).

--- a/REFERENCE_IMPLEMENTATIONS.md
+++ b/REFERENCE_IMPLEMENTATIONS.md
@@ -1,6 +1,6 @@
 # Reference Implementations
 
-This document tracks TOSD reference implementations and the expected validation surface for each implementation.
+This document tracks TOML Schema reference implementations and the expected validation surface for each implementation.
 
 ## Status
 
@@ -45,13 +45,13 @@ Validate using `[toml-schema].location` from the TOML document:
 java -jar reference-implementations/java/target/toml-schema-0.1.0-SNAPSHOT.jar validate config.toml
 ```
 
-Validate the example schema against the TOSD self-schema:
+Validate the example schema against the TOML Schema self-schema:
 
 ```shell
 java -jar reference-implementations/java/target/toml-schema-0.1.0-SNAPSHOT.jar validate toml-schema.tosd config.tosd
 ```
 
-Validate the TOSD self-schema against itself:
+Validate the TOML Schema self-schema against itself:
 
 ```shell
 java -jar reference-implementations/java/target/toml-schema-0.1.0-SNAPSHOT.jar validate toml-schema.tosd toml-schema.tosd
@@ -95,13 +95,13 @@ Validate using `[toml-schema].location` from the TOML document:
 go -C reference-implementations/go run . validate ../../config.toml
 ```
 
-Validate the example schema against the TOSD self-schema:
+Validate the example schema against the TOML Schema self-schema:
 
 ```shell
 go -C reference-implementations/go run . validate ../../toml-schema.tosd ../../config.tosd
 ```
 
-Validate the TOSD self-schema against itself:
+Validate the TOML Schema self-schema against itself:
 
 ```shell
 go -C reference-implementations/go run . validate ../../toml-schema.tosd ../../toml-schema.tosd
@@ -141,13 +141,13 @@ Validate using `[toml-schema].location` from the TOML document:
 cargo run --quiet --manifest-path reference-implementations/rust/Cargo.toml -- validate config.toml
 ```
 
-Validate the example schema against the TOSD self-schema:
+Validate the example schema against the TOML Schema self-schema:
 
 ```shell
 cargo run --quiet --manifest-path reference-implementations/rust/Cargo.toml -- validate toml-schema.tosd config.tosd
 ```
 
-Validate the TOSD self-schema against itself:
+Validate the TOML Schema self-schema against itself:
 
 ```shell
 cargo run --quiet --manifest-path reference-implementations/rust/Cargo.toml -- validate toml-schema.tosd toml-schema.tosd
@@ -177,7 +177,7 @@ Every reference implementation should:
 
 1. Parse TOML documents with a TOML 1.0-compliant parser rather than reimplementing TOML parsing.
 1. Treat `.tosd` schemas as valid TOML documents.
-1. Require `[toml-schema].version` to be a SemVer string compatible with the implementation's supported TOSD version.
+1. Require `[toml-schema].version` to be a SemVer string compatible with the implementation's supported TOML Schema version.
 1. Validate the checked-in `config.toml` document against `config.tosd`.
 1. Support schema lookup through `[toml-schema].location`.
 1. Validate `config.tosd` against `toml-schema.tosd`.
@@ -188,7 +188,7 @@ The GitHub Actions workflow in `.github/workflows/reference-implementations.yml`
 
 ## TOML version profile
 
-TOSD targets the TOML logical value model (string, integer, float, boolean, offset-date-time, local-date-time, local-date, local-time, array, table, inline table, array of tables). That model is unchanged between [TOML 1.0.0](https://toml.io/en/v1.0.0) and [TOML 1.1.0](https://toml.io/en/v1.1.0); the TOML 1.1 changes are mostly parser/input-syntax clarifications and additions (for example `\e` and `\xHH` string escapes, optional seconds in date-times, multi-line inline tables, and trailing commas in inline tables). No new TOSD schema keywords or built-in type names are required to support TOML 1.1.
+TOML Schema targets the TOML logical value model (string, integer, float, boolean, offset-date-time, local-date-time, local-date, local-time, array, table, inline table, array of tables). That model is unchanged between [TOML 1.0.0](https://toml.io/en/v1.0.0) and [TOML 1.1.0](https://toml.io/en/v1.1.0); the TOML 1.1 changes are mostly parser/input-syntax clarifications and additions (for example `\e` and `\xHH` string escapes, optional seconds in date-times, multi-line inline tables, and trailing commas in inline tables). No new TOML Schema keywords or built-in type names are required to support TOML 1.1.
 
 The current reference implementations parse TOML with libraries that target TOML 1.0:
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
-# TOML Schema Definition (TOSD) Specification
+# TOML Schema Specification
 
-A [TOML Schema](https://github.com/toml-lang/tosd) is a set of TOML-based constructs that define the structure, the names, and the types of configuration data on a TOML file.
+TOML Schema is a set of TOML-based constructs that define the structure, the names, and the types of configuration data on a TOML file.
 
 The TOML Schema is used to validate the input of a TOML file during parsing to:
 
@@ -38,7 +38,7 @@ The schema format follows the TOML specification, meaning that a TOML Schema is 
   - [Pattern - `pattern`](#pattern---pattern)
 - [Parsers](#parsers)
 - [Filename Extension](#filename-extension)
-- [MIME Types](#mime-types)
+- [MIME Type](#mime-type)
 - [TOML Reference of a TOML Schema](#toml-reference-of-a-toml-schema)
 
 ## First Glance
@@ -176,9 +176,9 @@ version = "1.0.0"
 
 ### Schema Versioning
 
-TOSD follows the same version-numbering policy as the TOML specification: schema language versions use [Semantic Versioning](https://semver.org/).
+TOML Schema follows the same version-numbering policy as the TOML specification: schema language versions use [Semantic Versioning](https://semver.org/).
 
-The `version` property MUST be a string containing a full SemVer version in `MAJOR.MINOR.PATCH` form. The current TOSD version is `1.0.0`.
+The `version` property MUST be a string containing a full SemVer version in `MAJOR.MINOR.PATCH` form. The current TOML Schema version is `1.0.0`.
 
 ```toml
 [toml-schema]
@@ -187,7 +187,7 @@ version = "1.0.0"
 
 Parsers MUST reject schema documents whose `version` is missing, is not a string, or is not a valid SemVer value. Shorthand values such as `"1"` and `"1.0"` are invalid.
 
-A parser that supports TOSD version `MAJOR.MINOR.PATCH` MUST accept schema documents with the same major version and a minor version less than or equal to the parser's supported minor version. Patch versions, pre-release identifiers, and build metadata do not add schema-language features and do not affect parser compatibility. Parsers MUST reject schema documents with an unsupported major version or a greater minor version.
+A parser that supports TOML Schema version `MAJOR.MINOR.PATCH` MUST accept schema documents with the same major version and a minor version less than or equal to the parser's supported minor version. Patch versions, pre-release identifiers, and build metadata do not add schema-language features and do not affect parser compatibility. Parsers MUST reject schema documents with an unsupported major version or a greater minor version.
 
 ## Elements table - `[elements]`
 
@@ -581,18 +581,13 @@ A parser that validates a TOML document against a TOML Schema must produce the e
 
 ## Filename Extension
 
-TOML Schema files should use the extension `.tosd`.
+TOML Schema files MUST use the extension `.tosd`.
 
-## MIME Types
+## MIME Type
 
-When transferring TOML Schema files over the internet, the appropriate MIME types are:
+When transferring TOML Schema files over the internet, the MIME type MUST be:
 
  - application/tosd
- - application/vnd.tosd
- - application/x-tosd
- - text/tosd
- - text/vnd.tosd
- - text/x-tosd
 
 ## TOML Reference of a TOML Schema
 

--- a/reference-implementations/go/extract.go
+++ b/reference-implementations/go/extract.go
@@ -31,7 +31,7 @@ func extract(documentPath, schemaPath string, out, errOut io.Writer) int {
 func generateSchema(document map[string]any) string {
 	var schema strings.Builder
 	schema.WriteString("[toml-schema]\n")
-	fmt.Fprintf(&schema, "version = %q\n\n", currentTOSDVersion)
+	fmt.Fprintf(&schema, "version = %q\n\n", currentTomlSchemaVersion)
 	schema.WriteString("[elements]\n")
 	for _, key := range sortedKeys(document) {
 		if key == "toml-schema" {

--- a/reference-implementations/go/schema.go
+++ b/reference-implementations/go/schema.go
@@ -37,7 +37,7 @@ var definitionKeys = map[string]bool{
 	"oneof": true, "anyof": true, "children": true,
 }
 
-const currentTOSDVersion = "1.0.0"
+const currentTomlSchemaVersion = "1.0.0"
 
 var semverPattern = regexp.MustCompile(`^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-((?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$`)
 
@@ -129,10 +129,10 @@ func validateSchemaVersion(value any) error {
 		return fmt.Errorf("[toml-schema].version must use SemVer MAJOR.MINOR.PATCH syntax")
 	}
 	if matches[1] != "1" {
-		return fmt.Errorf("unsupported TOSD major version: %s", version)
+		return fmt.Errorf("unsupported TOML Schema major version: %s", version)
 	}
 	if matches[2] != "0" {
-		return fmt.Errorf("unsupported TOSD minor version: %s", version)
+		return fmt.Errorf("unsupported TOML Schema minor version: %s", version)
 	}
 	return nil
 }

--- a/reference-implementations/java/pom.xml
+++ b/reference-implementations/java/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>toml-schema</artifactId>
     <version>0.1.0-SNAPSHOT</version>
     <name>TOML Schema</name>
-    <description>Java reference implementation for TOML Schema Definition (TOSD)</description>
+    <description>Java reference implementation for TOML Schema</description>
 
     <properties>
         <maven.compiler.release>25</maven.compiler.release>

--- a/reference-implementations/java/src/main/java/io/github/brunoborges/tomlschema/SchemaLoader.java
+++ b/reference-implementations/java/src/main/java/io/github/brunoborges/tomlschema/SchemaLoader.java
@@ -57,7 +57,7 @@ final class SchemaLoader {
         if (metadata == null || !metadata.contains("version")) {
             throw new SchemaException("[toml-schema] must contain version");
         }
-        TosdVersion.validate(metadata.get("version"));
+        TomlSchemaVersion.validate(metadata.get("version"));
         for (String key : metadata.keySet()) {
             if (!key.equals("version") && !key.equals("meta")) {
                 throw new SchemaException("Unsupported [toml-schema] key: " + key);

--- a/reference-implementations/java/src/main/java/io/github/brunoborges/tomlschema/TomlSchemaCli.java
+++ b/reference-implementations/java/src/main/java/io/github/brunoborges/tomlschema/TomlSchemaCli.java
@@ -122,7 +122,7 @@ public final class TomlSchemaCli {
     private static String generateSchema(TomlTable document) {
         StringBuilder schema = new StringBuilder();
         schema.append("[toml-schema]\n");
-        schema.append("version = \"").append(TosdVersion.CURRENT).append("\"\n\n");
+        schema.append("version = \"").append(TomlSchemaVersion.CURRENT).append("\"\n\n");
         schema.append("[elements]\n");
         for (String key : document.keySet()) {
             if ("toml-schema".equals(key)) {

--- a/reference-implementations/java/src/main/java/io/github/brunoborges/tomlschema/TomlSchemaVersion.java
+++ b/reference-implementations/java/src/main/java/io/github/brunoborges/tomlschema/TomlSchemaVersion.java
@@ -3,7 +3,7 @@ package io.github.brunoborges.tomlschema;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-final class TosdVersion {
+final class TomlSchemaVersion {
     static final String CURRENT = "1.0.0";
 
     private static final String SUPPORTED_MAJOR = "1";
@@ -14,7 +14,7 @@ final class TosdVersion {
                     + "(?:\\+([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?$"
     );
 
-    private TosdVersion() {
+    private TomlSchemaVersion() {
     }
 
     static void validate(Object value) {
@@ -28,10 +28,10 @@ final class TosdVersion {
         String major = matcher.group(1);
         String minor = matcher.group(2);
         if (!SUPPORTED_MAJOR.equals(major)) {
-            throw new SchemaException("Unsupported TOSD major version: " + version);
+            throw new SchemaException("Unsupported TOML Schema major version: " + version);
         }
         if (!SUPPORTED_MINOR.equals(minor)) {
-            throw new SchemaException("Unsupported TOSD minor version: " + version);
+            throw new SchemaException("Unsupported TOML Schema minor version: " + version);
         }
     }
 }

--- a/reference-implementations/rust/Cargo.toml
+++ b/reference-implementations/rust/Cargo.toml
@@ -2,7 +2,7 @@
 name = "toml-schema"
 version = "0.1.0"
 edition = "2021"
-description = "Reference implementation of TOML Schema Definition (TOSD) for Rust"
+description = "Reference implementation of TOML Schema for Rust"
 license = "MIT"
 publish = false
 

--- a/reference-implementations/rust/src/extract.rs
+++ b/reference-implementations/rust/src/extract.rs
@@ -6,15 +6,15 @@ use std::fmt::Write as _;
 use toml::value::Datetime;
 use toml::{Table, Value};
 
-use crate::schema::{encode_path_key, SchemaType, CURRENT_TOSD_VERSION};
+use crate::schema::{encode_path_key, SchemaType, CURRENT_TOML_SCHEMA_VERSION};
 
-/// Renders a TOSD schema as a TOML string from the parsed sample document. Keys
+/// Renders a TOML Schema document as a TOML string from the parsed sample document. Keys
 /// are emitted in the natural order of the parsed [`Table`] (which is sorted
 /// because the `toml` crate uses a `BTreeMap` by default).
 pub fn generate_schema(document: &Table) -> String {
     let mut schema = String::new();
     schema.push_str("[toml-schema]\n");
-    writeln!(schema, "version = \"{CURRENT_TOSD_VERSION}\"\n").expect("write to String");
+    writeln!(schema, "version = \"{CURRENT_TOML_SCHEMA_VERSION}\"\n").expect("write to String");
     schema.push_str("[elements]\n");
     for (key, value) in document.iter() {
         if key == "toml-schema" {

--- a/reference-implementations/rust/src/lib.rs
+++ b/reference-implementations/rust/src/lib.rs
@@ -1,7 +1,7 @@
-//! Rust reference implementation for TOML Schema Definition (TOSD).
+//! Rust reference implementation for TOML Schema.
 //!
 //! See `REFERENCE_IMPLEMENTATIONS.md` and `SPEC.md` at the repository root for the
-//! TOSD language and the conformance expectations every reference implementation
+//! TOML Schema language and the conformance expectations every reference implementation
 //! must meet.
 
 pub mod cli;

--- a/reference-implementations/rust/src/schema.rs
+++ b/reference-implementations/rust/src/schema.rs
@@ -1,6 +1,6 @@
-//! Schema model, loader, and validator for TOSD documents.
+//! Schema model, loader, and validator for TOML Schema documents.
 //!
-//! The implementation mirrors the Go and Java reference implementations: a TOSD
+//! The implementation mirrors the Go and Java reference implementations: a TOML Schema
 //! file is parsed as a TOML document, top-level `[types]` and `[elements]`
 //! tables are decoded into [`Definition`] values, and a [`Schema`] can validate
 //! a parsed TOML document against those definitions.
@@ -14,7 +14,7 @@ use regex::Regex;
 use toml::value::{Datetime, Offset};
 use toml::{Table, Value};
 
-/// Built-in TOSD schema types.
+/// Built-in TOML Schema types.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SchemaType {
     Any,
@@ -32,7 +32,7 @@ pub enum SchemaType {
 }
 
 impl SchemaType {
-    /// Returns the TOSD spelling for this type (e.g. `"offset-date-time"`).
+    /// Returns the TOML Schema spelling for this type (e.g. `"offset-date-time"`).
     pub fn schema_name(&self) -> &'static str {
         match self {
             SchemaType::Any => "any",
@@ -88,7 +88,7 @@ impl fmt::Display for SchemaType {
     }
 }
 
-/// The set of TOSD schema properties recognised by this implementation. The
+/// The set of TOML Schema properties recognised by this implementation. The
 /// keys are checked against the ABNF grammar in tests.
 pub const DEFINITION_KEYS: &[&str] = &[
     "type",
@@ -112,13 +112,13 @@ pub const DEFINITION_KEYS: &[&str] = &[
     "children",
 ];
 
-pub const CURRENT_TOSD_VERSION: &str = "1.0.0";
+pub const CURRENT_TOML_SCHEMA_VERSION: &str = "1.0.0";
 
 fn is_definition_key(key: &str) -> bool {
     DEFINITION_KEYS.contains(&key)
 }
 
-/// A single TOSD definition (either a reusable `[types.*]` entry or an
+/// A single TOML Schema definition (either a reusable `[types.*]` entry or an
 /// `[elements.*]` entry).
 #[derive(Debug, Clone, Default)]
 pub struct Definition {
@@ -159,7 +159,7 @@ impl ValidationResult {
     }
 }
 
-/// A loaded TOSD schema.
+/// A loaded TOML Schema document.
 #[derive(Debug, Clone)]
 pub struct Schema {
     source: PathBuf,
@@ -168,7 +168,7 @@ pub struct Schema {
 }
 
 impl Schema {
-    /// Loads a TOSD schema from a filesystem path.
+    /// Loads a TOML Schema document from a filesystem path.
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, String> {
         let path = path.as_ref();
         let parsed = parse_toml_file(path)
@@ -176,7 +176,7 @@ impl Schema {
         Self::from_table(path.to_path_buf(), parsed)
     }
 
-    /// Builds a schema from an already-parsed TOSD root table.
+    /// Builds a schema from an already-parsed TOML Schema root table.
     pub fn from_table(source: PathBuf, table: Table) -> Result<Self, String> {
         if !matches!(table.get("toml-schema"), Some(Value::Table(_))) {
             return Err("schema must contain a [toml-schema] table".to_string());
@@ -230,10 +230,10 @@ impl Schema {
             return Err("[toml-schema].version must use SemVer MAJOR.MINOR.PATCH syntax".to_string());
         };
         if captures.get(1).map(|major| major.as_str()) != Some("1") {
-            return Err(format!("unsupported TOSD major version: {version}"));
+            return Err(format!("unsupported TOML Schema major version: {version}"));
         }
         if captures.get(2).map(|minor| minor.as_str()) != Some("0") {
-            return Err(format!("unsupported TOSD minor version: {version}"));
+            return Err(format!("unsupported TOML Schema minor version: {version}"));
         }
         Ok(())
     }
@@ -267,7 +267,7 @@ impl Schema {
     }
 }
 
-/// Loads a TOSD schema referenced by a TOML document via
+/// Loads a TOML Schema document referenced by a TOML document via
 /// `[toml-schema].location` and returns the schema together with the parsed
 /// document.
 pub fn schema_from_document<P: AsRef<Path>>(

--- a/toml-schema.abnf
+++ b/toml-schema.abnf
@@ -1,12 +1,12 @@
-;; TOML Schema Definition (TOSD) grammar layer
+;; TOML Schema grammar layer
 ;; Author: Bruno Borges
 ;;
-;; TOSD files are TOML 1.0 documents. This ABNF defines the schema vocabulary
+;; TOML Schema files are TOML 1.0 documents. This ABNF defines the schema vocabulary
 ;; and document shape layered on top of TOML; TOML 1.0 remains authoritative for
 ;; base key, table, array, inline-table, string, number, boolean, and date/time
 ;; syntax.
 ;;
-;; The TOSD vocabulary defined below is independent of TOML version: the same
+;; The TOML Schema vocabulary defined below is independent of TOML version: the same
 ;; schema keys and built-in type names apply when targeting TOML 1.1 documents,
 ;; provided the underlying TOML parser supports TOML 1.1. See
 ;; REFERENCE_IMPLEMENTATIONS.md ("TOML version profile") for the current
@@ -74,7 +74,7 @@ tabletype           = DQUOTE %x74.61.62.6c.65 DQUOTE                            
 collectiontype      = DQUOTE %x63.6f.6c.6c.65.63.74.69.6f.6e DQUOTE                   ; "collection"
 tablecollectiontype = DQUOTE %x74.61.62.6c.65.2d.63.6f.6c.6c.65.63.74.69.6f.6e DQUOTE ; "table-collection"
 
-;; TOML 1.0 grammar terminals used by TOSD.
+;; TOML 1.0 grammar terminals used by TOML Schema.
 
 semver-string                     = <TOML string containing a Semantic Versioning 2.0.0 value>
 toml-table-header-toml-schema      = <TOML 1.0 table header for [toml-schema]>


### PR DESCRIPTION
## Summary
- Rename public project language from TOML Schema Definition/TOSD to TOML Schema
- Keep .tosd as the required schema file extension
- Narrow the specified MIME type to application/tosd only
- Update reference implementation metadata and internal version helper names

## Validation
- Markdown link and SPEC anchor checks
- mvn -q -f reference-implementations/java/pom.xml test
- go -C reference-implementations/go test ./...
- cargo test --manifest-path reference-implementations/rust/Cargo.toml --locked --quiet