### PR TITLE
Add pyproject schema and remove children escape hatch

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -36,7 +36,7 @@ This repository contains the TOML Schema specification/proposal plus reference i
 - Use `oneof` for exactly-one alternative type validation and `anyof` for at-least-one validation; both reference reusable `[types]` definitions and can apply to fields or array item types.
 - `min`/`max` are inclusive and only valid for numeric/date-time types, or arrays with comparable `arraytype`; NaN is not a valid boundary.
 - String `minlength`/`maxlength` count Unicode scalar values after TOML parsing, not UTF-8 bytes, UTF-16 code units, or grapheme clusters.
-- Use `[...children]` with inline table entries for literal dotted, quoted, empty, or built-in-colliding TOML keys, e.g. `"google.com" = { type = "boolean" }`.
+- Use quoted TOML key/table paths only when TOML syntax needs quoting, e.g. literal dotted or empty keys. Schema-key-colliding child paths like `[elements.plugin.pattern]` do not require quotes.
 - Root `[toml-schema]` in TOML documents is reserved metadata and ignored during application validation unless the schema explicitly defines `[elements.toml-schema]`.
 - Optionality defaults to required behavior. Only mark a schema node optional with `optional = true` when the TOML document may omit that structure.
 - Tables with no defined child structure are intentionally open-ended; tables with defined child properties are intended to validate exactly against those children.

--- a/SPEC.md
+++ b/SPEC.md
@@ -250,9 +250,13 @@ minlength = <integer>
 maxlength = <integer>
 ```
 
-### Keys That Need Escaping
+### Quoted and Special Keys
 
-Schema child definitions usually use nested TOML tables, but TOML keys can be quoted, empty, contain dots, or collide with built-in schema property names such as `type`, `typeof`, and `optional`. Use a `children` table to define those keys unambiguously.
+Schema child definitions use TOML tables. When a target TOML key is empty or contains characters that TOML requires to be quoted, such as a literal dot, quote that key in the schema table path.
+
+Target keys may have the same names as TOML Schema properties, such as `type`, `typeof`, `optional`, or `pattern`. When those names are used as child table path segments, they define target document keys rather than schema properties.
+
+A schema definition with nested child definitions and no explicit `type`, `typeof`, `oneof`, or `anyof` is treated as `type = "table"`. This lets schemas describe target keys that would otherwise collide with schema properties.
 
 Example TOML document:
 
@@ -261,19 +265,22 @@ Example TOML document:
 
 [site]
 "google.com" = true
+
+[plugin]
+type = "npm"
 ```
 
 Schema:
 
 ```toml
-[elements.children]
-"" = { type = "string" }
+[elements.""]
+type = "string"
 
-[elements.site]
-type = "table"
+[elements.site."google.com"]
+type = "boolean"
 
-    [elements.site.children]
-    "google.com" = { type = "boolean" }
+[elements.plugin.type]
+type = "string"
 ```
 
 ### Simple Types - `<simple-type>`
@@ -346,6 +353,8 @@ For simplicity, there is no definition of `inline table` since these are just ta
 #### Tables
 
 A `table` may have a set of properties, or none at all. If a table has a definition of properties, then the parser must validate the input and the input must match exactly the rules of the table and its children.
+
+If a schema definition has nested child definitions but does not declare `type`, `typeof`, `oneof`, or `anyof`, parsers MUST treat it as if it declared `type = "table"`.
 
 If a property of type `table` has no defined property and/or structure, the parser must not validate its input. This is useful for representing custom JSON data payloads.
 

--- a/examples/netlify.tosd
+++ b/examples/netlify.tosd
@@ -289,8 +289,9 @@ type = "table"
     typeof = "types.stringOrStringArray"
     optional = true
 
-    [types.edgeFunction.children]
-    pattern = { type = "string", optional = true }
+    [types.edgeFunction.pattern]
+    type = "string"
+    optional = true
 
     [types.edgeFunction.excludedPattern]
     typeof = "types.stringOrStringArray"
@@ -386,9 +387,15 @@ type = "table"
 [types.template]
 type = "table"
 
-    [types.template.children]
-    "incoming-hooks" = { type = "array", arraytype = "string", optional = true }
-    "required-extensions" = { type = "array", arraytype = "string", optional = true }
+    [types.template."incoming-hooks"]
+    type = "array"
+    arraytype = "string"
+    optional = true
+
+    [types.template."required-extensions"]
+    type = "array"
+    arraytype = "string"
+    optional = true
 
     [types.template.environment]
     typeof = "types.environment"

--- a/examples/pyproject.tosd
+++ b/examples/pyproject.tosd
@@ -26,9 +26,13 @@ type = "table"
     [types.buildSystem.requires]
     typeof = "types.dependencyArray"
 
-    [types.buildSystem.children]
-    "build-backend" = { type = "string", optional = true }
-    "backend-path" = { typeof = "types.stringArray", optional = true }
+    [types.buildSystem."build-backend"]
+    type = "string"
+    optional = true
+
+    [types.buildSystem."backend-path"]
+    typeof = "types.stringArray"
+    optional = true
 
 [types.readmeTable]
 type = "table"
@@ -41,8 +45,8 @@ type = "table"
     type = "string"
     optional = true
 
-    [types.readmeTable.children]
-    "content-type" = { type = "string" }
+    [types.readmeTable."content-type"]
+    type = "string"
 
 [types.readme]
 oneof = [ "string", "types.readmeTable" ]
@@ -177,22 +181,47 @@ type = "table"
     typeof = "types.stringMap"
     optional = true
 
-    [types.project.children]
-    "requires-python" = { type = "string", optional = true }
-    "license-files" = { typeof = "types.stringArray", optional = true }
-    "gui-scripts" = { typeof = "types.stringMap", optional = true }
-    "entry-points" = { typeof = "types.entryPoints", optional = true }
-    dependencies = { typeof = "types.dependencyArray", optional = true }
-    "optional-dependencies" = { typeof = "types.optionalDependencies", optional = true }
-    "import-names" = { typeof = "types.importNames", optional = true }
-    "import-namespaces" = { typeof = "types.importNamespaces", optional = true }
-    dynamic = { typeof = "types.dynamicMetadata", optional = true }
+    [types.project."requires-python"]
+    type = "string"
+    optional = true
+
+    [types.project."license-files"]
+    typeof = "types.stringArray"
+    optional = true
+
+    [types.project."gui-scripts"]
+    typeof = "types.stringMap"
+    optional = true
+
+    [types.project."entry-points"]
+    typeof = "types.entryPoints"
+    optional = true
+
+    [types.project.dependencies]
+    typeof = "types.dependencyArray"
+    optional = true
+
+    [types.project."optional-dependencies"]
+    typeof = "types.optionalDependencies"
+    optional = true
+
+    [types.project."import-names"]
+    typeof = "types.importNames"
+    optional = true
+
+    [types.project."import-namespaces"]
+    typeof = "types.importNamespaces"
+    optional = true
+
+    [types.project.dynamic]
+    typeof = "types.dynamicMetadata"
+    optional = true
 
 [types.dependencyGroupInclude]
 type = "table"
 
