### PR TITLE
Clarify elements and range boundaries

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -139,7 +139,7 @@ A TOML Schema file has the following structure:
 
  - `[toml-schema]`: table with information and metadata of the schema.
    - **Required**
- - `[types]`: table with definition of types to be reused in elements`.
+ - `[types]`: table with definitions of types to be reused in elements.
    - _Optional_
  - `[elements]`: table with the overall structure of the TOML document, its tables, properties, and conditions.
    - **Required**
@@ -191,7 +191,33 @@ A parser that supports TOML Schema version `MAJOR.MINOR.PATCH` MUST accept schem
 
 ## Elements table - `[elements]`
 
-The `elements` table defines the overall structure and properties of the TOML document. Elements follow the same structure and rules of Types, specified below, except that elements cannot reference other elements. To reuse conditions and structures, `[types]` must be defined and referenced back from the `[elements]` table.
+The `[elements]` table is the root schema for the TOML document being validated. Schema authors use it to describe the application data that may appear at the top level of the TOML document.
+
+Each direct child of `[elements]` defines one top-level TOML key. Nested children define the structure below that key, such as fields inside a table or item definitions inside arrays and collections.
+
+For example, this schema:
+
+```toml
+[elements.title]
+type = "string"
+
+[elements.database]
+type = "table"
+
+    [elements.database.enabled]
+    type = "boolean"
+```
+
+validates a TOML document shaped like this:
+
+```toml
+title = "Example"
+
+[database]
+enabled = true
+```
+
+Use `[elements]` for document-specific keys. Use `[types]` for reusable definitions that can be referenced from `[elements]` or from other reusable types. Elements follow the same structure and validation rules as types, except that elements cannot reference other elements. To reuse conditions and structures, define them under `[types]` and reference them from `[elements]`.
 
 ## Types table - `[types]`
 
@@ -218,8 +244,8 @@ anyof = [ "<type-reference>", ... ]
 allowedvalues = [ <array-with-enumeration-of-allowed-values> ]
 pattern = "<string-regex-for-string-validation>"
 optional = true|false
-min = <any>
-max = <any>
+min = <integer | float | offset-date-time | local-date-time | local-date | local-time>
+max = <integer | float | offset-date-time | local-date-time | local-date | local-time>
 minlength = <integer>
 maxlength = <integer>
 ```
@@ -282,9 +308,11 @@ These properties define inclusive value ranges. They may only be used for:
  - `float`
  - `integer`
  - date and/or time types: `offset-date-time`, `local-date-time`, `local-date`, and `local-time`
- - `array`, when `arraytype` is one of the numeric or date/time types above
+ - `array`, when `arraytype` is one of `integer`, `float`, or the temporal types above
 
 For arrays, `min` and `max` apply to each array item. They cannot be combined with `itemtype`; put range constraints in the referenced item type instead.
+
+A `min` or `max` boundary must be a TOML value that is comparable with the schema type: `integer` or `float` boundaries for `integer` and `float` values, and matching temporal boundaries for temporal values.
 
 `nan`, `+nan`, and `-nan` are not valid `min` or `max` boundaries because NaN is unordered. `inf`, `+inf`, and `-inf` are valid float boundaries.
 

--- a/reference-implementations/go/schema.go
+++ b/reference-implementations/go/schema.go
@@ -371,6 +371,12 @@ func validateRangeConstraints(name string, typeName, arrayType SchemaType, itemR
 	if min == nil && max == nil {
 		return nil
 	}
+	if err := validateRangeBoundary(name, "min", min); err != nil {
+		return err
+	}
+	if err := validateRangeBoundary(name, "max", max); err != nil {
+		return err
+	}
 	if isNaN(min) {
 		return fmt.Errorf("%s cannot use NaN as min", name)
 	}
@@ -389,14 +395,73 @@ func validateRangeConstraints(name string, typeName, arrayType SchemaType, itemR
 			itemType = TypeAny
 		}
 		if !isRangeComparable(itemType) {
-			return fmt.Errorf("%s can only define min or max for arrays with numeric or date/time arraytype", name)
+			return fmt.Errorf("%s can only define min or max for arrays with integer, float, or temporal arraytype", name)
+		}
+		if err := validateBoundaryMatchesType(name, "min", min, itemType); err != nil {
+			return err
+		}
+		if err := validateBoundaryMatchesType(name, "max", max, itemType); err != nil {
+			return err
 		}
 		return nil
 	}
 	if typeName != "" && !isRangeComparable(typeName) {
 		return fmt.Errorf("%s can only define min or max for integer, float, date/time, or compatible array types", name)
 	}
