### PR TITLE
Align package namespaces with tomlschema.org

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,9 +20,9 @@ This repository contains the TOML Schema specification/proposal plus reference i
 - `toml-schema.abnf` is the formal TOML Schema-layer grammar companion for schema vocabulary and document shape. Reference implementation tests include ABNF conformance guards to prevent vocabulary drift.
 - `toml-schema.tosd` is a TOML schema for schema documents themselves. It models allowed schema metadata, reusable type definitions, and top-level elements.
 - `config.tosd` and `config.toml` are the worked example pair: `config.toml` declares `[toml-schema] location = "config.tosd"`, and `config.tosd` describes the allowed document shape.
-- `reference-implementations/java/src/main/java/io/github/brunoborges/tomlschema` contains the Java reference implementation: schema loading/modeling, validation, result/error records, and `TomlSchemaCli`.
-- `reference-implementations/go` is an importable Go package, and its CLI entrypoint lives under `reference-implementations/go/cmd/toml-schema`.
-- `reference-implementations/java/src/test/java/io/github/brunoborges/tomlschema/TomlSchemaTest.java` covers the checked-in examples, self-schema validation, validation errors, and CLI schema-location lookup.
+- `reference-implementations/java/src/main/java/org/tomlschema` contains the Java reference implementation under the `org.tomlschema` package with Maven coordinate `org.tomlschema:toml-schema`.
+- `reference-implementations/go` is the `tomlschema.org/go` importable Go package, and its CLI entrypoint lives under `reference-implementations/go/cmd/toml-schema`.
+- `reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java` covers the checked-in examples, self-schema validation, validation errors, and CLI schema-location lookup.
 - Java, Go, and Rust ABNF conformance tests read `toml-schema.abnf` and check implementation schema properties and built-in type names against it.
 
 ## Key conventions

--- a/REFERENCE_IMPLEMENTATIONS.md
+++ b/REFERENCE_IMPLEMENTATIONS.md
@@ -6,9 +6,9 @@ This document tracks TOML Schema reference implementations and the expected vali
 
 | Language | Location | Status | Notes |
 | --- | --- | --- | --- |
-| Java | [`reference-implementations/java`](reference-implementations/java) | Active reference implementation | Java 25 library and CLI using Tomlj for TOML 1.0 parsing. |
-| Go | [`reference-implementations/go`](reference-implementations/go) | Active reference implementation | Go library and CLI using go-toml for TOML 1.0 parsing. |
-| Rust | [`reference-implementations/rust`](reference-implementations/rust) | Active reference implementation | Rust library and CLI using the `toml` crate for TOML 1.0 parsing. |
+| Java | [`reference-implementations/java`](reference-implementations/java) | Active reference implementation | Java 25 library and CLI using `org.tomlschema:toml-schema` and Tomlj for TOML 1.0 parsing. |
+| Go | [`reference-implementations/go`](reference-implementations/go) | Active reference implementation | Go module `tomlschema.org/go` using go-toml for TOML 1.0 parsing. |
+| Rust | [`reference-implementations/rust`](reference-implementations/rust) | Active reference implementation | Rust crate `toml-schema` with tomlschema.org package metadata, using the `toml` crate for TOML 1.0 parsing. |
 | Other languages | `reference-implementations/<language>` | Not started | Future implementations should follow the same conformance expectations below. |
 
 ## Java
@@ -66,6 +66,10 @@ java -jar reference-implementations/java/target/toml-schema-0.1.0-SNAPSHOT.jar e
 Use the library API:
 
 ```java
+import java.nio.file.Path;
+import org.tomlschema.TomlSchema;
+import org.tomlschema.ValidationResult;
+
 ValidationResult result = TomlSchema
     .load(Path.of("config.tosd"))
     .validate(Path.of("config.toml"));
@@ -118,7 +122,7 @@ Use the library API:
 ```go
 package main
 