-    [types.dependencyGroupInclude.children]
-    "include-group" = { type = "string" }
+    [types.dependencyGroupInclude."include-group"]
+    type = "string"
 
 [types.dependencyGroupItem]
 oneof = [ "string", "types.dependencyGroupInclude" ]
@@ -217,6 +246,10 @@ type = "collection"
 typeof = "types.openTable"
 optional = true
 
-[elements.children]
-"build-system" = { typeof = "types.buildSystem", optional = true }
-"dependency-groups" = { typeof = "types.dependencyGroups", optional = true }
+[elements."build-system"]
+typeof = "types.buildSystem"
+optional = true
+
+[elements."dependency-groups"]
+typeof = "types.dependencyGroups"
+optional = true

--- a/examples/pyproject.tosd
+++ b/examples/pyproject.tosd
@@ -1,0 +1,222 @@
+# Based on:
+# - https://packaging.python.org/en/latest/specifications/pyproject-toml/
+# - https://packaging.python.org/en/latest/specifications/dependency-groups/
+
+[toml-schema]
+version = "1.0.0"
+
+[types.stringArray]
+type = "array"
+arraytype = "string"
+
+[types.dependencyArray]
+type = "array"
+arraytype = "string"
+
+[types.stringMap]
+type = "collection"
+typeof = "string"
+
+[types.openTable]
+type = "table"
+
+[types.buildSystem]
+type = "table"
+
+    [types.buildSystem.requires]
+    typeof = "types.dependencyArray"
+
+    [types.buildSystem.children]
+    "build-backend" = { type = "string", optional = true }
+    "backend-path" = { typeof = "types.stringArray", optional = true }
+
+[types.readmeTable]
+type = "table"
+
+    [types.readmeTable.file]
+    type = "string"
+    optional = true
+
+    [types.readmeTable.text]
+    type = "string"
+    optional = true
+
+    [types.readmeTable.children]
+    "content-type" = { type = "string" }
+
+[types.readme]
+oneof = [ "string", "types.readmeTable" ]
+
+[types.legacyLicenseTable]
+type = "table"
+
+    [types.legacyLicenseTable.file]
+    type = "string"
+    optional = true
+
+    [types.legacyLicenseTable.text]
+    type = "string"
+    optional = true
+
+[types.license]
+oneof = [ "string", "types.legacyLicenseTable" ]
+
+[types.person]
+type = "table"
+
+    [types.person.name]
+    type = "string"
+    optional = true
+
+    [types.person.email]
+    type = "string"
+    optional = true
+
+[types.people]
+type = "array"
+arraytype = "table"
+itemtype = "types.person"
+
+[types.projectName]
+type = "string"
+pattern = '^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$'
+
+[types.pythonImportName]
+type = "string"
+pattern = '^([A-Za-z_][A-Za-z0-9_]*)(\.[A-Za-z_][A-Za-z0-9_]*)*(\s*;\s*private)?$'
+
+[types.pythonImportNameOrEmpty]
+type = "string"
+pattern = '^$|^([A-Za-z_][A-Za-z0-9_]*)(\.[A-Za-z_][A-Za-z0-9_]*)*(\s*;\s*private)?$'
+
+[types.importNames]
+type = "array"
+arraytype = "any"
+itemtype = "types.pythonImportNameOrEmpty"
+
+[types.importNamespaces]
+type = "array"
+arraytype = "any"
+itemtype = "types.pythonImportName"
+
+[types.dynamicMetadata]
+type = "array"
+arraytype = "string"
+allowedvalues = [
+    "version",
+    "description",
+    "readme",
+    "requires-python",
+    "license",
+    "license-files",
+    "authors",
+    "maintainers",
+    "keywords",
+    "classifiers",
+    "urls",
+    "scripts",
+    "gui-scripts",
+    "entry-points",
+    "dependencies",
+    "optional-dependencies",
+    "import-names",
+    "import-namespaces",
+]
+
+[types.optionalDependencies]
+type = "collection"
+typeof = "types.dependencyArray"
+
+[types.entryPoints]
+type = "collection"
+typeof = "types.stringMap"
+
+[types.project]
+type = "table"
+
+    [types.project.name]
+    typeof = "types.projectName"
+
+    [types.project.version]
+    type = "string"
+    optional = true
+
+    [types.project.description]
+    type = "string"
+    optional = true
+
+    [types.project.readme]
+    typeof = "types.readme"
+    optional = true
+
+    [types.project.license]
+    typeof = "types.license"
+    optional = true
+
+    [types.project.authors]
+    typeof = "types.people"
+    optional = true
+
+    [types.project.maintainers]
+    typeof = "types.people"
+    optional = true
+
+    [types.project.keywords]
+    typeof = "types.stringArray"
+    optional = true
+
+    [types.project.classifiers]
+    typeof = "types.stringArray"
+    optional = true
+
+    [types.project.urls]
+    typeof = "types.stringMap"
+    optional = true
+
+    [types.project.scripts]
+    typeof = "types.stringMap"
+    optional = true
+
+    [types.project.children]
+    "requires-python" = { type = "string", optional = true }
+    "license-files" = { typeof = "types.stringArray", optional = true }
+    "gui-scripts" = { typeof = "types.stringMap", optional = true }
+    "entry-points" = { typeof = "types.entryPoints", optional = true }
+    dependencies = { typeof = "types.dependencyArray", optional = true }
+    "optional-dependencies" = { typeof = "types.optionalDependencies", optional = true }
+    "import-names" = { typeof = "types.importNames", optional = true }
+    "import-namespaces" = { typeof = "types.importNamespaces", optional = true }
+    dynamic = { typeof = "types.dynamicMetadata", optional = true }
+
+[types.dependencyGroupInclude]
+type = "table"
+
+    [types.dependencyGroupInclude.children]
+    "include-group" = { type = "string" }
+
+[types.dependencyGroupItem]
+oneof = [ "string", "types.dependencyGroupInclude" ]
+
+[types.dependencyGroup]
+type = "array"
+arraytype = "any"
+itemtype = "types.dependencyGroupItem"
+
+[types.dependencyGroups]
+type = "collection"
+typeof = "types.dependencyGroup"
+
+[elements]
+
+[elements.project]
+typeof = "types.project"
+optional = true
+
+[elements.tool]
+type = "collection"
+typeof = "types.openTable"
+optional = true
+
+[elements.children]
+"build-system" = { typeof = "types.buildSystem", optional = true }
+"dependency-groups" = { typeof = "types.dependencyGroups", optional = true }

