### PR TITLE
Simplify schema vocabulary and reserve built-in type references

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,12 +17,12 @@ This repository contains the TOML Schema specification/proposal plus reference i
 - `SPEC.md` is the primary human-readable specification. It defines the TOML schema language, validation semantics, parser expectations, file extension, MIME types, and schema-reference metadata.
 - `README.md` is the project overview and quickstart. Keep it concise and link to `SPEC.md` for detailed language semantics and `REFERENCE_IMPLEMENTATIONS.md` for implementation usage.
 - `REFERENCE_IMPLEMENTATIONS.md` tracks reference implementation status, Java CLI/library usage, and cross-implementation conformance expectations.
-- `toml-schema.abnf` is the formal TOML Schema-layer grammar companion for schema vocabulary and document shape. The Java tests include an ABNF conformance guard to prevent vocabulary drift.
+- `toml-schema.abnf` is the formal TOML Schema-layer grammar companion for schema vocabulary and document shape. Reference implementation tests include ABNF conformance guards to prevent vocabulary drift.
 - `toml-schema.tosd` is a TOML schema for schema documents themselves. It models allowed schema metadata, reusable type definitions, and top-level elements.
 - `config.tosd` and `config.toml` are the worked example pair: `config.toml` declares `[toml-schema] location = "config.tosd"`, and `config.tosd` describes the allowed document shape.
 - `reference-implementations/java/src/main/java/io/github/brunoborges/tomlschema` contains the Java reference implementation: schema loading/modeling, validation, result/error records, and `TomlSchemaCli`.
 - `reference-implementations/java/src/test/java/io/github/brunoborges/tomlschema/TomlSchemaTest.java` covers the checked-in examples, self-schema validation, validation errors, and CLI schema-location lookup.
-- `reference-implementations/java/src/test/java/io/github/brunoborges/tomlschema/AbnfConformanceTest.java` reads `toml-schema.abnf` and checks Java schema properties and built-in type names against it.
+- Java, Go, and Rust ABNF conformance tests read `toml-schema.abnf` and check implementation schema properties and built-in type names against it.
 
 ## Key conventions
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,7 +21,7 @@ This repository contains the TOML Schema specification/proposal plus reference i
 - `toml-schema.tosd` is a TOML schema for schema documents themselves. It models allowed schema metadata, reusable type definitions, and top-level elements.
 - `config.tosd` and `config.toml` are the worked example pair: `config.toml` declares `[toml-schema] location = "config.tosd"`, and `config.tosd` describes the allowed document shape.
 - `reference-implementations/java/src/main/java/io/github/brunoborges/tomlschema` contains the Java reference implementation: schema loading/modeling, validation, result/error records, and `TomlSchemaCli`.
-- `reference-implementations/java/src/test/java/io/github/brunoborges/tomlschema/TomlSchemaTest.java` covers the checked-in examples, self-schema validation, legacy aliases, validation errors, and CLI schema-location lookup.
+- `reference-implementations/java/src/test/java/io/github/brunoborges/tomlschema/TomlSchemaTest.java` covers the checked-in examples, self-schema validation, validation errors, and CLI schema-location lookup.
 - `reference-implementations/java/src/test/java/io/github/brunoborges/tomlschema/AbnfConformanceTest.java` reads `toml-schema.abnf` and checks Java schema properties and built-in type names against it.
 
 ## Key conventions
@@ -30,7 +30,7 @@ This repository contains the TOML Schema specification/proposal plus reference i
 - Use full SemVer strings for `[toml-schema].version`; the current TOML Schema version is `1.0.0`, and shorthand values like `"1"` or `"1.0"` are invalid.
 - Custom metadata belongs under `[toml-schema.meta]`; do not add arbitrary keys or subtables directly under `[toml-schema]`.
 - Reusable definitions live under `[types.<name>]` and are referenced from `[elements]` or nested type definitions rather than duplicating structures.
-- Prefer canonical `typeof` and `collection` in schema examples. The Java implementation still accepts legacy aliases `typeref` and `table-collection` for compatibility.
+- Use canonical `typeof` in schema examples. The Java implementation still accepts `table-collection` as a legacy alias for `collection`.
 - Use `itemtype = "types.<name>"` on `type = "array"` definitions when array items need structural validation, including TOML arrays of tables (`[[name]]`) and arrays of inline tables.
 - Use `oneof` for exactly-one alternative type validation and `anyof` for at-least-one validation; both reference reusable `[types]` definitions and can apply to fields or array item types.
 - `min`/`max` are inclusive and only valid for numeric/date-time types, or arrays with comparable `arraytype`; NaN is not a valid boundary.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,7 +30,7 @@ This repository contains the TOML Schema specification/proposal plus reference i
 - Use full SemVer strings for `[toml-schema].version`; the current TOML Schema version is `1.0.0`, and shorthand values like `"1"` or `"1.0"` are invalid.
 - Custom metadata belongs under `[toml-schema.meta]`; do not add arbitrary keys or subtables directly under `[toml-schema]`.
 - Reusable definitions live under `[types.<name>]` and are referenced from `[elements]` or nested type definitions rather than duplicating structures.
-- Use canonical `typeof` in schema examples. The Java implementation still accepts `table-collection` as a legacy alias for `collection`.
+- Use canonical `typeof` and `collection` in schema examples.
 - Use `itemtype = "types.<name>"` on `type = "array"` definitions when array items need structural validation, including TOML arrays of tables (`[[name]]`) and arrays of inline tables.
 - Use `oneof` for exactly-one alternative type validation and `anyof` for at-least-one validation; both reference reusable `[types]` definitions and can apply to fields or array item types.
 - `min`/`max` are inclusive and only valid for numeric/date-time types, or arrays with comparable `arraytype`; NaN is not a valid boundary.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Java, Go, and Rust reference implementations live under `reference-implementatio
 
 For array tuple/positional validation (`items`), see [SPEC.md: Tuple / Positional Array Validation](SPEC.md#tuple-positional-array-validation---items).
 
+Type references such as `typeof`, `itemtype`, `items`, `oneof`, and `anyof` can point directly at reserved built-in type names (`"string"`, `"boolean"`, `"integer"`, etc.) or at reusable `[types]` definitions.
+
 ## Schema reference from TOML
 
 A TOML document can point to a schema with reserved metadata:

--- a/REFERENCE_IMPLEMENTATIONS.md
+++ b/REFERENCE_IMPLEMENTATIONS.md
@@ -113,6 +113,8 @@ Extract a schema from a sample TOML document:
 go -C reference-implementations/go run . extract ../../config.toml /tmp/config.generated.tosd
 ```
 