+	if typeName != "" {
+		if err := validateBoundaryMatchesType(name, "min", min, typeName); err != nil {
+			return err
+		}
+		if err := validateBoundaryMatchesType(name, "max", max, typeName); err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+func validateRangeBoundary(name, key string, value any) error {
+	if value == nil || isRangeBoundary(value) {
+		return nil
+	}
+	return fmt.Errorf("%s %s must be an integer, float, or temporal value", name, key)
+}
+
+func isRangeBoundary(value any) bool {
+	switch value.(type) {
+	case int64, float64, time.Time, toml.LocalDateTime, toml.LocalDate, toml.LocalTime:
+		return true
+	default:
+		return false
+	}
+}
+
+func validateBoundaryMatchesType(name, key string, value any, typeName SchemaType) error {
+	if value == nil || boundaryMatchesType(value, typeName) {
+		return nil
+	}
+	return fmt.Errorf("%s %s must be comparable with %s", name, key, typeName)
+}
+
+func boundaryMatchesType(value any, typeName SchemaType) bool {
+	switch typeName {
+	case TypeInteger, TypeFloat:
+		_, ok := numeric(value)
+		return ok
+	case TypeOffsetDateTime:
+		_, ok := value.(time.Time)
+		return ok
+	case TypeLocalDateTime:
+		_, ok := value.(toml.LocalDateTime)
+		return ok
+	case TypeLocalDate:
+		_, ok := value.(toml.LocalDate)
+		return ok
+	case TypeLocalTime:
+		_, ok := value.(toml.LocalTime)
+		return ok
+	default:
+		return false
+	}
 }
 
 type validator struct {

--- a/reference-implementations/go/schema_test.go
+++ b/reference-implementations/go/schema_test.go
@@ -86,6 +86,52 @@ port = 70000
 	}
 }
 