--- a/examples/wrangler.tosd
+++ b/examples/wrangler.tosd
@@ -43,8 +43,8 @@ pattern = '^[A-Za-z0-9][A-Za-z0-9-]{0,254}$'
 [types.routeTable]
 type = "table"
 
-    [types.routeTable.children]
-    pattern = { type = "string" }
+    [types.routeTable.pattern]
+    type = "string"
 
     [types.routeTable.custom_domain]
     type = "boolean"
@@ -158,8 +158,9 @@ type = "table"
 [types.moduleRule]
 type = "table"
 
-    [types.moduleRule.children]
-    type = { type = "string", allowedvalues = [ "CommonJS", "CompiledWasm", "Data", "ESModule", "Text" ] }
+    [types.moduleRule.type]
+    type = "string"
+    allowedvalues = [ "CommonJS", "CompiledWasm", "Data", "ESModule", "Text" ]
 
     [types.moduleRule.globs]
     type = "array"

--- a/reference-implementations/go/schema.go
+++ b/reference-implementations/go/schema.go
@@ -34,7 +34,7 @@ var definitionKeys = map[string]bool{
 	"type": true, "typeof": true, "arraytype": true, "itemtype": true, "items": true,
 	"allowedvalues": true, "pattern": true, "optional": true, "default": true, "min": true,
 	"max": true, "minlength": true, "maxlength": true,
-	"oneof": true, "anyof": true, "children": true,
+	"oneof": true, "anyof": true,
 }
 
 const currentTomlSchemaVersion = "1.0.0"
@@ -218,20 +218,6 @@ func parseDefinitions(prefix string, table map[string]any, required bool) (map[s
 			}
 		}
 		valueMap, ok := asMap(value)
-		if key == "children" && ok && !hasDefinitionMarker(valueMap) {
-			for childKey, childValue := range valueMap {
-				childMap, ok := asMap(childValue)
-				if !ok {
-					return nil, fmt.Errorf("[%s.children] entry must be a table: %s", prefix, childKey)
-				}
-				definition, err := parseDefinition(prefix+"."+childKey, childMap)
-				if err != nil {
-					return nil, err
-				}
-				definitions[childKey] = definition
-			}
-			continue
-		}
 		if !ok {
 			return nil, fmt.Errorf("[%s] entry must be a table: %s", prefix, key)
 		}
@@ -297,28 +283,9 @@ func parseDefinition(name string, table map[string]any) (Definition, error) {
 		return Definition{}, fmt.Errorf("%s cannot define both oneof and anyof", name)
 	}
 	children := map[string]Definition{}