+The Go test suite includes an ABNF conformance test (`abnf_conformance_test.go`) that reads `toml-schema.abnf` and asserts that the implementation's supported schema keys and built-in type names match the grammar.
+
 ## Rust
 
 The Rust reference implementation uses the [`toml`](https://crates.io/crates/toml) crate to parse TOML and validates the parsed data model against a `.tosd` schema. It can be used as a library or as an executable CLI, and it can extract a starter schema from a sample TOML document.

--- a/SPEC.md
+++ b/SPEC.md
@@ -195,19 +195,26 @@ The `elements` table defines the overall structure and properties of the TOML do
 
 ## Types table - `[types]`
 
-The `[types]` table is for use when there is a need for custom, reusable types of structure or properties. A `type` is referenced in an `element` by the property `typeof`.
+The `[types]` table is for use when there is a need for custom, reusable types of structure or properties. A type is referenced in an element or another type with a type reference.
+
+Type references are strings accepted by `typeof`, `itemtype`, `items`, `oneof`, and `anyof`. A type reference may be either:
+
+- a built-in type name such as `"string"`, `"boolean"`, or `"integer"`;
+- a named reusable definition from `[types]`, written either as `"types.<typename>"` or `"<typename>"`.
+
+Built-in type names are reserved and MUST NOT be used as `[types]` definition names. The reserved names are `any`, `string`, `integer`, `float`, `boolean`, `offset-date-time`, `local-date-time`, `local-date`, `local-time`, `array`, `table`, and `collection`. The legacy alias `table-collection` is also reserved when accepted by a parser.
 
 ```toml
 [types]
 
 [types.<typename>]
 type = "<simple-type> | array | table | collection"
-typeof = "<full-name-of-a-defined-type>"
+typeof = "<type-reference>"
 arraytype = "<simple-type> | array | table"
-itemtype = "<full-name-of-a-defined-type>"
-items = [ "<full-name-of-a-defined-type>", ... ]
-oneof = [ "<full-name-of-a-defined-type>", ... ]
-anyof = [ "<full-name-of-a-defined-type>", ... ]
+itemtype = "<type-reference>"
+items = [ "<type-reference>", ... ]
+oneof = [ "<type-reference>", ... ]
+anyof = [ "<type-reference>", ... ]
 allowedvalues = [ <array-with-enumeration-of-allowed-values> ]
 pattern = "<string-regex-for-string-validation>"
 optional = true|false
@@ -319,7 +326,7 @@ If a property of type `table` has no defined property and/or structure, the pars
 Arrays can be defined by mixing the following properties:
 
  - `arraytype`: the built-in type of each value in the array (e.g. string, array, or table).
- - `itemtype`: a reusable `[types]` definition used to validate each item in the array.
+ - `itemtype`: a type reference used to validate each item in the array.
  - `items`: ordered type references for tuple-style positional validation with fixed arity.
  - `minlength`: the minimum length of the array (e.g. no less than 2 elements).
  - `maxlength`: the maximum length of the array (e.g. no more than 2 elements).
@@ -514,7 +521,7 @@ A `collection` may be represented as subtables of a common table in a TOML docum
 
 ### Type Reference
 
-A type may be referenced to inherit the defined rules existent in given type. Both `type` and `element` may reference a `type`.
+A type reference applies the referenced built-in type or inherits the rules of a named reusable type. Both `[types]` definitions and `[elements]` definitions may use type references.
 
 ```toml
 [types]
@@ -526,6 +533,9 @@ A type may be referenced to inherit the defined rules existent in given type. Bo
     [types.serverType.name]
     typeof = "types.nameType"
 
+    [types.serverType.enabled]
+    typeof = "boolean"
+
 [elements]
 
     [elements.datacenter]
@@ -534,6 +544,10 @@ A type may be referenced to inherit the defined rules existent in given type. Bo
         [elements.datacenter.name]
         typeof="types.nameType"
 
+        [elements.datacenter.tags]
+        type = "array"
+        itemtype = "string"
+
         [elements.datacenter.servers]
         type = "collection"
         typeof = "types.serverType"
@@ -541,12 +555,12 @@ A type may be referenced to inherit the defined rules existent in given type. Bo
 
 ### Alternative Types - `oneof` and `anyof`
 
-Use `oneof` or `anyof` when a value may validate against alternative reusable type definitions.
+Use `oneof` or `anyof` when a value may validate against alternative type references.
 
 - `oneof`: exactly one referenced type must validate.
 - `anyof`: at least one referenced type must validate.
 
-These properties can be used anywhere a schema definition can appear, including an `[elements]` field, a reusable `[types]` definition, and a type referenced through `itemtype` for array items.
+These properties can be used anywhere a schema definition can appear, including an `[elements]` field, a reusable `[types]` definition, and a type referenced through `itemtype` for array items. Alternatives may reference built-in type names directly or named definitions when a branch needs constraints.
 
 ```toml
 [types.stringId]
@@ -559,23 +573,23 @@ min = 1
 
 [elements.id]
 anyof = [ "types.stringId", "types.integerId" ]
+
+[elements.simpleId]
+oneof = [ "string", "integer" ]
 ```
 
-Built-in type names are not valid entries in `oneof` or `anyof`; alternatives must
-reference named definitions. Keeping alternatives as definitions gives every branch
-a place for constraints such as `pattern`, `min`, `allowedvalues`, `arraytype`, or
-child fields. For simple unions, define a small reusable wrapper for each built-in
-type that participates in the union.
+Use a named reusable definition whenever an alternative needs constraints such as `pattern`, `min`, `allowedvalues`, `arraytype`, or child fields.
 
 ```toml
-[types.stringValue]
+[types.dependencyVersion]
 type = "string"
+pattern = "^\\d+\\.\\d+\\.\\d+$"
 
 [types.inlineDependency]
 type = "table"
 
 [types.dependency]
-oneof = [ "types.stringValue", "types.inlineDependency" ]
+oneof = [ "types.dependencyVersion", "types.inlineDependency" ]
 ```
 
 ### Optionality - `optional`

--- a/SPEC.md
+++ b/SPEC.md
@@ -440,7 +440,7 @@ Semantics:
  - `items` is ordered, and each index validates against the corresponding referenced type.
  - When `items` is present, the array must have exactly the same number of items.
  - `items` is mutually exclusive with `arraytype` and `itemtype`.
- - `items` is also mutually exclusive with `minlength` and `maxlength` (and aliases `minoccurs` / `maxoccurs`).
+ - `items` is also mutually exclusive with `minlength` and `maxlength`.
 
 #### Collection of Elements for Dynamic Keys
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -202,7 +202,7 @@ Type references are strings accepted by `typeof`, `itemtype`, `items`, `oneof`, 
 - a built-in type name such as `"string"`, `"boolean"`, or `"integer"`;
 - a named reusable definition from `[types]`, written either as `"types.<typename>"` or `"<typename>"`.
 
-Built-in type names are reserved and MUST NOT be used as `[types]` definition names. The reserved names are `any`, `string`, `integer`, `float`, `boolean`, `offset-date-time`, `local-date-time`, `local-date`, `local-time`, `array`, `table`, and `collection`. The legacy alias `table-collection` is also reserved when accepted by a parser.
+Built-in type names are reserved and MUST NOT be used as `[types]` definition names. The reserved names are `any`, `string`, `integer`, `float`, `boolean`, `offset-date-time`, `local-date-time`, `local-date`, `local-time`, `array`, `table`, and `collection`.
 
 ```toml
 [types]

--- a/config.toml
+++ b/config.toml
@@ -81,7 +81,7 @@ points = [
   { x = 2, y = 4 }
 ]
 
-# This element is a 'table-collection' of type 'libraryType'
+# This element is a 'collection' of type 'libraryType'
 # and each library can be expressed with an inline table
 [libraries]
 lib1 = { name = "gcc", version = "10.2" }

--- a/docs/index.html
+++ b/docs/index.html
@@ -195,7 +195,7 @@ max = 10</code></pre>
         </p>
         <div class="spec-list">
           <div class="spec-item"><strong>Versioned metadata</strong><span><code>[toml-schema]</code> declares SemVer language compatibility.</span></div>
-          <div class="spec-item"><strong>Reusable types</strong><span><code>[types]</code> definitions keep schemas compact and consistent.</span></div>
+          <div class="spec-item"><strong>Type references</strong><span><code>typeof</code>, <code>itemtype</code>, <code>items</code>, <code>oneof</code>, and <code>anyof</code> can reference built-in type names or reusable <code>[types]</code>.</span></div>
           <div class="spec-item"><strong>Dynamic keys</strong><span><code>collection</code> validates user-provided table keys.</span></div>
           <div class="spec-item"><strong>Union shapes</strong><span><code>oneof</code> and <code>anyof</code> model alternative valid forms.</span></div>
           <div class="spec-item"><strong>Arrays and tuples</strong><span><code>arraytype</code>, <code>itemtype</code>, and <code>items</code> cover homogeneous and positional arrays.</span></div>

--- a/examples/gitlab-runner.tosd
+++ b/examples/gitlab-runner.tosd
@@ -3,30 +3,15 @@
 [toml-schema]
 version = "1.0.0"
 
-[types.anyValue]
-type = "any"
-
-[types.booleanValue]
-type = "boolean"
-
-[types.integerValue]
-type = "integer"
-
-[types.floatValue]
-type = "float"
-
-[types.stringValue]
-type = "string"
-
 [types.numberValue]
-oneof = [ "types.integerValue", "types.floatValue" ]
+oneof = [ "integer", "float" ]
 
 [types.durationValue]
 type = "string"
 pattern = '^(?:[0-9]+(?:\.[0-9]+)?(?:ns|us|ms|s|m|h))+$'
 
 [types.durationOrInteger]
-oneof = [ "types.durationValue", "types.integerValue" ]
+oneof = [ "types.durationValue", "integer" ]
 
 [types.stringArray]
 type = "array"
@@ -38,17 +23,17 @@ arraytype = "integer"
 
 [types.stringMap]
 type = "collection"
-typeof = "types.stringValue"
+typeof = "string"
 
 [types.anyMap]
 type = "collection"
-typeof = "types.anyValue"
+typeof = "any"
 
 [types.stringOrStringArray]
-oneof = [ "types.stringValue", "types.stringArray" ]
+oneof = [ "string", "types.stringArray" ]
 
 [types.stringOrInteger]
-oneof = [ "types.stringValue", "types.integerValue" ]
+oneof = [ "string", "integer" ]
 
 [types.logLevel]
 type = "string"
@@ -203,7 +188,7 @@ itemtype = "types.dockerService"
 
 [types.docker]
 type = "collection"
-typeof = "types.anyValue"
+typeof = "any"
 
     [types.docker.host]
     type = "string"
@@ -447,7 +432,7 @@ typeof = "types.anyValue"
 
 [types.kubernetes]
 type = "collection"
-typeof = "types.anyValue"
+typeof = "any"
 
     [types.kubernetes.host]
     type = "string"
@@ -661,7 +646,7 @@ itemtype = "types.machineAutoscaling"
 
 [types.runnerMachine]
 type = "collection"
-typeof = "types.anyValue"
+typeof = "any"
 
     [types.runnerMachine.MaxGrowthRate]
     type = "integer"
@@ -728,7 +713,7 @@ typeof = "types.anyValue"
 
 [types.autoscalerConnectorConfig]
 type = "collection"
-typeof = "types.anyValue"
+typeof = "any"
 
     [types.autoscalerConnectorConfig.username]
     type = "string"
@@ -822,7 +807,7 @@ itemtype = "types.autoscalerPolicy"
 
 [types.vmIsolation]
 type = "collection"
-typeof = "types.anyValue"
+typeof = "any"
 
     [types.vmIsolation.enabled]
     type = "boolean"
@@ -846,7 +831,7 @@ typeof = "types.anyValue"
 
 [types.autoscaler]
 type = "collection"
-typeof = "types.anyValue"
+typeof = "any"
 
     [types.autoscaler.capacity_per_instance]
     type = "integer"
@@ -1097,7 +1082,7 @@ type = "table"
 
 [types.runner]
 type = "collection"
-typeof = "types.anyValue"
+typeof = "any"
 
     [types.runner.name]
     type = "string"

--- a/examples/hugo.tosd
+++ b/examples/hugo.tosd
@@ -3,21 +3,6 @@
 [toml-schema]
 version = "1.0.0"
 
-[types.anyValue]
-type = "any"
-
-[types.booleanValue]
-type = "boolean"
-
-[types.integerValue]
-type = "integer"
-
-[types.floatValue]
-type = "float"
-
-[types.stringValue]
-type = "string"
-
 [types.stringArray]
 type = "array"
 arraytype = "string"
@@ -27,18 +12,18 @@ type = "array"
 arraytype = "any"
 
 [types.numberValue]
-oneof = [ "types.integerValue", "types.floatValue" ]
+oneof = [ "integer", "float" ]
 
 [types.stringOrStringArray]
-oneof = [ "types.stringValue", "types.stringArray" ]
+oneof = [ "string", "types.stringArray" ]
 
 [types.anyMap]
 type = "collection"
-typeof = "types.anyValue"
+typeof = "any"
 
 [types.stringMap]
 type = "collection"
-typeof = "types.stringValue"
+typeof = "string"
 
 [types.buildStats]
 type = "table"
@@ -517,7 +502,7 @@ type = "table"
 
 [types.highlight]
 type = "collection"
-typeof = "types.anyValue"
+typeof = "any"
 
     [types.highlight.anchorLineNos]
     type = "boolean"
@@ -670,7 +655,7 @@ type = "table"
 
 [types.moduleImport]
 type = "collection"
-typeof = "types.anyValue"
+typeof = "any"
 
     [types.moduleImport.path]
     type = "string"
@@ -696,7 +681,7 @@ typeof = "types.anyValue"
 
 [types.moduleMount]
 type = "collection"
-typeof = "types.anyValue"
+typeof = "any"
 
     [types.moduleMount.source]
     type = "string"
@@ -777,7 +762,7 @@ type = "table"
 
 [types.permalinks]
 type = "collection"
-typeof = "types.anyValue"
+typeof = "any"
 
 [types.privacyDisqus]
 type = "table"
@@ -897,11 +882,11 @@ type = "table"
 
 [types.server]
 type = "collection"
-typeof = "types.anyValue"
+typeof = "any"
 
 [types.services]
 type = "collection"
-typeof = "types.anyValue"
+typeof = "any"
 
 [types.sitemap]
 type = "table"
@@ -925,11 +910,11 @@ type = "table"
 
 [types.taxonomies]
 type = "collection"
-typeof = "types.stringValue"
+typeof = "string"
 
 [types.language]
 type = "collection"
-typeof = "types.anyValue"
+typeof = "any"
 
     [types.language.baseURL]
     type = "string"

--- a/examples/netlify.tosd
+++ b/examples/netlify.tosd
@@ -3,29 +3,20 @@
 [toml-schema]
 version = "1.0.0"
 
-[types.anyValue]
-type = "any"
-
-[types.stringValue]
-type = "string"
-
-[types.booleanValue]
-type = "boolean"
-
 [types.stringArray]
 type = "array"
 arraytype = "string"
 
 [types.stringMap]
 type = "collection"
-typeof = "types.stringValue"
+typeof = "string"
 
 [types.anyMap]
 type = "collection"
-typeof = "types.anyValue"
+typeof = "any"
 
 [types.stringOrStringArray]
-oneof = [ "types.stringValue", "types.stringArray" ]
+oneof = [ "string", "types.stringArray" ]
 
 [types.httpMethod]
 type = "string"
@@ -166,7 +157,7 @@ type = "collection"
 typeof = "types.context"
 
 [types.redirectCondition]
-oneof = [ "types.stringValue", "types.stringArray" ]
+oneof = [ "string", "types.stringArray" ]
 
 [types.redirectConditions]
 type = "collection"
@@ -278,7 +269,7 @@ typeof = "types.functionConfig"
     optional = true
 
 [types.edgeHeaderCondition]
-oneof = [ "types.stringValue", "types.booleanValue" ]
+oneof = [ "string", "boolean" ]
 
 [types.edgeHeaderConditions]
 type = "collection"

--- a/examples/wrangler.tosd
+++ b/examples/wrangler.tosd
@@ -3,23 +3,8 @@
 [toml-schema]
 version = "1.0.0"
 
-[types.anyValue]
-type = "any"
-
-[types.booleanValue]
-type = "boolean"
-
-[types.integerValue]
-type = "integer"
-
-[types.floatValue]
-type = "float"
-
-[types.stringValue]
-type = "string"
-
 [types.numberValue]
-oneof = [ "types.integerValue", "types.floatValue" ]
+oneof = [ "integer", "float" ]
 
 [types.stringArray]
 type = "array"
@@ -32,17 +17,17 @@ itemtype = "types.numberValue"
 
 [types.stringMap]
 type = "collection"
-typeof = "types.stringValue"
+typeof = "string"
 
 [types.anyMap]
 type = "collection"
-typeof = "types.anyValue"
+typeof = "any"
 
 [types.stringOrStringArray]
-oneof = [ "types.stringValue", "types.stringArray" ]
+oneof = [ "string", "types.stringArray" ]
 
 [types.booleanOrStringArray]
-oneof = [ "types.booleanValue", "types.stringArray" ]
+oneof = [ "boolean", "types.stringArray" ]
 
 [types.numberOrNumberArray]
 oneof = [ "types.numberValue", "types.numberArray" ]
@@ -74,7 +59,7 @@ type = "table"
     optional = true
 
 [types.route]
-oneof = [ "types.stringValue", "types.routeTable" ]
+oneof = [ "string", "types.routeTable" ]
 
 [types.routes]
 type = "array"
@@ -751,7 +736,7 @@ itemtype = "types.secretsStoreSecret"
 
 [types.workerSettings]
 type = "collection"
-typeof = "types.anyValue"
+typeof = "any"
 
     [types.workerSettings.account_id]
     type = "string"

--- a/reference-implementations/go/abnf_conformance_test.go
+++ b/reference-implementations/go/abnf_conformance_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+)
+
+var tokenCommentPattern = regexp.MustCompile(`;\s*"([^"]+)"`)
+
+func TestSchemaLoaderDefinitionKeysMatchAbnfSchemaKeys(t *testing.T) {
+	abnf := readAbnf(t)
+	expected := alternativesFor("schema-key", abnf)
+	actual := mapKeys(definitionKeys)
+
+	assertSameStrings(t, actual, expected)
+}
+
+func TestSchemaTypesMatchAbnfBuiltInTypes(t *testing.T) {
+	abnf := readAbnf(t)
+	implementationTypes := []string{
+		string(TypeAny),
+		string(TypeString),
+		string(TypeInteger),
+		string(TypeFloat),
+		string(TypeBoolean),
+		string(TypeOffsetDateTime),
+		string(TypeLocalDateTime),
+		string(TypeLocalDate),
+		string(TypeLocalTime),
+		string(TypeArray),
+		string(TypeTable),
+		string(TypeCollection),
+	}
+
+	assertSameStrings(t, implementationTypes, builtInTypeTokens(abnf))
+}
+
+func readAbnf(t *testing.T) string {
+	t.Helper()
+	content, err := os.ReadFile(abnfPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(content)
+}
+
+func abnfPath() string {
+	if _, err := os.Stat("toml-schema.abnf"); err == nil {
+		return "toml-schema.abnf"
+	}
+	return filepath.Join("..", "..", "toml-schema.abnf")
+}
+
+func alternativesFor(ruleName, abnf string) []string {
+	expression := ruleExpression(ruleName, abnf)
+	tokens := []string{}
+	for _, token := range strings.Split(expression, "/") {
+		token = strings.TrimSpace(token)
+		if token == "" || token == "version" {
+			continue
+		}
+		tokens = append(tokens, token)
+	}
+	return tokens
+}
+
+func ruleExpression(ruleName, abnf string) string {
+	var expression strings.Builder
+	inRule := false
+	for _, line := range strings.Split(abnf, "\n") {
+		if strings.HasPrefix(line, ruleName+" =") {
+			_, value, _ := strings.Cut(line, "=")
+			expression.WriteString(strings.TrimSpace(value))
+			inRule = true
+			continue
+		}
+		if inRule {
+			if strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t") {
+				expression.WriteString(" ")
+				expression.WriteString(strings.TrimSpace(line))
+				continue
+			}
+			break
+		}
+	}
+	return expression.String()
+}
+
+func builtInTypeTokens(abnf string) []string {
+	tokens := []string{}
+	for _, line := range strings.Split(abnf, "\n") {
+		matches := tokenCommentPattern.FindStringSubmatch(line)
+		if len(matches) != 2 {
+			continue
+		}
+		token := matches[1]
+		if definitionKeys[token] {
+			continue
+		}
+		tokens = append(tokens, token)
+	}
+	return tokens
+}
+
+func mapKeys(values map[string]bool) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+func assertSameStrings(t *testing.T, actual, expected []string) {
+	t.Helper()
+	slices.Sort(actual)
+	slices.Sort(expected)
+	if !slices.Equal(actual, expected) {
+		t.Fatalf("got %v, want %v", actual, expected)
+	}
+}