+func TestRejectsMalformedBoundarySchemas(t *testing.T) {
+	dir := t.TempDir()
+	cases := map[string]string{
+		"any-min": `
+[toml-schema]
+version = "1.0.0"
+
+[elements.payload]
+type = "any"
+min = 1
+`,
+		"nan-min": `
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "float"
+min = nan
+`,
+		"string-min": `
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "integer"
+min = "1"
+`,
+		"date-time-min": `
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "local-date"
+min = 2026-01-01T00:00:00Z
+`,
+	}
+
+	for name, content := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := LoadSchema(write(t, dir, name+".tosd", content)); err == nil {
+				t.Fatal("expected malformed boundary schema to be rejected")
+			}
+		})
+	}
+}
+
 func TestPatternMustMatchEntireString(t *testing.T) {
 	dir := t.TempDir()
 	schemaPath := write(t, dir, "schema.tosd", `

--- a/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
@@ -8,6 +8,10 @@ import org.tomlj.TomlTable;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -275,6 +279,8 @@ final class SchemaLoader {
         if (min == null && max == null) {
             return;
         }
+        validateRangeBoundary(name, "min", min);
+        validateRangeBoundary(name, "max", max);
         rejectNaNBoundary(name, "min", min);
         rejectNaNBoundary(name, "max", max);
         if (type == SchemaType.ANY) {
@@ -286,13 +292,26 @@ final class SchemaLoader {
             }
             SchemaType itemType = arrayType == null ? SchemaType.ANY : arrayType;
             if (!isRangeComparable(itemType)) {
-                throw new SchemaException(name + " can only define min or max for arrays with numeric or date/time arraytype");
+                throw new SchemaException(name + " can only define min or max for arrays with integer, float, or temporal arraytype");
             }
+            validateBoundaryMatchesType(name, "min", min, itemType);
+            validateBoundaryMatchesType(name, "max", max, itemType);
             return;
         }
         if (type != null && !isRangeComparable(type)) {
             throw new SchemaException(name + " can only define min or max for integer, float, date/time, or compatible array types");
         }
+        if (type != null) {
+            validateBoundaryMatchesType(name, "min", min, type);
+            validateBoundaryMatchesType(name, "max", max, type);
+        }
+    }
+
+    private void validateRangeBoundary(String name, String key, Object value) {
+        if (value == null || isRangeBoundary(value)) {
+            return;
+        }
+        throw new SchemaException(name + " " + key + " must be an integer, float, or temporal value");
     }
 
     private void rejectNaNBoundary(String name, String key, Object value) {
@@ -301,9 +320,36 @@ final class SchemaLoader {
         }
     }
 
+    private boolean isRangeBoundary(Object value) {
+        return value instanceof Long
+                || value instanceof Double
+                || value instanceof OffsetDateTime
+                || value instanceof LocalDateTime
+                || value instanceof LocalDate
+                || value instanceof LocalTime;
+    }
+
     private boolean isRangeComparable(SchemaType type) {
         return switch (type) {
             case INTEGER, FLOAT, OFFSET_DATE_TIME, LOCAL_DATE_TIME, LOCAL_DATE, LOCAL_TIME -> true;
+            default -> false;
+        };
+    }
+
+    private void validateBoundaryMatchesType(String name, String key, Object value, SchemaType type) {
+        if (value == null || boundaryMatchesType(value, type)) {
+            return;
+        }
+        throw new SchemaException(name + " " + key + " must be comparable with " + type.schemaName());
+    }
+
+    private boolean boundaryMatchesType(Object value, SchemaType type) {
+        return switch (type) {
+            case INTEGER, FLOAT -> value instanceof Number;
+            case OFFSET_DATE_TIME -> value instanceof OffsetDateTime;
+            case LOCAL_DATE_TIME -> value instanceof LocalDateTime;
+            case LOCAL_DATE -> value instanceof LocalDate;
+            case LOCAL_TIME -> value instanceof LocalTime;
             default -> false;
         };
     }

--- a/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
+++ b/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
@@ -570,9 +570,27 @@ class TomlSchemaTest {
                 type = "float"
                 min = nan
                 """);
+        Path stringBoundarySchema = write("string-min.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.value]
+                type = "integer"
+                min = "1"
+                """);
+        Path mismatchedTemporalSchema = write("date-time-min.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.value]
+                type = "local-date"
+                min = 2026-01-01T00:00:00Z
+                """);
 
         assertThrows(SchemaException.class, () -> TomlSchema.load(anySchema));
         assertThrows(SchemaException.class, () -> TomlSchema.load(nanSchema));
+        assertThrows(SchemaException.class, () -> TomlSchema.load(stringBoundarySchema));
+        assertThrows(SchemaException.class, () -> TomlSchema.load(mismatchedTemporalSchema));
     }
 
     @Test

--- a/reference-implementations/rust/src/schema.rs
+++ b/reference-implementations/rust/src/schema.rs
@@ -456,6 +456,8 @@ fn validate_range_constraints(
     if min.is_none() && max.is_none() {
         return Ok(());
     }
+    validate_range_boundary(name, "min", min)?;
+    validate_range_boundary(name, "max", max)?;
     if is_nan(min) {
         return Err(format!("{name} cannot use NaN as min"));
     }
@@ -474,9 +476,11 @@ fn validate_range_constraints(
         let item_type = array_type.unwrap_or(SchemaType::Any);
         if !item_type.is_range_comparable() {
             return Err(format!(
-                "{name} can only define min or max for arrays with numeric or date/time arraytype"
+                "{name} can only define min or max for arrays with integer, float, or temporal arraytype"
             ));
         }
+        validate_boundary_matches_type(name, "min", min, item_type)?;
+        validate_boundary_matches_type(name, "max", max, item_type)?;
         return Ok(());
     }
     if let Some(type_name) = type_name {
@@ -485,8 +489,61 @@ fn validate_range_constraints(
                 "{name} can only define min or max for integer, float, date/time, or compatible array types"
             ));
         }
+        validate_boundary_matches_type(name, "min", min, type_name)?;
+        validate_boundary_matches_type(name, "max", max, type_name)?;
     }
     Ok(())
+}
+
+fn validate_range_boundary(name: &str, key: &str, value: Option<&Value>) -> Result<(), String> {
+    if value.map_or(true, is_range_boundary) {
+        return Ok(());
+    }
+    Err(format!(
+        "{name} {key} must be an integer, float, or temporal value"
+    ))
+}
+
+fn is_range_boundary(value: &Value) -> bool {
+    matches!(value, Value::Integer(_) | Value::Float(_))
+        || matches!(value, Value::Datetime(datetime) if is_temporal_boundary(datetime))
+}
+
+fn is_temporal_boundary(datetime: &Datetime) -> bool {
+    matches!(
+        (
+            datetime.date.is_some(),
+            datetime.time.is_some(),
+            datetime.offset.is_some()
+        ),
+        (true, true, true) | (true, true, false) | (true, false, false) | (false, true, false)
+    )
+}
+
+fn validate_boundary_matches_type(
+    name: &str,
+    key: &str,
+    value: Option<&Value>,
+    type_name: SchemaType,
+) -> Result<(), String> {
+    if value.map_or(true, |value| boundary_matches_type(value, type_name)) {
+        return Ok(());
+    }
+    Err(format!(
+        "{name} {key} must be comparable with {}",
+        type_name.schema_name()
+    ))
+}
+
+fn boundary_matches_type(value: &Value, type_name: SchemaType) -> bool {
+    match type_name {
+        SchemaType::Integer | SchemaType::Float => numeric(value).is_some(),
+        SchemaType::OffsetDateTime
+        | SchemaType::LocalDateTime
+        | SchemaType::LocalDate
+        | SchemaType::LocalTime => value_matches_type(value, type_name),
+        _ => false,
+    }
 }
 
 struct Validator<'schema> {

--- a/reference-implementations/rust/tests/integration.rs
+++ b/reference-implementations/rust/tests/integration.rs
@@ -159,6 +159,62 @@ port = 70000
 }
 
 #[test]
+fn rejects_malformed_boundary_schemas() {
+    let directory = tempfile_dir("malformed-boundaries");
+    let cases = [
+        (
+            "any-min",
+            r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.payload]
+type = "any"
+min = 1
+"#,
+        ),
+        (
+            "nan-min",
+            r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "float"
+min = nan
+"#,
+        ),
+        (
+            "string-min",
+            r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "integer"
+min = "1"
+"#,
+        ),
+        (
+            "date-time-min",
+            r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "local-date"
+min = 2026-01-01T00:00:00Z
+"#,
+        ),
+    ];
+
+    for (name, content) in cases {
+        let schema_path = write_file(&directory, &format!("{name}.tosd"), content);
+        Schema::load(&schema_path).expect_err("expected malformed boundary schema");
+    }
+}
+
+#[test]
 fn pattern_must_match_entire_string() {
     let directory = tempfile_dir("pattern-entire-string");
     let schema_path = write_file(

--- a/toml-schema.abnf
+++ b/toml-schema.abnf
@@ -43,8 +43,8 @@ allowedvalues = "allowedvalues" keyval-sep toml-array
 pattern       = "pattern" keyval-sep toml-string
 optional      = "optional" keyval-sep toml-boolean
 default       = "default" keyval-sep toml-value
-min           = "min" keyval-sep toml-value
-max           = "max" keyval-sep toml-value
+min           = "min" keyval-sep range-boundary
+max           = "max" keyval-sep range-boundary
 minlength     = "minlength" keyval-sep toml-integer ; strings count Unicode scalar values after TOML parsing
 maxlength     = "maxlength" keyval-sep toml-integer ; strings count Unicode scalar values after TOML parsing
 children      = "children"
@@ -59,6 +59,8 @@ array-built-in-type = anytype / stringtype / integertype / floattype / booleanty
 
 type-reference       = built-in-type / toml-string
 type-reference-array = toml-array ; semantically intended to contain only type-reference values; element types are not constrained by this ABNF
+range-boundary       = toml-integer / toml-float / toml-offset-date-time
+                     / toml-local-date-time / toml-local-date / toml-local-time
 
 anytype             = DQUOTE %x61.6e.79 DQUOTE                                      ; "any"
 stringtype          = DQUOTE %x73.74.72.69.6e.67 DQUOTE                             ; "string"
@@ -90,6 +92,11 @@ toml-array                         = <TOML 1.0 array>
 toml-inline-table                  = <TOML 1.0 inline table>
 toml-boolean                       = <TOML 1.0 boolean>
 toml-integer                       = <TOML 1.0 integer>
+toml-float                         = <TOML 1.0 float>
+toml-offset-date-time              = <TOML 1.0 offset date-time>
+toml-local-date-time               = <TOML 1.0 local date-time>
+toml-local-date                    = <TOML 1.0 local date>
+toml-local-time                    = <TOML 1.0 local time>
 
 keyval-sep = *WSP "=" *WSP
 


### PR DESCRIPTION
## Summary
- Clarify `[elements]` as the root schema for the TOML document being validated, with a concrete schema-to-document example.
- Replace generic `min = <any>` / `max = <any>` wording with explicit integer, float, and temporal boundary types.
- Update ABNF to model `min`/`max` with a dedicated `range-boundary` production instead of generic TOML values.
- Align Java, Go, and Rust reference implementations to reject invalid or mismatched range boundaries while loading schemas.

## Validation
- `mvn -f reference-implementations/java/pom.xml test -q`
- `go -C reference-implementations/go test ./...`
- `cargo test --manifest-path reference-implementations/rust/Cargo.toml`