-	if explicitChildren, ok := asMap(table["children"]); ok {
-		for key, value := range explicitChildren {
-			childTable, ok := asMap(value)
-			if !ok {
-				return Definition{}, fmt.Errorf("%s.children.%s must be a table", name, key)
-			}
-			child, err := parseDefinition(name+"."+key, childTable)
-			if err != nil {
-				return Definition{}, err
-			}
-			children[key] = child
-		}
-	}
 	for key, value := range table {
 		childTable, ok := asMap(value)
 		if ok {
-			if definitionKeys[key] {
-				if key != "children" {
-					return Definition{}, fmt.Errorf("%s.%s must not be a table", name, key)
-				}
-				continue
-			}
 			if _, exists := children[key]; exists {
 				return Definition{}, fmt.Errorf("%s defines child %s more than once", name, key)
 			}
@@ -332,7 +299,10 @@ func parseDefinition(name string, table map[string]any) (Definition, error) {
 		}
 	}
 	if typeName == "" && reference == "" && len(oneOf) == 0 && len(anyOf) == 0 {
-		return Definition{}, fmt.Errorf("%s must define type, typeof, oneof, or anyof", name)
+		if len(children) == 0 {
+			return Definition{}, fmt.Errorf("%s must define type, typeof, oneof, anyof, or child definitions", name)
+		}
+		typeName = TypeTable
 	}
 	if typeName != TypeArray && arrayType != "" {
 		return Definition{}, fmt.Errorf("%s can only define arraytype when type is array", name)
@@ -354,14 +324,16 @@ func parseDefinition(name string, table map[string]any) (Definition, error) {
 			return Definition{}, fmt.Errorf("%s cannot define minlength or maxlength together with items", name)
 		}
 	}
-	if err := validateRangeConstraints(name, typeName, arrayType, normalizeReference(itemReference), table["min"], table["max"]); err != nil {
+	min := propertyValue(table, "min")
+	max := propertyValue(table, "max")
+	if err := validateRangeConstraints(name, typeName, arrayType, normalizeReference(itemReference), min, max); err != nil {
 		return Definition{}, err
 	}
 	return Definition{
 		name: name, typeName: typeName, reference: normalizeReference(reference),
 		arrayType: arrayType, itemReference: normalizeReference(itemReference), optional: optional,
 		items:         normalizeReferences(items),
-		allowedValues: allowedValues, pattern: pattern, min: table["min"], max: table["max"],
+		allowedValues: allowedValues, pattern: pattern, min: min, max: max,
 		minLength: minLength, maxLength: maxLength, oneOf: normalizeReferences(oneOf), anyOf: normalizeReferences(anyOf),
 		children: children,
 	}, nil
@@ -804,9 +776,17 @@ func getSchemaType(table map[string]any, key string) (SchemaType, error) {
 	return "", fmt.Errorf("unsupported schema type: %s", value)
 }
 
+func propertyValue(table map[string]any, key string) any {
+	value := table[key]
+	if _, ok := asMap(value); ok {
+		return nil
+	}
+	return value
+}
+
 func getString(table map[string]any, key string) (string, error) {
-	value, ok := table[key]
-	if !ok || value == nil {
+	value := propertyValue(table, key)
+	if value == nil {
 		return "", nil
 	}
 	stringValue, ok := value.(string)
@@ -817,8 +797,8 @@ func getString(table map[string]any, key string) (string, error) {
 }
 
 func getBool(table map[string]any, key string) (bool, error) {
-	value, ok := table[key]
-	if !ok || value == nil {
+	value := propertyValue(table, key)
+	if value == nil {
 		return false, nil
 	}
 	boolValue, ok := value.(bool)
@@ -829,8 +809,8 @@ func getBool(table map[string]any, key string) (bool, error) {
 }
 
 func getIntegerPointer(table map[string]any, key string) (*int, error) {
-	value, ok := table[key]
-	if !ok || value == nil {
+	value := propertyValue(table, key)
+	if value == nil {
 		return nil, nil
 	}
 	intValue, ok := value.(int64)
@@ -857,8 +837,8 @@ func getPattern(name string, table map[string]any) (*regexp.Regexp, error) {
 }
 
 func getArrayValues(table map[string]any, key string) ([]any, error) {
-	value, ok := table[key]
-	if !ok || value == nil {
+	value := propertyValue(table, key)
+	if value == nil {
 		return nil, nil
 	}
 	array, ok := value.([]any)
@@ -1019,12 +999,6 @@ func encodePathKey(key string) string {
 func matchesEntireString(pattern *regexp.Regexp, value string) bool {
 	match := pattern.FindStringIndex(value)
 	return match != nil && match[0] == 0 && match[1] == len(value)
-}
-
-func hasDefinitionMarker(table map[string]any) bool {
-	_, hasType := table["type"]
-	_, hasTypeOf := table["typeof"]
-	return hasType || hasTypeOf
 }
 
 func asMap(value any) (map[string]any, bool) {

--- a/reference-implementations/go/schema_test.go
+++ b/reference-implementations/go/schema_test.go
@@ -428,26 +428,33 @@ minlength = 2
 	}
 }
 
-func TestSupportsQuotedDottedAndEmptyKeysWithChildrenTable(t *testing.T) {
+func TestSupportsQuotedDottedEmptyAndSchemaKeywordKeys(t *testing.T) {
 	dir := t.TempDir()
 	schemaPath := write(t, dir, "schema.tosd", `
 [toml-schema]
 version = "1.0.0"
 
-[elements.site]
-type = "table"
-
-    [elements.site.children]
-    "google.com" = { type = "boolean" }
+[elements.""]
+type = "string"
 
 [elements.children]
-"" = { type = "string" }
+type = "string"
+
+[elements.site."google.com"]
+type = "boolean"
+
+[elements.plugin.type]
+type = "string"
 `)
 	documentPath := write(t, dir, "document.toml", `
 "" = "blank"
+children = "literal"
 
 [site]
 "google.com" = true
+
+[plugin]
+type = "npm"
 `)
 
 	schema, err := LoadSchema(schemaPath)

--- a/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
@@ -26,7 +26,7 @@ final class SchemaLoader {
     static final Set<String> DEFINITION_KEYS = Set.of(
             "type", "typeof", "arraytype", "itemtype", "items", "allowedvalues", "pattern",
             "optional", "default", "min", "max", "minlength", "maxlength",
-            "oneof", "anyof", "children"
+            "oneof", "anyof"
     );
 
     TomlSchema load(Path schemaPath) {
@@ -81,18 +81,7 @@ final class SchemaLoader {
             if (prefix.equals("types") && SchemaType.fromSchemaNameOptional(key).isPresent()) {
                 throw new SchemaException("[types." + key + "] uses a reserved built-in type name");
             }
-            Object value = table.get(List.of(key));
-            if (key.equals("children") && value instanceof TomlTable childrenTable && !hasDefinitionMarker(childrenTable)) {
-                for (String childKey : childrenTable.keySet()) {
-                    Object childValue = childrenTable.get(List.of(childKey));
-                    if (!(childValue instanceof TomlTable childDefinitionTable)) {
-                        throw new SchemaException("[" + prefix + ".children] entry must be a table: " + childKey);
-                    }
-                    definitions.put(childKey, parseDefinition(prefix + "." + childKey, childDefinitionTable));
-                }
-                continue;
-            }
-            if (!(value instanceof TomlTable definitionTable)) {
+            if (!(table.get(List.of(key)) instanceof TomlTable definitionTable)) {
                 throw new SchemaException("[" + prefix + "] entry must be a table: " + key);
             }
             definitions.put(key, parseDefinition(prefix + "." + key, definitionTable));
@@ -119,25 +108,9 @@ final class SchemaLoader {
         }
 
         Map<String, SchemaDefinition> children = new LinkedHashMap<>();
-        TomlTable explicitChildren = table.getTable("children");
-        if (explicitChildren != null) {
-            for (String key : explicitChildren.keySet()) {
-                Object value = explicitChildren.get(List.of(key));
-                if (!(value instanceof TomlTable childTable)) {
-                    throw new SchemaException(name + ".children." + key + " must be a table");
-                }
-                children.put(key, parseDefinition(name + "." + key, childTable));
-            }
-        }
         for (String key : table.keySet()) {
             Object value = table.get(List.of(key));
             if (value instanceof TomlTable childTable) {
-                if (DEFINITION_KEYS.contains(key)) {
-                    if (!key.equals("children")) {
-                        throw new SchemaException(name + "." + key + " must not be a table");
-                    }
-                    continue;
-                }
                 if (children.containsKey(key)) {
                     throw new SchemaException(name + " defines child " + key + " more than once");
                 }
@@ -147,7 +120,10 @@ final class SchemaLoader {
             }
         }
         if (type == null && normalizedReference == null && oneOf.isEmpty() && anyOf.isEmpty()) {
-            throw new SchemaException(name + " must define type, typeof, oneof, or anyof");
+            if (children.isEmpty()) {
+                throw new SchemaException(name + " must define type, typeof, oneof, anyof, or child definitions");
+            }
+            type = SchemaType.TABLE;
         }
         if (type != SchemaType.ARRAY && arrayType != null) {
             throw new SchemaException(name + " can only define arraytype when type is array");
@@ -169,7 +145,9 @@ final class SchemaLoader {
                 throw new SchemaException(name + " cannot define minlength or maxlength together with items");
             }
         }
-        validateRangeConstraints(name, type, arrayType, itemReference, table.get("min"), table.get("max"));
+        Object min = getPropertyValue(table, "min");
+        Object max = getPropertyValue(table, "max");
+        validateRangeConstraints(name, type, arrayType, itemReference, min, max);
         return new SchemaDefinition(
                 name,
                 type,
@@ -180,8 +158,8 @@ final class SchemaLoader {
                 optional != null && optional,
                 allowedValues,
                 pattern,
-                table.get("min"),
-                table.get("max"),
+                min,
+                max,
                 minLength,
                 maxLength,
                 oneOf.stream().map(this::normalizeReference).toList(),
@@ -195,13 +173,13 @@ final class SchemaLoader {
         return value == null ? null : SchemaType.fromSchemaName(value);
     }
 
-    private boolean hasDefinitionMarker(TomlTable table) {
-        return table.contains(List.of("type"))
-                || table.contains(List.of("typeof"));
+    private Object getPropertyValue(TomlTable table, String key) {
+        Object value = table.get(key);
+        return value instanceof TomlTable ? null : value;
     }
 
     private String getString(TomlTable table, String key) {
-        Object value = table.get(key);
+        Object value = getPropertyValue(table, key);
         if (value == null) {
             return null;
         }
@@ -212,7 +190,7 @@ final class SchemaLoader {
     }
 
     private Boolean getBoolean(TomlTable table, String key) {
-        Object value = table.get(key);
+        Object value = getPropertyValue(table, key);
         if (value == null) {
             return null;
         }
@@ -223,7 +201,7 @@ final class SchemaLoader {
     }
 
     private Integer getInteger(TomlTable table, String key) {
-        Object value = table.get(key);
+        Object value = getPropertyValue(table, key);
         if (value == null) {
             return null;
         }
@@ -249,7 +227,7 @@ final class SchemaLoader {
     }
 
     private List<Object> getArrayValues(TomlTable table, String key) {
-        Object value = table.get(key);
+        Object value = getPropertyValue(table, key);
         if (value == null) {
             return List.of();
         }

--- a/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
+++ b/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
@@ -336,25 +336,32 @@ class TomlSchemaTest {
     }
 
     @Test
-    void supportsQuotedDottedAndEmptyTomlKeysWithChildrenTable() throws IOException {
+    void supportsQuotedDottedEmptyAndSchemaKeywordTomlKeys() throws IOException {
         Path schema = write("special-keys.tosd", """
                 [toml-schema]
                 version = "1.0.0"
 
-                [elements.site]
-                type = "table"
-
-                    [elements.site.children]
-                    "google.com" = { type = "boolean" }
+                [elements.""]
+                type = "string"
 
                 [elements.children]
-                "" = { type = "string" }
+                type = "string"
+
+                [elements.site."google.com"]
+                type = "boolean"
+
+                [elements.plugin.type]
+                type = "string"
                 """);
         Path document = write("special-keys.toml", """
                 "" = "blank"
+                children = "literal"
 
                 [site]
                 "google.com" = true
+
+                [plugin]
+                type = "npm"
                 """);
 
         ValidationResult result = TomlSchema.load(schema).validate(document);
@@ -368,11 +375,8 @@ class TomlSchemaTest {
                 [toml-schema]
                 version = "1.0.0"
 
-                [elements.site]
-                type = "table"
-
-                    [elements.site.children]
-                    "google.com" = { type = "boolean" }
+                [elements.site."google.com"]
+                type = "boolean"
                 """);
         Path document = write("special-key-error.toml", """
                 [site]

--- a/reference-implementations/rust/Cargo.tosd
+++ b/reference-implementations/rust/Cargo.tosd
@@ -256,8 +256,9 @@ type = "table"
     type = "boolean"
     optional = true
 
-    [types.dependencyTable.children]
-    optional = { type = "boolean", optional = true }
+    [types.dependencyTable.optional]
+    type = "boolean"
+    optional = true
 
 [types.dependencyCollection]
 type = "collection"

--- a/reference-implementations/rust/src/schema.rs
+++ b/reference-implementations/rust/src/schema.rs
@@ -105,7 +105,6 @@ pub const DEFINITION_KEYS: &[&str] = &[
     "maxlength",
     "oneof",
     "anyof",
-    "children",
 ];
 
 pub const CURRENT_TOML_SCHEMA_VERSION: &str = "1.0.0";
@@ -223,7 +222,9 @@ impl Schema {
         )
         .expect("valid SemVer regex");
         let Some(captures) = semver.captures(version) else {
-            return Err("[toml-schema].version must use SemVer MAJOR.MINOR.PATCH syntax".to_string());
+            return Err(
+                "[toml-schema].version must use SemVer MAJOR.MINOR.PATCH syntax".to_string(),
+            );
         };
         if captures.get(1).map(|major| major.as_str()) != Some("1") {
             return Err(format!("unsupported TOML Schema major version: {version}"));
@@ -266,9 +267,7 @@ impl Schema {
 /// Loads a TOML Schema document referenced by a TOML document via
 /// `[toml-schema].location` and returns the schema together with the parsed
 /// document.
-pub fn schema_from_document<P: AsRef<Path>>(
-    document_path: P,
-) -> Result<(Schema, Table), String> {
+pub fn schema_from_document<P: AsRef<Path>>(document_path: P) -> Result<(Schema, Table), String> {
     let document_path = document_path.as_ref();
     let document = parse_toml_file(document_path)?;
     let metadata = document
@@ -288,10 +287,9 @@ pub fn schema_from_document<P: AsRef<Path>>(
 }
 
 fn parse_toml_file(path: &Path) -> Result<Table, String> {
-    let content = fs::read_to_string(path)
-        .map_err(|error| format!("{}: {}", path.display(), error))?;
-    toml::from_str::<Table>(&content)
-        .map_err(|error| format!("{}: {}", path.display(), error))
+    let content =
+        fs::read_to_string(path).map_err(|error| format!("{}: {}", path.display(), error))?;
+    toml::from_str::<Table>(&content).map_err(|error| format!("{}: {}", path.display(), error))
 }
 
 fn parse_definitions(
@@ -310,23 +308,8 @@ fn parse_definitions(
         if prefix == "types" && SchemaType::parse(key).is_some() {
             return Err(format!("[types.{key}] uses a reserved built-in type name"));
         }
-        let value_map = value.as_table();
-        if key == "children"
-            && value_map
-                .map(|child_table| !has_definition_marker(child_table))
-                .unwrap_or(false)
-        {
-            for (child_key, child_value) in value_map.unwrap().iter() {
-                let child_map = child_value.as_table().ok_or_else(|| {
-                    format!("[{prefix}.children] entry must be a table: {child_key}")
-                })?;
-                let definition =
-                    parse_definition(&format!("{prefix}.{child_key}"), child_map)?;
-                definitions.insert(child_key.clone(), definition);
-            }
-            continue;
-        }
-        let value_map = value_map
+        let value_map = value
+            .as_table()
             .ok_or_else(|| format!("[{prefix}] entry must be a table: {key}"))?;
         let definition = parse_definition(&format!("{prefix}.{key}"), value_map)?;
         definitions.insert(key.clone(), definition);
@@ -335,7 +318,7 @@ fn parse_definitions(
 }
 
 fn parse_definition(name: &str, table: &Table) -> Result<Definition, String> {
-    let type_name = get_schema_type(name, table, "type")?;
+    let mut type_name = get_schema_type(name, table, "type")?;
     let reference = get_string(name, table, "typeof")?;
     let array_type = get_schema_type(name, table, "arraytype")?;
     let item_reference = get_string(name, table, "itemtype")?;
@@ -351,23 +334,8 @@ fn parse_definition(name: &str, table: &Table) -> Result<Definition, String> {
         return Err(format!("{name} cannot define both oneof and anyof"));
     }
     let mut children: BTreeMap<String, Definition> = BTreeMap::new();
-    if let Some(Value::Table(explicit_children)) = table.get("children") {
-        for (key, value) in explicit_children.iter() {
-            let child_table = value.as_table().ok_or_else(|| {
-                format!("{name}.children.{key} must be a table")
-            })?;
-            let child = parse_definition(&format!("{name}.{key}"), child_table)?;
-            children.insert(key.clone(), child);
-        }
-    }
     for (key, value) in table.iter() {
         if let Some(child_table) = value.as_table() {
-            if is_definition_key(key) {
-                if key != "children" {
-                    return Err(format!("{name}.{key} must not be a table"));
-                }
-                continue;
-            }
             if children.contains_key(key) {
                 return Err(format!("{name} defines child {key} more than once"));
             }
@@ -377,14 +345,13 @@ fn parse_definition(name: &str, table: &Table) -> Result<Definition, String> {
             return Err(format!("{name} contains unsupported property: {key}"));
         }
     }
-    if type_name.is_none()
-        && reference.is_none()
-        && one_of.is_empty()
-        && any_of.is_empty()
-    {
-        return Err(format!(
-            "{name} must define type, typeof, oneof, or anyof"
-        ));
+    if type_name.is_none() && reference.is_none() && one_of.is_empty() && any_of.is_empty() {
+        if children.is_empty() {
+            return Err(format!(
+                "{name} must define type, typeof, oneof, anyof, or child definitions"
+            ));
+        }
+        type_name = Some(SchemaType::Table);
     }
     if type_name != Some(SchemaType::Array) && array_type.is_some() {
         return Err(format!(
@@ -397,9 +364,7 @@ fn parse_definition(name: &str, table: &Table) -> Result<Definition, String> {
         ));
     }
     if type_name != Some(SchemaType::Array) && !items.is_empty() {
-        return Err(format!(
-            "{name} can only define items when type is array"
-        ));
+        return Err(format!("{name} can only define items when type is array"));
     }
     if !items.is_empty() {
         if array_type.is_some() {
@@ -414,8 +379,8 @@ fn parse_definition(name: &str, table: &Table) -> Result<Definition, String> {
             ));
         }
     }
-    let min = table.get("min").cloned();
-    let max = table.get("max").cloned();
+    let min = property_value(table, "min").cloned();
+    let max = property_value(table, "max").cloned();
     validate_range_constraints(
         name,
         type_name,
@@ -655,12 +620,7 @@ impl<'schema> Validator<'schema> {
         }
     }
 
-    fn validate_table_value(
-        &mut self,
-        path: &str,
-        table: &Table,
-        definition: &Definition,
-    ) {
+    fn validate_table_value(&mut self, path: &str, table: &Table, definition: &Definition) {
         if definition.children.is_empty() {
             return;
         }
@@ -672,12 +632,7 @@ impl<'schema> Validator<'schema> {
         }
     }
 
-    fn validate_collection(
-        &mut self,
-        path: &str,
-        table: &Table,
-        definition: &Definition,
-    ) {
+    fn validate_collection(&mut self, path: &str, table: &Table, definition: &Definition) {
         let mut dynamic_entries = 0usize;
         for (key, value) in table.iter() {
             let child_path = append_path(path, key);
@@ -744,9 +699,7 @@ impl<'schema> Validator<'schema> {
                 continue;
             }
             match &item_definition {
-                Some(item_definition) => {
-                    self.validate_value(&item_path, item, item_definition)
-                }
+                Some(item_definition) => self.validate_value(&item_path, item, item_definition),
                 None => {
                     self.validate_allowed_values(&item_path, item, definition);
                     self.validate_range(&item_path, item, definition);
@@ -769,13 +722,14 @@ impl<'schema> Validator<'schema> {
         let upper_bound = array.len().min(definition.items.len());
         for index in 0..upper_bound {
             let item_path = format!("{path}[{index}]");
-            let referenced = match self.resolve_reference(&definition.items[index], &mut HashSet::new()) {
-                Ok(referenced) => referenced,
-                Err(error) => {
-                    self.add(&item_path, &error);
-                    continue;
-                }
-            };
+            let referenced =
+                match self.resolve_reference(&definition.items[index], &mut HashSet::new()) {
+                    Ok(referenced) => referenced,
+                    Err(error) => {
+                        self.add(&item_path, &error);
+                        continue;
+                    }
+                };
             self.validate_value(&item_path, &array[index], &referenced);
         }
     }
@@ -793,12 +747,7 @@ impl<'schema> Validator<'schema> {
         }
     }
 
-    fn validate_common_constraints(
-        &mut self,
-        path: &str,
-        value: &Value,
-        definition: &Definition,
-    ) {
+    fn validate_common_constraints(&mut self, path: &str, value: &Value, definition: &Definition) {
         if let Value::Array(array) = value {
             self.validate_length(path, array.len(), definition);
             return;
@@ -818,12 +767,7 @@ impl<'schema> Validator<'schema> {
         }
     }
 
-    fn validate_allowed_values(
-        &mut self,
-        path: &str,
-        value: &Value,
-        definition: &Definition,
-    ) {
+    fn validate_allowed_values(&mut self, path: &str, value: &Value, definition: &Definition) {
         if definition.allowed_values.is_empty() {
             return;
         }
@@ -871,8 +815,7 @@ impl<'schema> Validator<'schema> {
         definition: &Definition,
         seen: &mut HashSet<String>,
     ) -> Result<Definition, String> {
-        if definition.reference.is_none() || definition.type_name == Some(SchemaType::Collection)
-        {
+        if definition.reference.is_none() || definition.type_name == Some(SchemaType::Collection) {
             return Ok(definition.clone());
         }
         let reference = definition.reference.as_deref().unwrap();
@@ -912,10 +855,7 @@ impl<'schema> Validator<'schema> {
             } else {
                 definition.allowed_values.clone()
             },
-            pattern: definition
-                .pattern
-                .clone()
-                .or(referenced.pattern.clone()),
+            pattern: definition.pattern.clone().or(referenced.pattern.clone()),
             min: definition.min.clone().or(referenced.min.clone()),
             max: definition.max.clone().or(referenced.max.clone()),
             min_length: definition.min_length.or(referenced.min_length),
@@ -1110,9 +1050,7 @@ fn values_equal(left: &Value, right: &Value) -> bool {
     match (left, right) {
         (Value::String(left), Value::String(right)) => left == right,
         (Value::Boolean(left), Value::Boolean(right)) => left == right,
-        (Value::Datetime(left), Value::Datetime(right)) => {
-            left.to_string() == right.to_string()
-        }
+        (Value::Datetime(left), Value::Datetime(right)) => left.to_string() == right.to_string(),
         (Value::Array(left), Value::Array(right)) => {
             left.len() == right.len()
                 && left
@@ -1149,9 +1087,9 @@ fn append_path(path: &str, key: &str) -> String {
 /// quoted with TOML-style escaping.
 pub fn encode_path_key(key: &str) -> String {
     if !key.is_empty()
-        && key
-            .chars()
-            .all(|character| character.is_ascii_alphanumeric() || character == '_' || character == '-')
+        && key.chars().all(|character| {
+            character.is_ascii_alphanumeric() || character == '_' || character == '-'
+        })
     {
         return key.to_string();
     }
@@ -1176,11 +1114,6 @@ pub fn encode_path_key(key: &str) -> String {
     encoded
 }
 
-fn has_definition_marker(table: &Table) -> bool {
-    table.contains_key("type")
-        || table.contains_key("typeof")
-}
-
 fn normalize_reference(reference: String) -> String {
     reference
         .strip_prefix("types.")
@@ -1196,11 +1129,7 @@ fn is_nan(value: Option<&Value>) -> bool {
     matches!(value, Some(Value::Float(float)) if float.is_nan())
 }
 
-fn get_schema_type(
-    name: &str,
-    table: &Table,
-    key: &str,
-) -> Result<Option<SchemaType>, String> {
+fn get_schema_type(name: &str, table: &Table, key: &str) -> Result<Option<SchemaType>, String> {
     let Some(value) = get_string(name, table, key)? else {
         return Ok(None);
     };
@@ -1209,8 +1138,15 @@ fn get_schema_type(
         .ok_or_else(|| format!("{name} has unsupported schema type: {value}"))
 }
 
-fn get_string(name: &str, table: &Table, key: &str) -> Result<Option<String>, String> {
+fn property_value<'a>(table: &'a Table, key: &str) -> Option<&'a Value> {
     match table.get(key) {
+        Some(Value::Table(_)) => None,
+        value => value,
+    }
+}
+
+fn get_string(name: &str, table: &Table, key: &str) -> Result<Option<String>, String> {
+    match property_value(table, key) {
         None => Ok(None),
         Some(Value::String(string)) => Ok(Some(string.clone())),
         Some(_) => Err(format!("{name}.{key} must be a string")),
@@ -1218,19 +1154,15 @@ fn get_string(name: &str, table: &Table, key: &str) -> Result<Option<String>, St
 }
 
 fn get_bool(name: &str, table: &Table, key: &str) -> Result<Option<bool>, String> {
-    match table.get(key) {
+    match property_value(table, key) {
         None => Ok(None),
         Some(Value::Boolean(value)) => Ok(Some(*value)),
         Some(_) => Err(format!("{name}.{key} must be a boolean")),
     }
 }
 
-fn get_unsigned_integer(
-    name: &str,
-    table: &Table,
-    key: &str,
-) -> Result<Option<i64>, String> {
-    match table.get(key) {
+fn get_unsigned_integer(name: &str, table: &Table, key: &str) -> Result<Option<i64>, String> {
+    match property_value(table, key) {
         None => Ok(None),
         Some(Value::Integer(value)) => {
             if *value < 0 {
@@ -1251,23 +1183,15 @@ fn get_pattern(name: &str, table: &Table) -> Result<Option<Regex>, String> {
         .map_err(|error| format!("{name} has invalid pattern: {error}"))
 }
 
-fn get_array_values(
-    name: &str,
-    table: &Table,
-    key: &str,
-) -> Result<Vec<Value>, String> {
-    match table.get(key) {
+fn get_array_values(name: &str, table: &Table, key: &str) -> Result<Vec<Value>, String> {
+    match property_value(table, key) {
         None => Ok(Vec::new()),
         Some(Value::Array(array)) => Ok(array.clone()),
         Some(_) => Err(format!("{name}.{key} must be an array")),
     }
 }
 
-fn get_string_array_values(
-    name: &str,
-    table: &Table,
-    key: &str,
-) -> Result<Vec<String>, String> {
+fn get_string_array_values(name: &str, table: &Table, key: &str) -> Result<Vec<String>, String> {
     let values = get_array_values(name, table, key)?;
     let mut result = Vec::with_capacity(values.len());
     for value in values {

--- a/reference-implementations/rust/tests/integration.rs
+++ b/reference-implementations/rust/tests/integration.rs
@@ -33,7 +33,10 @@ fn has_path(result: &ValidationResult, path: &str) -> bool {
 }
 
 fn capture(args: &[&str]) -> (u8, String, String) {
-    let owned: Vec<String> = args.iter().map(|argument| (*argument).to_string()).collect();
+    let owned: Vec<String> = args
+        .iter()
+        .map(|argument| (*argument).to_string())
+        .collect();
     let mut out = Cursor::new(Vec::new());
     let mut err = Cursor::new(Vec::new());
     let exit_code = run(&owned, &mut out, &mut err);
@@ -564,8 +567,8 @@ minlength = 2
 }
 
 #[test]
-fn supports_quoted_dotted_and_empty_keys_with_children_table() {
-    let directory = tempfile_dir("children-keys");
+fn supports_quoted_dotted_empty_and_schema_keyword_keys() {
+    let directory = tempfile_dir("special-keys");
     let schema_path = write_file(
         &directory,
         "schema.tosd",
@@ -573,14 +576,17 @@ fn supports_quoted_dotted_and_empty_keys_with_children_table() {
 [toml-schema]
 version = "1.0.0"
 
-[elements.site]
-type = "table"
-
-    [elements.site.children]
-    "google.com" = { type = "boolean" }
+[elements.""]
+type = "string"
 
 [elements.children]
-"" = { type = "string" }
+type = "string"
+
+[elements.site."google.com"]
+type = "boolean"
+
+[elements.plugin.type]
+type = "string"
 "#,
     );
     let document_path = write_file(
@@ -588,9 +594,13 @@ type = "table"
         "document.toml",
         r#"
 "" = "blank"
+children = "literal"
 
 [site]
 "google.com" = true
+
+[plugin]
+type = "npm"
 "#,
     );
 
@@ -631,8 +641,14 @@ location = "schema.tosd"
 
     let (exit_code, stdout, stderr) = capture(&["validate", document_path.to_str().unwrap()]);
 
-    assert_eq!(exit_code, 0, "expected exit code 0, got {exit_code}: {stderr}");
-    assert!(stdout.contains("is valid"), "expected valid output, got {stdout:?}");
+    assert_eq!(
+        exit_code, 0,
+        "expected exit code 0, got {exit_code}: {stderr}"
+    );
+    assert!(
+        stdout.contains("is valid"),
+        "expected valid output, got {stdout:?}"
+    );
 }
 
 #[test]
@@ -664,7 +680,10 @@ location = "ignored.tosd"
         extracted_schema.to_str().unwrap(),
     ]);
 
-    assert_eq!(exit_code, 0, "expected exit code 0, got {exit_code}: {stderr}");
+    assert_eq!(
+        exit_code, 0,
+        "expected exit code 0, got {exit_code}: {stderr}"
+    );
     assert!(
         stdout.contains("Extracted schema to"),
         "expected extract output, got {stdout:?}"

--- a/toml-schema.abnf
+++ b/toml-schema.abnf
@@ -19,13 +19,11 @@ types-table       = toml-table-header-types *schema-definition
 elements-table    = toml-table-header-elements 1*schema-definition
 metadata-table    = toml-table-header-toml-schema-meta *toml-keyval
 
-schema-definition = schema-definition-table *definition-property [ children-table ]
-children-table    = schema-children-table *children-entry
-children-entry    = toml-key keyval-sep toml-inline-table
+schema-definition = schema-definition-table *definition-property *schema-definition
 
 schema-key = type / typeof / arraytype / itemtype / items / oneof / anyof
            / allowedvalues / pattern / optional / default / min / max
-           / minlength / maxlength / children
+           / minlength / maxlength
 
 definition-property = type / typeof / arraytype / itemtype / items / oneof / anyof
                     / allowedvalues / pattern / optional / default / min / max
@@ -47,7 +45,6 @@ min           = "min" keyval-sep range-boundary
 max           = "max" keyval-sep range-boundary
 minlength     = "minlength" keyval-sep toml-integer ; strings count Unicode scalar values after TOML parsing
 maxlength     = "maxlength" keyval-sep toml-integer ; strings count Unicode scalar values after TOML parsing
-children      = "children"
 
 built-in-type = anytype / stringtype / integertype / floattype / booleantype
               / offsetdatetimetype / localdatetimetype / localdatetype / localtimetype
@@ -83,13 +80,11 @@ toml-table-header-types            = <TOML 1.0 table header for [types]>
 toml-table-header-elements         = <TOML 1.0 table header for [elements]>
 toml-table-header-toml-schema-meta = <TOML 1.0 table header under [toml-schema.meta]>
 schema-definition-table            = <TOML 1.0 table header under [types] or [elements]>
-schema-children-table              = <TOML 1.0 table header named children under a schema definition>
 toml-keyval                        = <TOML 1.0 key/value pair>
 toml-key                           = <TOML 1.0 key>
 toml-value                         = <TOML 1.0 value>
 toml-string                        = <TOML 1.0 string>
 toml-array                         = <TOML 1.0 array>
-toml-inline-table                  = <TOML 1.0 inline table>
 toml-boolean                       = <TOML 1.0 boolean>
 toml-integer                       = <TOML 1.0 integer>
 toml-float                         = <TOML 1.0 float>

--- a/toml-schema.tosd
+++ b/toml-schema.tosd
@@ -5,89 +5,10 @@ version = "1.0.0"
 # Types
 [types]
 
+    # Schema definitions are open tables here because the reference
+    # implementations enforce schema property types at load time.
     [types.schemaDef]
-    type = "collection"
-    typeof = "types.schemaDef"
-
-        [types.schemaDef.children.type]
-        type = "string"
-        allowedvalues = [ "array", "table", "collection", "any", "string", "integer", "float", "boolean", "offset-date-time", "local-date-time", "local-date", "local-time" ]
-        optional = true
-
-        [types.schemaDef.children.typeof]
-        type = "string"
-        optional = true
-        # Type reference: built-in type name or [types] definition name.
-
-        [types.schemaDef.children.arraytype]
-        type = "string"
-        allowedvalues = [ "any", "string", "integer", "float", "boolean", "offset-date-time", "local-date-time", "local-date", "local-time", "array", "table" ]
-        optional = true
-
-        [types.schemaDef.children.itemtype]
-        type = "string"
-        optional = true
-        # Type reference: built-in type name or [types] definition name.
-
-        [types.schemaDef.children.items]
-        type = "array"
-        arraytype = "string"
-        optional = true
-        # Each item is a type reference.
-
-        [types.schemaDef.children.allowedvalues]
-        type = "array"
-        arraytype = "any"
-        optional = true
-
-        [types.schemaDef.children.pattern]
-        type = "string"
-        optional = true
-
-        [types.schemaDef.children.optional]
-        type = "boolean"
-        optional = true
-
-        [types.schemaDef.children.default]
-        type = "any"
-        optional = true
-
-        [types.schemaDef.children.min]
-        type = "any"
-        optional = true
-
-        [types.schemaDef.children.max]
-        type = "any"
-        optional = true
-
-        [types.schemaDef.children.minlength]
-        type = "integer"
-        optional = true
-        min = 0
-        # For strings, this counts Unicode scalar values after TOML parsing.
-
-        [types.schemaDef.children.maxlength]
-        type = "integer"
-        optional = true
-        min = 1
-        # For strings, this counts Unicode scalar values after TOML parsing.
-
-        [types.schemaDef.children.oneof]
-        type = "array"
-        arraytype = "string"
-        optional = true
-        # Each item is a type reference.
-
-        [types.schemaDef.children.anyof]
-        type = "array"
-        arraytype = "string"
-        optional = true
-        # Each item is a type reference.
-
-        [types.schemaDef.children.children]
-        type = "collection"
-        typeof = "types.schemaDef"
-        optional = true
+    type = "table"
 
 # Elements
 [elements]


### PR DESCRIPTION
## Summary
- add a `pyproject.toml` TOML Schema example under `examples/pyproject.tosd`
- remove the `children` schema escape hatch from examples, SPEC, ABNF, self-schema, and reference implementations
- support normal TOML table paths for child keys that collide with schema property names, such as `pattern` and `type`
- keep quoted keys only for cases where TOML syntax requires quoting, such as literal dotted or empty keys

## Validation
- `git diff --check`
- `mvn -f reference-implementations/java/pom.xml test -q`
- `go -C reference-implementations/go test ./...`
- `cargo test --manifest-path reference-implementations/rust/Cargo.toml`