--- a/reference-implementations/go/schema.go
+++ b/reference-implementations/go/schema.go
@@ -31,7 +31,7 @@ const (
 )
 
 var definitionKeys = map[string]bool{
-	"type": true, "typeof": true, "typeref": true, "arraytype": true, "itemtype": true, "items": true,
+	"type": true, "typeof": true, "arraytype": true, "itemtype": true, "items": true,
 	"allowedvalues": true, "pattern": true, "optional": true, "default": true, "min": true,
 	"max": true, "minlength": true, "maxlength": true, "minoccurs": true, "maxoccurs": true,
 	"oneof": true, "anyof": true, "children": true,
@@ -249,13 +249,6 @@ func parseDefinition(name string, table map[string]any) (Definition, error) {
 	if err != nil {
 		return Definition{}, err
 	}
-	legacyReference, err := getString(table, "typeref")
-	if err != nil {
-		return Definition{}, err
-	}
-	if reference != "" && legacyReference != "" && reference != legacyReference {
-		return Definition{}, fmt.Errorf("%s cannot define both typeof and typeref with different values", name)
-	}
 	arrayType, err := getSchemaType(table, "arraytype")
 	if err != nil {
 		return Definition{}, err
@@ -348,8 +341,8 @@ func parseDefinition(name string, table map[string]any) (Definition, error) {
 			return Definition{}, fmt.Errorf("%s contains unsupported property: %s", name, key)
 		}
 	}
-	if typeName == "" && reference == "" && legacyReference == "" && len(oneOf) == 0 && len(anyOf) == 0 {
-		return Definition{}, fmt.Errorf("%s must define type, typeof, typeref, oneof, or anyof", name)
+	if typeName == "" && reference == "" && len(oneOf) == 0 && len(anyOf) == 0 {
+		return Definition{}, fmt.Errorf("%s must define type, typeof, oneof, or anyof", name)
 	}
 	if typeName != TypeArray && arrayType != "" {
 		return Definition{}, fmt.Errorf("%s can only define arraytype when type is array", name)
@@ -375,7 +368,7 @@ func parseDefinition(name string, table map[string]any) (Definition, error) {
 		return Definition{}, err
 	}
 	return Definition{
-		name: name, typeName: typeName, reference: normalizeReference(firstNonEmpty(reference, legacyReference)),
+		name: name, typeName: typeName, reference: normalizeReference(reference),
 		arrayType: arrayType, itemReference: normalizeReference(itemReference), optional: optional,
 		items:         normalizeReferences(items),
 		allowedValues: allowedValues, pattern: pattern, min: table["min"], max: table["max"],
@@ -976,8 +969,7 @@ func matchesEntireString(pattern *regexp.Regexp, value string) bool {
 func hasDefinitionMarker(table map[string]any) bool {
 	_, hasType := table["type"]
 	_, hasTypeOf := table["typeof"]
-	_, hasTypeRef := table["typeref"]
-	return hasType || hasTypeOf || hasTypeRef
+	return hasType || hasTypeOf
 }
 
 func asMap(value any) (map[string]any, bool) {

--- a/reference-implementations/go/schema.go
+++ b/reference-implementations/go/schema.go
@@ -33,7 +33,7 @@ const (
 var definitionKeys = map[string]bool{
 	"type": true, "typeof": true, "arraytype": true, "itemtype": true, "items": true,
 	"allowedvalues": true, "pattern": true, "optional": true, "default": true, "min": true,
-	"max": true, "minlength": true, "maxlength": true, "minoccurs": true, "maxoccurs": true,
+	"max": true, "minlength": true, "maxlength": true,
 	"oneof": true, "anyof": true, "children": true,
 }
 
@@ -277,20 +277,6 @@ func parseDefinition(name string, table map[string]any) (Definition, error) {
 	if err != nil {
 		return Definition{}, err
 	}
-	minOccurs, err := getIntegerPointer(table, "minoccurs")
-	if err != nil {
-		return Definition{}, err
-	}
-	maxOccurs, err := getIntegerPointer(table, "maxoccurs")
-	if err != nil {
-		return Definition{}, err
-	}
-	if minLength == nil {
-		minLength = minOccurs
-	}
-	if maxLength == nil {
-		maxLength = maxOccurs
-	}
 	allowedValues, err := getArrayValues(table, "allowedvalues")
 	if err != nil {
 		return Definition{}, err
@@ -360,8 +346,8 @@ func parseDefinition(name string, table map[string]any) (Definition, error) {
 		if itemReference != "" {
 			return Definition{}, fmt.Errorf("%s cannot define both items and itemtype", name)
 		}
-		if minLength != nil || maxLength != nil || minOccurs != nil || maxOccurs != nil {
-			return Definition{}, fmt.Errorf("%s cannot define minlength, maxlength, minoccurs, or maxoccurs together with items", name)
+		if minLength != nil || maxLength != nil {
+			return Definition{}, fmt.Errorf("%s cannot define minlength or maxlength together with items", name)
 		}
 	}
 	if err := validateRangeConstraints(name, typeName, arrayType, normalizeReference(itemReference), table["min"], table["max"]); err != nil {

--- a/reference-implementations/go/schema.go
+++ b/reference-implementations/go/schema.go
@@ -41,6 +41,37 @@ const currentTomlSchemaVersion = "1.0.0"
 
 var semverPattern = regexp.MustCompile(`^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-((?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$`)
 
+func parseSchemaType(value string) (SchemaType, bool) {
+	switch value {
+	case "any":
+		return TypeAny, true
+	case "string":
+		return TypeString, true
+	case "integer":
+		return TypeInteger, true
+	case "float":
+		return TypeFloat, true
+	case "boolean":
+		return TypeBoolean, true
+	case "offset-date-time":
+		return TypeOffsetDateTime, true
+	case "local-date-time":
+		return TypeLocalDateTime, true
+	case "local-date":
+		return TypeLocalDate, true
+	case "local-time":
+		return TypeLocalTime, true
+	case "array":
+		return TypeArray, true
+	case "table":
+		return TypeTable, true
+	case "collection", "table-collection":
+		return TypeCollection, true
+	default:
+		return "", false
+	}
+}
+
 type Schema struct {
 	source   string
 	types    map[string]Definition
@@ -177,6 +208,11 @@ func parseDefinitions(prefix string, table map[string]any, required bool) (map[s
 	}
 	definitions := map[string]Definition{}
 	for key, value := range table {
+		if prefix == "types" {
+			if _, ok := parseSchemaType(key); ok {
+				return nil, fmt.Errorf("[types.%s] uses a reserved built-in type name", key)
+			}
+		}
 		valueMap, ok := asMap(value)
 		if key == "children" && ok && !hasDefinitionMarker(valueMap) {
 			for childKey, childValue := range valueMap {
@@ -341,7 +377,7 @@ func parseDefinition(name string, table map[string]any) (Definition, error) {
 	return Definition{
 		name: name, typeName: typeName, reference: normalizeReference(firstNonEmpty(reference, legacyReference)),
 		arrayType: arrayType, itemReference: normalizeReference(itemReference), optional: optional,
-		items: normalizeReferences(items),
+		items:         normalizeReferences(items),
 		allowedValues: allowedValues, pattern: pattern, min: table["min"], max: table["max"],
 		minLength: minLength, maxLength: maxLength, oneOf: normalizeReferences(oneOf), anyOf: normalizeReferences(anyOf),
 		children: children,
@@ -669,6 +705,9 @@ func (v *validator) resolve(definition Definition, seenReferences map[string]boo
 
 func (v *validator) resolveReference(reference string, seenReferences map[string]bool) (Definition, error) {
 	normalized := normalizeReference(reference)
+	if builtInType, ok := parseSchemaType(normalized); ok {
+		return Definition{name: normalized, typeName: builtInType}, nil
+	}
 	if seenReferences[normalized] {
 		return Definition{}, fmt.Errorf("cyclic type reference: %s", normalized)
 	}
@@ -711,34 +750,10 @@ func getSchemaType(table map[string]any, key string) (SchemaType, error) {
 	if err != nil || value == "" {
 		return "", err
 	}
-	switch value {
-	case "any":
-		return TypeAny, nil
-	case "string":
-		return TypeString, nil
-	case "integer":
-		return TypeInteger, nil
-	case "float":
-		return TypeFloat, nil
-	case "boolean":
-		return TypeBoolean, nil
-	case "offset-date-time":
-		return TypeOffsetDateTime, nil
-	case "local-date-time":
-		return TypeLocalDateTime, nil
-	case "local-date":
-		return TypeLocalDate, nil
-	case "local-time":
-		return TypeLocalTime, nil
-	case "array":
-		return TypeArray, nil
-	case "table":
-		return TypeTable, nil
-	case "collection", "table-collection":
-		return TypeCollection, nil
-	default:
-		return "", fmt.Errorf("unsupported schema type: %s", value)
+	if schemaType, ok := parseSchemaType(value); ok {
+		return schemaType, nil
 	}
+	return "", fmt.Errorf("unsupported schema type: %s", value)
 }
 
 func getString(table map[string]any, key string) (string, error) {

--- a/reference-implementations/go/schema.go
+++ b/reference-implementations/go/schema.go
@@ -65,7 +65,7 @@ func parseSchemaType(value string) (SchemaType, bool) {
 		return TypeArray, true
 	case "table":
 		return TypeTable, true
-	case "collection", "table-collection":
+	case "collection":
 		return TypeCollection, true
 	default:
 		return "", false

--- a/reference-implementations/go/schema_test.go
+++ b/reference-implementations/go/schema_test.go
@@ -253,6 +253,25 @@ typeof = "types.item"
 	}
 }
 
+func TestRejectsOccurrenceAliases(t *testing.T) {
+	dir := t.TempDir()
+	aliases := []string{"minoccurs", "maxoccurs"}
+	for _, alias := range aliases {
+		schemaPath := write(t, dir, alias+".tosd", fmt.Sprintf(`
+[toml-schema]
+version = "1.0.0"
+
+[elements.values]
+type = "array"
+arraytype = "string"
+%s = 1
+`, alias))
+		if _, err := LoadSchema(schemaPath); err == nil {
+			t.Fatalf("expected %s alias to be rejected", alias)
+		}
+	}
+}
+
 func TestValidatesTupleArraysByPosition(t *testing.T) {
 	dir := t.TempDir()
 	schemaPath := write(t, dir, "schema.tosd", `

--- a/reference-implementations/go/schema_test.go
+++ b/reference-implementations/go/schema_test.go
@@ -171,6 +171,66 @@ entries = [
 	}
 }
 
+func TestSupportsBuiltInTypeReferences(t *testing.T) {
+	dir := t.TempDir()
+	schemaPath := write(t, dir, "schema.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[elements.name]
+typeof = "string"
+
+[elements.flags]
+type = "array"
+itemtype = "boolean"
+
+[elements.tuple]
+type = "array"
+items = [ "string", "integer" ]
+
+[elements.identity]
+oneof = [ "string", "integer" ]
+
+[elements.flex]
+anyof = [ "string", "integer" ]
+`)
+	documentPath := write(t, dir, "document.toml", `
+name = "Alice"
+flags = [ true, false ]
+tuple = [ "port", 8080 ]
+identity = 42
+flex = "abc"
+`)
+
+	schema, err := LoadSchema(schemaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := schema.ValidateFile(documentPath)
+
+	if !result.Valid() {
+		t.Fatalf("expected valid document, got %#v", result.Errors)
+	}
+}
+
+func TestRejectsTypesNamedAfterBuiltIns(t *testing.T) {
+	dir := t.TempDir()
+	schemaPath := write(t, dir, "schema.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[types.string]
+type = "integer"
+
+[elements.value]
+type = "string"
+`)
+
+	if _, err := LoadSchema(schemaPath); err == nil {
+		t.Fatal("expected reserved built-in type name to be rejected")
+	}
+}
+
 func TestValidatesTupleArraysByPosition(t *testing.T) {
 	dir := t.TempDir()
 	schemaPath := write(t, dir, "schema.tosd", `

--- a/reference-implementations/go/schema_test.go
+++ b/reference-implementations/go/schema_test.go
@@ -231,6 +231,28 @@ type = "string"
 	}
 }
 
+func TestRejectsTableCollectionAlias(t *testing.T) {
+	dir := t.TempDir()
+	schemaPath := write(t, dir, "schema.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[types.item]
+type = "table"
+
+    [types.item.name]
+    type = "string"
+
+[elements.items]
+type = "table-collection"
+typeof = "types.item"
+`)
+
+	if _, err := LoadSchema(schemaPath); err == nil {
+		t.Fatal("expected table-collection alias to be rejected")
+	}
+}
+
 func TestValidatesTupleArraysByPosition(t *testing.T) {
 	dir := t.TempDir()
 	schemaPath := write(t, dir, "schema.tosd", `

--- a/reference-implementations/java/src/main/java/io/github/brunoborges/tomlschema/SchemaLoader.java
+++ b/reference-implementations/java/src/main/java/io/github/brunoborges/tomlschema/SchemaLoader.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 final class SchemaLoader {
     static final Set<String> TOP_LEVEL_KEYS = Set.of("toml-schema", "types", "elements");
     static final Set<String> DEFINITION_KEYS = Set.of(
-            "type", "typeof", "typeref", "arraytype", "itemtype", "items", "allowedvalues", "pattern",
+            "type", "typeof", "arraytype", "itemtype", "items", "allowedvalues", "pattern",
             "optional", "default", "min", "max", "minlength", "maxlength", "minoccurs", "maxoccurs",
             "oneof", "anyof", "children"
     );
@@ -99,11 +99,7 @@ final class SchemaLoader {
     private SchemaDefinition parseDefinition(String name, TomlTable table) {
         SchemaType type = getSchemaType(table, "type");
         String reference = getString(table, "typeof");
-        String legacyReference = getString(table, "typeref");
-        if (reference != null && legacyReference != null && !reference.equals(legacyReference)) {
-            throw new SchemaException(name + " cannot define both typeof and typeref with different values");
-        }
-        String normalizedReference = normalizeReference(reference != null ? reference : legacyReference);
+        String normalizedReference = normalizeReference(reference);
         SchemaType arrayType = getSchemaType(table, "arraytype");
         String itemReference = normalizeReference(getString(table, "itemtype"));
         List<String> items = getStringArrayValues(table, "items").stream().map(this::normalizeReference).toList();
@@ -155,7 +151,7 @@ final class SchemaLoader {
             }
         }
         if (type == null && normalizedReference == null && oneOf.isEmpty() && anyOf.isEmpty()) {
-            throw new SchemaException(name + " must define type, typeof, typeref, oneof, or anyof");
+            throw new SchemaException(name + " must define type, typeof, oneof, or anyof");
         }
         if (type != SchemaType.ARRAY && arrayType != null) {
             throw new SchemaException(name + " can only define arraytype when type is array");
@@ -205,8 +201,7 @@ final class SchemaLoader {
 
     private boolean hasDefinitionMarker(TomlTable table) {
         return table.contains(List.of("type"))
-                || table.contains(List.of("typeof"))
-                || table.contains(List.of("typeref"));
+                || table.contains(List.of("typeof"));
     }
 
     private String getString(TomlTable table, String key) {

--- a/reference-implementations/java/src/main/java/io/github/brunoborges/tomlschema/SchemaLoader.java
+++ b/reference-implementations/java/src/main/java/io/github/brunoborges/tomlschema/SchemaLoader.java
@@ -21,7 +21,7 @@ final class SchemaLoader {
     static final Set<String> TOP_LEVEL_KEYS = Set.of("toml-schema", "types", "elements");
     static final Set<String> DEFINITION_KEYS = Set.of(
             "type", "typeof", "arraytype", "itemtype", "items", "allowedvalues", "pattern",
-            "optional", "default", "min", "max", "minlength", "maxlength", "minoccurs", "maxoccurs",
+            "optional", "default", "min", "max", "minlength", "maxlength",
             "oneof", "anyof", "children"
     );
 
@@ -107,14 +107,6 @@ final class SchemaLoader {
         Pattern pattern = getPattern(name, table);
         Integer minLength = getInteger(table, "minlength");
         Integer maxLength = getInteger(table, "maxlength");
-        Integer minOccurs = getInteger(table, "minoccurs");
-        Integer maxOccurs = getInteger(table, "maxoccurs");
-        if (minLength == null) {
-            minLength = minOccurs;
-        }
-        if (maxLength == null) {
-            maxLength = maxOccurs;
-        }
         List<Object> allowedValues = getArrayValues(table, "allowedvalues");
         List<String> oneOf = getStringArrayValues(table, "oneof");
         List<String> anyOf = getStringArrayValues(table, "anyof");
@@ -169,8 +161,8 @@ final class SchemaLoader {
             if (itemReference != null) {
                 throw new SchemaException(name + " cannot define both items and itemtype");
             }
-            if (minLength != null || maxLength != null || minOccurs != null || maxOccurs != null) {
-                throw new SchemaException(name + " cannot define minlength, maxlength, minoccurs, or maxoccurs together with items");
+            if (minLength != null || maxLength != null) {
+                throw new SchemaException(name + " cannot define minlength or maxlength together with items");
             }
         }
         validateRangeConstraints(name, type, arrayType, itemReference, table.get("min"), table.get("max"));

--- a/reference-implementations/java/src/main/java/io/github/brunoborges/tomlschema/SchemaLoader.java
+++ b/reference-implementations/java/src/main/java/io/github/brunoborges/tomlschema/SchemaLoader.java
@@ -74,6 +74,9 @@ final class SchemaLoader {
         }
         Map<String, SchemaDefinition> definitions = new LinkedHashMap<>();
         for (String key : table.keySet()) {
+            if (prefix.equals("types") && SchemaType.fromSchemaNameOptional(key).isPresent()) {
+                throw new SchemaException("[types." + key + "] uses a reserved built-in type name");
+            }
             Object value = table.get(List.of(key));
             if (key.equals("children") && value instanceof TomlTable childrenTable && !hasDefinitionMarker(childrenTable)) {
                 for (String childKey : childrenTable.keySet()) {

--- a/reference-implementations/java/src/main/java/io/github/brunoborges/tomlschema/SchemaType.java
+++ b/reference-implementations/java/src/main/java/io/github/brunoborges/tomlschema/SchemaType.java
@@ -44,7 +44,7 @@ enum SchemaType {
             case "local-time" -> Optional.of(LOCAL_TIME);
             case "array" -> Optional.of(ARRAY);
             case "table" -> Optional.of(TABLE);
-            case "collection", "table-collection" -> Optional.of(COLLECTION);
+            case "collection" -> Optional.of(COLLECTION);
             default -> Optional.empty();
         };
     }

--- a/reference-implementations/java/src/main/java/io/github/brunoborges/tomlschema/SchemaType.java
+++ b/reference-implementations/java/src/main/java/io/github/brunoborges/tomlschema/SchemaType.java
@@ -1,5 +1,7 @@
 package io.github.brunoborges.tomlschema;
 
+import java.util.Optional;
+
 enum SchemaType {
     ANY("any"),
     STRING("string"),
@@ -25,20 +27,25 @@ enum SchemaType {
     }
 
     static SchemaType fromSchemaName(String value) {
+        return fromSchemaNameOptional(value)
+                .orElseThrow(() -> new SchemaException("Unsupported schema type: " + value));
+    }
+
+    static Optional<SchemaType> fromSchemaNameOptional(String value) {
         return switch (value) {
-            case "any" -> ANY;
-            case "string" -> STRING;
-            case "integer" -> INTEGER;
-            case "float" -> FLOAT;
-            case "boolean" -> BOOLEAN;
-            case "offset-date-time" -> OFFSET_DATE_TIME;
-            case "local-date-time" -> LOCAL_DATE_TIME;
-            case "local-date" -> LOCAL_DATE;
-            case "local-time" -> LOCAL_TIME;
-            case "array" -> ARRAY;
-            case "table" -> TABLE;
-            case "collection", "table-collection" -> COLLECTION;
-            default -> throw new SchemaException("Unsupported schema type: " + value);
+            case "any" -> Optional.of(ANY);
+            case "string" -> Optional.of(STRING);
+            case "integer" -> Optional.of(INTEGER);
+            case "float" -> Optional.of(FLOAT);
+            case "boolean" -> Optional.of(BOOLEAN);
+            case "offset-date-time" -> Optional.of(OFFSET_DATE_TIME);
+            case "local-date-time" -> Optional.of(LOCAL_DATE_TIME);
+            case "local-date" -> Optional.of(LOCAL_DATE);
+            case "local-time" -> Optional.of(LOCAL_TIME);
+            case "array" -> Optional.of(ARRAY);
+            case "table" -> Optional.of(TABLE);
+            case "collection", "table-collection" -> Optional.of(COLLECTION);
+            default -> Optional.empty();
         };
     }
 }

--- a/reference-implementations/java/src/main/java/io/github/brunoborges/tomlschema/TomlSchemaValidator.java
+++ b/reference-implementations/java/src/main/java/io/github/brunoborges/tomlschema/TomlSchemaValidator.java
@@ -293,14 +293,44 @@ final class TomlSchemaValidator {
     }
 
     private SchemaDefinition resolveReference(String reference, Set<String> seenReferences) {
-        if (!seenReferences.add(reference)) {
-            throw new SchemaException("Cyclic schema reference involving types." + reference);
+        String normalizedReference = normalizeReference(reference);
+        SchemaType builtInType = SchemaType.fromSchemaNameOptional(normalizedReference).orElse(null);
+        if (builtInType != null) {
+            return builtInReference(normalizedReference, builtInType);
         }
-        SchemaDefinition referenced = schema.types().get(reference);
+        if (!seenReferences.add(normalizedReference)) {
+            throw new SchemaException("Cyclic schema reference involving types." + normalizedReference);
+        }
+        SchemaDefinition referenced = schema.types().get(normalizedReference);
         if (referenced == null) {
-            throw new SchemaException("Unknown schema type reference: types." + reference);
+            throw new SchemaException("Unknown schema type reference: types." + normalizedReference);
         }
         return resolve(referenced, seenReferences);
+    }
+
+    private SchemaDefinition builtInReference(String reference, SchemaType type) {
+        return new SchemaDefinition(
+                reference,
+                type,
+                null,
+                null,
+                null,
+                List.of(),
+                false,
+                List.of(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                List.of(),
+                List.of(),
+                Map.of()
+        );
+    }
+
+    private String normalizeReference(String reference) {
+        return reference.startsWith("types.") ? reference.substring("types.".length()) : reference;
     }
 
     private String typeName(Object value) {

--- a/reference-implementations/java/src/test/java/io/github/brunoborges/tomlschema/AbnfConformanceTest.java
+++ b/reference-implementations/java/src/test/java/io/github/brunoborges/tomlschema/AbnfConformanceTest.java
@@ -31,8 +31,6 @@ class AbnfConformanceTest {
         Set<String> implementationTypes = Arrays.stream(SchemaType.values())
                 .map(SchemaType::schemaName)
                 .collect(Collectors.toSet());
-        implementationTypes.add("table-collection");
-
         assertEquals(implementationTypes, builtInTypeTokens(abnf));
     }
 

--- a/reference-implementations/java/src/test/java/io/github/brunoborges/tomlschema/TomlSchemaTest.java
+++ b/reference-implementations/java/src/test/java/io/github/brunoborges/tomlschema/TomlSchemaTest.java
@@ -123,7 +123,7 @@ class TomlSchemaTest {
     }
 
     @Test
-    void supportsLegacyReferenceAndCollectionAliases() throws IOException {
+    void supportsLegacyCollectionAlias() throws IOException {
         Path schema = write("legacy.tosd", """
                 [toml-schema]
                 version = "1.0.0"
@@ -136,7 +136,7 @@ class TomlSchemaTest {
 
                 [elements.items]
                 type = "table-collection"
-                typeref = "types.item"
+                typeof = "types.item"
                 """);
         Path document = write("legacy.toml", """
                 [items.one]

--- a/reference-implementations/java/src/test/java/io/github/brunoborges/tomlschema/TomlSchemaTest.java
+++ b/reference-implementations/java/src/test/java/io/github/brunoborges/tomlschema/TomlSchemaTest.java
@@ -123,8 +123,8 @@ class TomlSchemaTest {
     }
 
     @Test
-    void supportsLegacyCollectionAlias() throws IOException {
-        Path schema = write("legacy.tosd", """
+    void rejectsTableCollectionAlias() throws IOException {
+        Path schema = write("table-collection-alias.tosd", """
                 [toml-schema]
                 version = "1.0.0"
 
@@ -138,14 +138,8 @@ class TomlSchemaTest {
                 type = "table-collection"
                 typeof = "types.item"
                 """);
-        Path document = write("legacy.toml", """
-                [items.one]
-                name = "alpha"
-                """);
 
-        ValidationResult result = TomlSchema.load(schema).validate(document);
-
-        assertTrue(result.isValid(), () -> result.errors().toString());
+        assertThrows(SchemaException.class, () -> TomlSchema.load(schema));
     }
 
     @Test

--- a/reference-implementations/java/src/test/java/io/github/brunoborges/tomlschema/TomlSchemaTest.java
+++ b/reference-implementations/java/src/test/java/io/github/brunoborges/tomlschema/TomlSchemaTest.java
@@ -417,6 +417,58 @@ class TomlSchemaTest {
     }
 
     @Test
+    void supportsBuiltInTypeReferences() throws IOException {
+        Path schema = write("built-in-references.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.name]
+                typeof = "string"
+
+                [elements.flags]
+                type = "array"
+                itemtype = "boolean"
+
+                [elements.tuple]
+                type = "array"
+                items = [ "string", "integer" ]
+
+                [elements.identity]
+                oneof = [ "string", "integer" ]
+
+                [elements.flex]
+                anyof = [ "string", "integer" ]
+                """);
+        Path document = write("built-in-references.toml", """
+                name = "Alice"
+                flags = [ true, false ]
+                tuple = [ "port", 8080 ]
+                identity = 42
+                flex = "abc"
+                """);
+
+        ValidationResult result = TomlSchema.load(schema).validate(document);
+
+        assertTrue(result.isValid(), () -> result.errors().toString());
+    }
+
+    @Test
+    void rejectsTypesNamedAfterBuiltIns() throws IOException {
+        Path schema = write("reserved-built-in.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [types.string]
+                type = "integer"
+
+                [elements.value]
+                type = "string"
+                """);
+
+        assertThrows(SchemaException.class, () -> TomlSchema.load(schema));
+    }
+
+    @Test
     void reportsUnionValidationFailures() throws IOException {
         Path schema = write("union-failure.tosd", """
                 [toml-schema]

--- a/reference-implementations/java/src/test/java/io/github/brunoborges/tomlschema/TomlSchemaTest.java
+++ b/reference-implementations/java/src/test/java/io/github/brunoborges/tomlschema/TomlSchemaTest.java
@@ -143,6 +143,31 @@ class TomlSchemaTest {
     }
 
     @Test
+    void rejectsOccurrenceAliases() throws IOException {
+        Path minOccurs = write("minoccurs-alias.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.values]
+                type = "array"
+                arraytype = "string"
+                minoccurs = 1
+                """);
+        Path maxOccurs = write("maxoccurs-alias.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.values]
+                type = "array"
+                arraytype = "string"
+                maxoccurs = 2
+                """);
+
+        assertThrows(SchemaException.class, () -> TomlSchema.load(minOccurs));
+        assertThrows(SchemaException.class, () -> TomlSchema.load(maxOccurs));
+    }
+
+    @Test
     void validatesArrayOfTablesWithItemSchema() throws IOException {
         Path schema = write("products.tosd", """
                 [toml-schema]

--- a/reference-implementations/rust/Cargo.tosd
+++ b/reference-implementations/rust/Cargo.tosd
@@ -3,15 +3,6 @@
 [toml-schema]
 version = "1.0.0"
 
-[types.stringValue]
-type = "string"
-
-[types.booleanValue]
-type = "boolean"
-
-[types.integerValue]
-type = "integer"
-
 [types.stringArray]
 type = "array"
 arraytype = "string"
@@ -23,22 +14,22 @@ type = "table"
     type = "boolean"
 
 [types.stringOrWorkspace]
-oneof = [ "types.stringValue", "types.workspaceInherited" ]
+oneof = [ "string", "types.workspaceInherited" ]
 
 [types.stringArrayOrWorkspace]
 oneof = [ "types.stringArray", "types.workspaceInherited" ]
 
 [types.booleanOrWorkspace]
-oneof = [ "types.booleanValue", "types.workspaceInherited" ]
+oneof = [ "boolean", "types.workspaceInherited" ]
 
 [types.stringOrBoolean]
-oneof = [ "types.stringValue", "types.booleanValue" ]
+oneof = [ "string", "boolean" ]
 
 [types.stringOrBooleanOrWorkspace]
-oneof = [ "types.stringValue", "types.booleanValue", "types.workspaceInherited" ]
+oneof = [ "string", "boolean", "types.workspaceInherited" ]
 
 [types.publish]
-oneof = [ "types.booleanValue", "types.stringArray", "types.workspaceInherited" ]
+oneof = [ "boolean", "types.stringArray", "types.workspaceInherited" ]
 
 [types.packageBase]
 type = "table"
@@ -211,7 +202,7 @@ type = "table"
     optional = true
 
 [types.dependency]
-oneof = [ "types.stringValue", "types.dependencyTable" ]
+oneof = [ "string", "types.dependencyTable" ]
 
 [types.dependencyTable]
 type = "table"
@@ -288,7 +279,7 @@ type = "table"
     optional = true
 
 [types.lintValue]
-oneof = [ "types.stringValue", "types.lintTable" ]
+oneof = [ "string", "types.lintTable" ]
 
 [types.lintTable]
 type = "table"
@@ -313,16 +304,16 @@ typeof = "types.lintGroup"
     optional = true
 
 [types.profileOptLevel]
-oneof = [ "types.integerValue", "types.stringValue" ]
+oneof = [ "integer", "string" ]
 
 [types.profileDebug]
-oneof = [ "types.booleanValue", "types.integerValue", "types.stringValue" ]
+oneof = [ "boolean", "integer", "string" ]
 
 [types.profileStrip]
-oneof = [ "types.booleanValue", "types.stringValue" ]
+oneof = [ "boolean", "string" ]
 
 [types.profileLto]
-oneof = [ "types.booleanValue", "types.stringValue" ]
+oneof = [ "boolean", "string" ]
 
 [types.profileSettings]
 type = "table"

--- a/reference-implementations/rust/src/schema.rs
+++ b/reference-implementations/rust/src/schema.rs
@@ -311,6 +311,9 @@ fn parse_definitions(
     };
     let mut definitions = BTreeMap::new();
     for (key, value) in table.iter() {
+        if prefix == "types" && SchemaType::parse(key).is_some() {
+            return Err(format!("[types.{key}] uses a reserved built-in type name"));
+        }
         let value_map = value.as_table();
         if key == "children"
             && value_map
@@ -901,6 +904,13 @@ impl<'schema> Validator<'schema> {
         seen: &mut HashSet<String>,
     ) -> Result<Definition, String> {
         let normalized = normalize_reference(reference.to_string());
+        if let Some(type_name) = SchemaType::parse(&normalized) {
+            return Ok(Definition {
+                name: normalized,
+                type_name: Some(type_name),
+                ..Definition::default()
+            });
+        }
         if !seen.insert(normalized.clone()) {
             return Err(format!("cyclic type reference: {normalized}"));
         }

--- a/reference-implementations/rust/src/schema.rs
+++ b/reference-implementations/rust/src/schema.rs
@@ -63,8 +63,7 @@ impl SchemaType {
             "local-time" => SchemaType::LocalTime,
             "array" => SchemaType::Array,
             "table" => SchemaType::Table,
-            // "table-collection" is an accepted legacy alias for "collection".
-            "collection" | "table-collection" => SchemaType::Collection,
+            "collection" => SchemaType::Collection,
             _ => return None,
         })
     }

--- a/reference-implementations/rust/src/schema.rs
+++ b/reference-implementations/rust/src/schema.rs
@@ -93,7 +93,6 @@ impl fmt::Display for SchemaType {
 pub const DEFINITION_KEYS: &[&str] = &[
     "type",
     "typeof",
-    "typeref",
     "arraytype",
     "itemtype",
     "items",
@@ -341,14 +340,6 @@ fn parse_definitions(
 fn parse_definition(name: &str, table: &Table) -> Result<Definition, String> {
     let type_name = get_schema_type(name, table, "type")?;
     let reference = get_string(name, table, "typeof")?;
-    let legacy_reference = get_string(name, table, "typeref")?;
-    if let (Some(reference), Some(legacy_reference)) = (&reference, &legacy_reference) {
-        if reference != legacy_reference {
-            return Err(format!(
-                "{name} cannot define both typeof and typeref with different values"
-            ));
-        }
-    }
     let array_type = get_schema_type(name, table, "arraytype")?;
     let item_reference = get_string(name, table, "itemtype")?;
     let items = get_string_array_values(name, table, "items")?;
@@ -393,14 +384,13 @@ fn parse_definition(name: &str, table: &Table) -> Result<Definition, String> {
             return Err(format!("{name} contains unsupported property: {key}"));
         }
     }
-    let has_typeref_or_typeof = reference.is_some() || legacy_reference.is_some();
     if type_name.is_none()
-        && !has_typeref_or_typeof
+        && reference.is_none()
         && one_of.is_empty()
         && any_of.is_empty()
     {
         return Err(format!(
-            "{name} must define type, typeof, typeref, oneof, or anyof"
+            "{name} must define type, typeof, oneof, or anyof"
         ));
     }
     if type_name != Some(SchemaType::Array) && array_type.is_some() {
@@ -445,7 +435,7 @@ fn parse_definition(name: &str, table: &Table) -> Result<Definition, String> {
         min.as_ref(),
         max.as_ref(),
     )?;
-    let reference = reference.or(legacy_reference).map(normalize_reference);
+    let reference = reference.map(normalize_reference);
     Ok(Definition {
         name: name.to_string(),
         type_name,
@@ -1143,7 +1133,6 @@ pub fn encode_path_key(key: &str) -> String {
 fn has_definition_marker(table: &Table) -> bool {
     table.contains_key("type")
         || table.contains_key("typeof")
-        || table.contains_key("typeref")
 }
 
 fn normalize_reference(reference: String) -> String {

--- a/reference-implementations/rust/src/schema.rs
+++ b/reference-implementations/rust/src/schema.rs
@@ -103,8 +103,6 @@ pub const DEFINITION_KEYS: &[&str] = &[
     "max",
     "minlength",
     "maxlength",
-    "minoccurs",
-    "maxoccurs",
     "oneof",
     "anyof",
     "children",
@@ -346,10 +344,6 @@ fn parse_definition(name: &str, table: &Table) -> Result<Definition, String> {
     let pattern = get_pattern(name, table)?;
     let min_length = get_unsigned_integer(name, table, "minlength")?;
     let max_length = get_unsigned_integer(name, table, "maxlength")?;
-    let min_occurs = get_unsigned_integer(name, table, "minoccurs")?;
-    let max_occurs = get_unsigned_integer(name, table, "maxoccurs")?;
-    let min_length = min_length.or(min_occurs);
-    let max_length = max_length.or(max_occurs);
     let allowed_values = get_array_values(name, table, "allowedvalues")?;
     let one_of = get_string_array_values(name, table, "oneof")?;
     let any_of = get_string_array_values(name, table, "anyof")?;
@@ -414,13 +408,9 @@ fn parse_definition(name: &str, table: &Table) -> Result<Definition, String> {
         if item_reference.is_some() {
             return Err(format!("{name} cannot define both items and itemtype"));
         }
-        if min_length.is_some()
-            || max_length.is_some()
-            || min_occurs.is_some()
-            || max_occurs.is_some()
-        {
+        if min_length.is_some() || max_length.is_some() {
             return Err(format!(
-                "{name} cannot define minlength, maxlength, minoccurs, or maxoccurs together with items"
+                "{name} cannot define minlength or maxlength together with items"
             ));
         }
     }

--- a/reference-implementations/rust/tests/abnf_conformance.rs
+++ b/reference-implementations/rust/tests/abnf_conformance.rs
@@ -81,7 +81,7 @@ fn schema_loader_definition_keys_match_abnf_schema_keys() {
 #[test]
 fn schema_types_match_abnf_built_in_types() {
     let abnf = read_abnf();
-    let mut implementation_types: BTreeSet<String> = [
+    let implementation_types: BTreeSet<String> = [
         SchemaType::Any,
         SchemaType::String,
         SchemaType::Integer,
@@ -98,8 +98,5 @@ fn schema_types_match_abnf_built_in_types() {
     .iter()
     .map(|schema_type| schema_type.schema_name().to_string())
     .collect();
-    // The collection type accepts "table-collection" as a legacy alias in the
-    // ABNF, matching the Java reference implementation's assertion.
-    implementation_types.insert("table-collection".to_string());
     assert_eq!(implementation_types, built_in_type_tokens(&abnf));
 }

--- a/reference-implementations/rust/tests/integration.rs
+++ b/reference-implementations/rust/tests/integration.rs
@@ -327,6 +327,32 @@ type = "string"
 }
 
 #[test]
+fn rejects_table_collection_alias() {
+    let directory = tempfile_dir("table-collection-alias");
+    let schema_path = write_file(
+        &directory,
+        "schema.tosd",
+        r#"
+[toml-schema]
+version = "1.0.0"
+
+[types.item]
+type = "table"
+
+    [types.item.name]
+    type = "string"
+
+[elements.items]
+type = "table-collection"
+typeof = "types.item"
+"#,
+    );
+
+    let error = Schema::load(&schema_path).expect_err("expected table-collection alias rejection");
+    assert!(error.contains("unsupported schema type"));
+}
+
+#[test]
 fn validates_tuple_arrays_by_position() {
     let directory = tempfile_dir("tuple-arrays");
     let schema_path = write_file(

--- a/reference-implementations/rust/tests/integration.rs
+++ b/reference-implementations/rust/tests/integration.rs
@@ -256,6 +256,77 @@ entries = [
 }
 
 #[test]
+fn supports_built_in_type_references() {
+    let directory = tempfile_dir("built-in-references");
+    let schema_path = write_file(
+        &directory,
+        "schema.tosd",
+        r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.name]
+typeof = "string"
+
+[elements.flags]
+type = "array"
+itemtype = "boolean"
+
+[elements.tuple]
+type = "array"
+items = [ "string", "integer" ]
+
+[elements.identity]
+oneof = [ "string", "integer" ]
+
+[elements.flex]
+anyof = [ "string", "integer" ]
+"#,
+    );
+    let document_path = write_file(
+        &directory,
+        "document.toml",
+        r#"
+name = "Alice"
+flags = [ true, false ]
+tuple = [ "port", 8080 ]
+identity = 42
+flex = "abc"
+"#,
+    );
+
+    let schema = Schema::load(&schema_path).expect("load schema");
+    let result = schema.validate_file(&document_path);
+    assert!(
+        result.valid(),
+        "expected valid document, got {:#?}",
+        result.errors
+    );
+}
+
+#[test]
+fn rejects_types_named_after_built_ins() {
+    let directory = tempfile_dir("reserved-built-in");
+    let schema_path = write_file(
+        &directory,
+        "schema.tosd",
+        r#"
+[toml-schema]
+version = "1.0.0"
+
+[types.string]
+type = "integer"
+
+[elements.value]
+type = "string"
+"#,
+    );
+
+    let error = Schema::load(&schema_path).expect_err("expected reserved built-in name");
+    assert!(error.contains("reserved built-in type name"));
+}
+
+#[test]
 fn validates_tuple_arrays_by_position() {
     let directory = tempfile_dir("tuple-arrays");
     let schema_path = write_file(

--- a/reference-implementations/rust/tests/integration.rs
+++ b/reference-implementations/rust/tests/integration.rs
@@ -353,6 +353,31 @@ typeof = "types.item"
 }
 
 #[test]
+fn rejects_occurrence_aliases() {
+    let directory = tempfile_dir("occurrence-aliases");
+    for alias in ["minoccurs", "maxoccurs"] {
+        let schema_path = write_file(
+            &directory,
+            &format!("{alias}.tosd"),
+            &format!(
+                r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.values]
+type = "array"
+arraytype = "string"
+{alias} = 1
+"#
+            ),
+        );
+
+        let error = Schema::load(&schema_path).expect_err("expected occurrence alias rejection");
+        assert!(error.contains("unsupported property"));
+    }
+}
+
+#[test]
 fn validates_tuple_arrays_by_position() {
     let directory = tempfile_dir("tuple-arrays");
     let schema_path = write_file(

--- a/toml-schema.abnf
+++ b/toml-schema.abnf
@@ -58,7 +58,7 @@ array-built-in-type = anytype / stringtype / integertype / floattype / booleanty
                     / arraytype-name / tabletype
 
 type-reference       = built-in-type / toml-string
-type-reference-array = toml-array ; each array value is a type-reference string
+type-reference-array = toml-array ; semantically intended to contain only type-reference values; element types are not constrained by this ABNF
 
 anytype             = DQUOTE %x61.6e.79 DQUOTE                                      ; "any"
 stringtype          = DQUOTE %x73.74.72.69.6e.67 DQUOTE                             ; "string"

--- a/toml-schema.abnf
+++ b/toml-schema.abnf
@@ -25,11 +25,11 @@ children-entry    = toml-key keyval-sep toml-inline-table
 
 schema-key = type / typeof / arraytype / itemtype / items / oneof / anyof
            / allowedvalues / pattern / optional / default / min / max
-           / minlength / maxlength / minoccurs / maxoccurs / children
+           / minlength / maxlength / children
 
 definition-property = type / typeof / arraytype / itemtype / items / oneof / anyof
                     / allowedvalues / pattern / optional / default / min / max
-                    / minlength / maxlength / minoccurs / maxoccurs
+                    / minlength / maxlength
 
 version       = "version" keyval-sep semver-string
 type          = "type" keyval-sep built-in-type
@@ -47,8 +47,6 @@ min           = "min" keyval-sep toml-value
 max           = "max" keyval-sep toml-value
 minlength     = "minlength" keyval-sep toml-integer ; strings count Unicode scalar values after TOML parsing
 maxlength     = "maxlength" keyval-sep toml-integer ; strings count Unicode scalar values after TOML parsing
-minoccurs     = "minoccurs" keyval-sep toml-integer    ; legacy alias for minlength
-maxoccurs     = "maxoccurs" keyval-sep toml-integer    ; legacy alias for maxlength
 children      = "children"
 
 built-in-type = anytype / stringtype / integertype / floattype / booleantype

--- a/toml-schema.abnf
+++ b/toml-schema.abnf
@@ -53,7 +53,7 @@ children      = "children"
 
 built-in-type = anytype / stringtype / integertype / floattype / booleantype
               / offsetdatetimetype / localdatetimetype / localdatetype / localtimetype
-              / arraytype-name / tabletype / collectiontype / tablecollectiontype
+              / arraytype-name / tabletype / collectiontype
 
 array-built-in-type = anytype / stringtype / integertype / floattype / booleantype
                     / offsetdatetimetype / localdatetimetype / localdatetype / localtimetype
@@ -74,7 +74,6 @@ localtimetype       = DQUOTE %x6c.6f.63.61.6c.2d.74.69.6d.65 DQUOTE             
 arraytype-name      = DQUOTE %x61.72.72.61.79 DQUOTE                                  ; "array"
 tabletype           = DQUOTE %x74.61.62.6c.65 DQUOTE                                  ; "table"
 collectiontype      = DQUOTE %x63.6f.6c.6c.65.63.74.69.6f.6e DQUOTE                   ; "collection"
-tablecollectiontype = DQUOTE %x74.61.62.6c.65.2d.63.6f.6c.6c.65.63.74.69.6f.6e DQUOTE ; "table-collection"
 
 ;; TOML 1.0 grammar terminals used by TOML Schema.
 

--- a/toml-schema.abnf
+++ b/toml-schema.abnf
@@ -33,13 +33,13 @@ definition-property = type / typeof / typeref / arraytype / itemtype / items / o
 
 version       = "version" keyval-sep semver-string
 type          = "type" keyval-sep built-in-type
-typeof        = "typeof" keyval-sep toml-string
-typeref       = "typeref" keyval-sep toml-string       ; legacy alias for typeof
+typeof        = "typeof" keyval-sep type-reference
+typeref       = "typeref" keyval-sep type-reference    ; legacy alias for typeof
 arraytype     = "arraytype" keyval-sep array-built-in-type
-itemtype      = "itemtype" keyval-sep toml-string
-items         = "items" keyval-sep toml-array         ; ordered type references for positional array validation
-oneof         = "oneof" keyval-sep toml-array
-anyof         = "anyof" keyval-sep toml-array
+itemtype      = "itemtype" keyval-sep type-reference
+items         = "items" keyval-sep type-reference-array ; ordered type references for positional array validation
+oneof         = "oneof" keyval-sep type-reference-array
+anyof         = "anyof" keyval-sep type-reference-array
 allowedvalues = "allowedvalues" keyval-sep toml-array
 pattern       = "pattern" keyval-sep toml-string
 optional      = "optional" keyval-sep toml-boolean
@@ -59,6 +59,9 @@ built-in-type = anytype / stringtype / integertype / floattype / booleantype
 array-built-in-type = anytype / stringtype / integertype / floattype / booleantype
                     / offsetdatetimetype / localdatetimetype / localdatetype / localtimetype
                     / arraytype-name / tabletype
+
+type-reference       = built-in-type / toml-string
+type-reference-array = toml-array ; each array value is a type-reference string
 
 anytype             = DQUOTE %x61.6e.79 DQUOTE                                      ; "any"
 stringtype          = DQUOTE %x73.74.72.69.6e.67 DQUOTE                             ; "string"

--- a/toml-schema.abnf
+++ b/toml-schema.abnf
@@ -23,18 +23,17 @@ schema-definition = schema-definition-table *definition-property [ children-tabl
 children-table    = schema-children-table *children-entry
 children-entry    = toml-key keyval-sep toml-inline-table
 
-schema-key = type / typeof / typeref / arraytype / itemtype / items / oneof / anyof
+schema-key = type / typeof / arraytype / itemtype / items / oneof / anyof
            / allowedvalues / pattern / optional / default / min / max
            / minlength / maxlength / minoccurs / maxoccurs / children
 
-definition-property = type / typeof / typeref / arraytype / itemtype / items / oneof / anyof
+definition-property = type / typeof / arraytype / itemtype / items / oneof / anyof
                     / allowedvalues / pattern / optional / default / min / max
                     / minlength / maxlength / minoccurs / maxoccurs
 
 version       = "version" keyval-sep semver-string
 type          = "type" keyval-sep built-in-type
 typeof        = "typeof" keyval-sep type-reference
-typeref       = "typeref" keyval-sep type-reference    ; legacy alias for typeof
 arraytype     = "arraytype" keyval-sep array-built-in-type
 itemtype      = "itemtype" keyval-sep type-reference
 items         = "items" keyval-sep type-reference-array ; ordered type references for positional array validation

--- a/toml-schema.tosd
+++ b/toml-schema.tosd
@@ -72,16 +72,6 @@ version = "1.0.0"
         min = 1
         # For strings, this counts Unicode scalar values after TOML parsing.
 
-        [types.schemaDef.children.minoccurs]
-        type = "integer"
-        optional = true
-        min = 0
-
-        [types.schemaDef.children.maxoccurs]
-        type = "integer"
-        optional = true
-        min = 1
-
         [types.schemaDef.children.oneof]
         type = "array"
         arraytype = "string"

--- a/toml-schema.tosd
+++ b/toml-schema.tosd
@@ -17,10 +17,12 @@ version = "1.0.0"
         [types.schemaDef.children.typeof]
         type = "string"
         optional = true
+        # Type reference: built-in type name or [types] definition name.
 
         [types.schemaDef.children.typeref]
         type = "string"
         optional = true
+        # Legacy alias for typeof.
 
         [types.schemaDef.children.arraytype]
         type = "string"
@@ -30,11 +32,13 @@ version = "1.0.0"
         [types.schemaDef.children.itemtype]
         type = "string"
         optional = true
+        # Type reference: built-in type name or [types] definition name.
 
         [types.schemaDef.children.items]
         type = "array"
         arraytype = "string"
         optional = true
+        # Each item is a type reference.
 
         [types.schemaDef.children.allowedvalues]
         type = "array"
@@ -87,11 +91,13 @@ version = "1.0.0"
         type = "array"
         arraytype = "string"
         optional = true
+        # Each item is a type reference.
 
         [types.schemaDef.children.anyof]
         type = "array"
         arraytype = "string"
         optional = true
+        # Each item is a type reference.
 
         [types.schemaDef.children.children]
         type = "collection"

--- a/toml-schema.tosd
+++ b/toml-schema.tosd
@@ -11,7 +11,7 @@ version = "1.0.0"
 
         [types.schemaDef.children.type]
         type = "string"
-        allowedvalues = [ "array", "table", "collection", "any", "string", "integer", "float", "boolean", "offset-date-time", "local-date-time", "local-date", "local-time", "table-collection" ]
+        allowedvalues = [ "array", "table", "collection", "any", "string", "integer", "float", "boolean", "offset-date-time", "local-date-time", "local-date", "local-time" ]
         optional = true
 
         [types.schemaDef.children.typeof]

--- a/toml-schema.tosd
+++ b/toml-schema.tosd
@@ -19,11 +19,6 @@ version = "1.0.0"
         optional = true
         # Type reference: built-in type name or [types] definition name.
 
-        [types.schemaDef.children.typeref]
-        type = "string"
-        optional = true
-        # Legacy alias for typeof.
-
         [types.schemaDef.children.arraytype]
         type = "string"
         allowedvalues = [ "any", "string", "integer", "float", "boolean", "offset-date-time", "local-date-time", "local-date", "local-time", "array", "table" ]


### PR DESCRIPTION
## Summary
- Allow built-in type names such as `string`, `boolean`, `integer`, and `any` as first-class type references in `typeof`, `itemtype`, `items`, `oneof`, and `anyof`.
- Reserve built-in type names under `[types]` so schemas like `[types.string]` are rejected instead of shadowing built-ins.
- Remove legacy schema aliases from the spec and Java/Go/Rust implementations: `typeref`, `table-collection`, `minoccurs`, and `maxoccurs`.
- Update the spec, ABNF, self-schema, website/docs, real-world examples, and reference implementation conformance coverage.
- Add a Go ABNF conformance test so Java, Go, and Rust all guard schema vocabulary against `toml-schema.abnf` drift.

## Validation
- `mvn -f reference-implementations/java/pom.xml test`
- `go -C reference-implementations/go test ./...`
- `cargo test --manifest-path reference-implementations/rust/Cargo.toml`

Refs #46