-import tomlschema "github.com/brunoborges/toml-schema/reference-implementations/go"
+import tomlschema "tomlschema.org/go"
 
 func main() {
 	schema, err := tomlschema.LoadSchema("config.tosd")

--- a/docs/404.html
+++ b/docs/404.html
@@ -18,7 +18,7 @@
   <main>
     <h1>Page not found</h1>
     <p>The TOML Schema page you requested does not exist.</p>
-    <p><a href="/">Return to tomlschema.org</a></p>
+    <p><a href="/">Return to toml-schema.org</a></p>
   </main>
 </body>
 </html>

--- a/docs/404.html
+++ b/docs/404.html
@@ -18,7 +18,7 @@
   <main>
     <h1>Page not found</h1>
     <p>The TOML Schema page you requested does not exist.</p>
-    <p><a href="/">Return to toml-schema.org</a></p>
+    <p><a href="/">Return to tomlschema.org</a></p>
   </main>
 </body>
 </html>

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-toml-schema.org
+tomlschema.org

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-tomlschema.org
+toml-schema.org

--- a/docs/go/index.html
+++ b/docs/go/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="go-import" content="tomlschema.org/go git https://github.com/brunoborges/toml-schema reference-implementations/go">
+  <meta name="go-source" content="tomlschema.org/go https://github.com/brunoborges/toml-schema https://github.com/brunoborges/toml-schema/tree/main/reference-implementations/go{/dir} https://github.com/brunoborges/toml-schema/blob/main/reference-implementations/go{/dir}/{file}#L{line}">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="refresh" content="0; url=/">
+  <title>TOML Schema Go module</title>
+</head>
+<body>
+  <p><a href="/">TOML Schema Go module</a></p>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="TOML Schema is a TOML-native schema language for validating TOML configuration documents.">
-  <link rel="canonical" href="https://tomlschema.org/">
+  <link rel="canonical" href="https://toml-schema.org/">
   <title>TOML Schema</title>
   <script>
     (() => {

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="TOML Schema is a TOML-native schema language for validating TOML configuration documents.">
+  <link rel="canonical" href="https://tomlschema.org/">
   <title>TOML Schema</title>
   <script>
     (() => {

--- a/reference-implementations/go/cmd/toml-schema/main.go
+++ b/reference-implementations/go/cmd/toml-schema/main.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"os"
 
-	tomlschema "github.com/brunoborges/toml-schema/reference-implementations/go"
+	tomlschema "tomlschema.org/go"
 )
 
 func main() {

--- a/reference-implementations/go/go.mod
+++ b/reference-implementations/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/brunoborges/toml-schema/reference-implementations/go
+module tomlschema.org/go
 
 go 1.22
 

--- a/reference-implementations/java/pom.xml
+++ b/reference-implementations/java/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.github.brunoborges</groupId>
+    <groupId>org.tomlschema</groupId>
     <artifactId>toml-schema</artifactId>
     <version>0.1.0-SNAPSHOT</version>
     <name>TOML Schema</name>
@@ -52,7 +52,7 @@
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>io.github.brunoborges.tomlschema.TomlSchemaCli</mainClass>
+                                    <mainClass>org.tomlschema.TomlSchemaCli</mainClass>
                                 </transformer>
                             </transformers>
                         </configuration>

--- a/reference-implementations/java/src/main/java/org/tomlschema/SchemaDefinition.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/SchemaDefinition.java
@@ -1,4 +1,4 @@
-package io.github.brunoborges.tomlschema;
+package org.tomlschema;
 
 import java.util.List;
 import java.util.Map;

--- a/reference-implementations/java/src/main/java/org/tomlschema/SchemaException.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/SchemaException.java
@@ -1,4 +1,4 @@
-package io.github.brunoborges.tomlschema;
+package org.tomlschema;
 
 /**
  * Thrown when a TOML Schema document is malformed or cannot be loaded.

--- a/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
@@ -1,4 +1,4 @@
-package io.github.brunoborges.tomlschema;
+package org.tomlschema;
 
 import org.tomlj.Toml;
 import org.tomlj.TomlArray;

--- a/reference-implementations/java/src/main/java/org/tomlschema/SchemaType.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/SchemaType.java
@@ -1,4 +1,4 @@
-package io.github.brunoborges.tomlschema;
+package org.tomlschema;
 
 import java.util.Optional;
 

--- a/reference-implementations/java/src/main/java/org/tomlschema/TomlSchema.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/TomlSchema.java
@@ -1,4 +1,4 @@
-package io.github.brunoborges.tomlschema;
+package org.tomlschema;
 
 import org.tomlj.Toml;
 import org.tomlj.TomlParseError;

--- a/reference-implementations/java/src/main/java/org/tomlschema/TomlSchemaCli.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/TomlSchemaCli.java
@@ -1,4 +1,4 @@
-package io.github.brunoborges.tomlschema;
+package org.tomlschema;
 
 import org.tomlj.Toml;
 import org.tomlj.TomlArray;

--- a/reference-implementations/java/src/main/java/org/tomlschema/TomlSchemaValidator.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/TomlSchemaValidator.java
@@ -1,4 +1,4 @@
-package io.github.brunoborges.tomlschema;
+package org.tomlschema;
 
 import org.tomlj.TomlArray;
 import org.tomlj.TomlTable;

--- a/reference-implementations/java/src/main/java/org/tomlschema/TomlSchemaVersion.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/TomlSchemaVersion.java
@@ -1,4 +1,4 @@
-package io.github.brunoborges.tomlschema;
+package org.tomlschema;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/reference-implementations/java/src/main/java/org/tomlschema/ValidationError.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/ValidationError.java
@@ -1,4 +1,4 @@
-package io.github.brunoborges.tomlschema;
+package org.tomlschema;
 
 public record ValidationError(String path, String message) {
     @Override

--- a/reference-implementations/java/src/main/java/org/tomlschema/ValidationResult.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/ValidationResult.java
@@ -1,4 +1,4 @@
-package io.github.brunoborges.tomlschema;
+package org.tomlschema;
 
 import java.util.List;
 

--- a/reference-implementations/java/src/test/java/org/tomlschema/AbnfConformanceTest.java
+++ b/reference-implementations/java/src/test/java/org/tomlschema/AbnfConformanceTest.java
@@ -1,4 +1,4 @@
-package io.github.brunoborges.tomlschema;
+package org.tomlschema;
 
 import org.junit.jupiter.api.Test;
 

--- a/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
+++ b/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
@@ -1,4 +1,4 @@
-package io.github.brunoborges.tomlschema;
+package org.tomlschema;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;

--- a/reference-implementations/rust/Cargo.toml
+++ b/reference-implementations/rust/Cargo.toml
@@ -3,6 +3,8 @@ name = "toml-schema"
 version = "0.1.0"
 edition = "2021"
 description = "Reference implementation of TOML Schema for Rust"
+homepage = "https://tomlschema.org"
+repository = "https://github.com/brunoborges/toml-schema"
 license = "MIT"
 publish = false
 


### PR DESCRIPTION
## Summary
- Move the Java reference implementation from `io.github.brunoborges.tomlschema` to `org.tomlschema` and update the Maven coordinate to `org.tomlschema:toml-schema`.
- Change the Go module/import path to `tomlschema.org/go` and update the CLI import/docs accordingly.
- Add Go vanity import metadata under `/go/` so `tomlschema.org/go` can resolve to the Go module in `reference-implementations/go`.
- Add tomlschema.org package metadata to the Rust crate while keeping Rust-legal crate/module names (`toml-schema` / `toml_schema`).
- Keep the public website on `toml-schema.org`; `tomlschema.org` is only for source/package namespace identity.

## Validation
- `mvn -f reference-implementations/java/pom.xml test`
- `go -C reference-implementations/go test ./...`
- `cargo test --manifest-path reference-implementations/rust/Cargo.toml`
- `mvn -f reference-implementations/java/pom.xml package -DskipTests`
- `java -jar reference-implementations/java/target/toml-schema-0.1.0-SNAPSHOT.jar validate config.tosd config.toml`
