### PR TITLE
Add visual TOML Schema (.tosd) editor canvas extension

### DIFF
--- a/.github/extensions/tosd-editor/client.js
+++ b/.github/extensions/tosd-editor/client.js
@@ -155,7 +155,7 @@ function updateValidityPill() {
 
 // --- Render orchestration -----------------------------------------------
 function renderAll() {
-    $("#path").textContent = state.path || "(new schema)";
+    $("#path").value = state.path || "";
     $("#path").title = state.path || "";
     renderDiagram();
     renderEditor();
@@ -829,18 +829,41 @@ function renderIssues() {
 function boot() {
     document.body.innerHTML = `
     <div class="toolbar">
-      <span class="title"><span class="brand-mark">◆</span> TOML Schema Editor</span>
-      <span class="path" id="path"></span>
-      <span class="pill" id="validity"></span>
-      <span class="spacer"></span>
-      <span class="status" id="status"></span>
-      <button id="new" title="Start a new, empty schema">New</button>
-      <button id="generate" title="Describe a config file and let Copilot generate the schema">&#10024; Generate</button>
-      <button id="infer" title="Generate a schema from a sample TOML document">Infer from TOML</button>
-      <button id="add-type">+ Type</button>
-      <button id="add-element">+ Element</button>
-      <button id="revert">Revert</button>
-      <button id="save" class="primary">Save</button>
+      <div class="tb-row tb-row-info">
+        <div class="tb-brand">
+          <span class="brand-mark">&#9670;</span>
+          <span class="brand-text">TOML Schema <b>Editor</b></span>
+        </div>
+        <span class="tb-sep"></span>
+        <div class="tb-info">
+          <input class="path-field mono" id="path" readonly title="" placeholder="(new schema)" />
+          <span class="pill" id="validity"></span>
+          <span class="status" id="status"></span>
+        </div>
+      </div>
+      <div class="tb-row tb-row-actions">
+        <div class="tb-actions">
+          <div class="tb-group">
+            <button id="add-element" class="btn"><span class="bi">+</span>Element</button>
+            <button id="add-type" class="btn"><span class="bi">+</span>Type</button>
+          </div>
+          <span class="tb-sep"></span>
+          <div class="tb-group">
+            <button id="generate" class="btn accent" title="Describe a config file and let Copilot generate the schema"><span class="bi">&#10024;</span>Generate</button>
+            <button id="infer" class="btn" title="Infer a schema from a sample TOML document">Infer from TOML</button>
+          </div>
+          <span class="tb-sep"></span>
+          <div class="tb-group">
+            <button id="new" class="btn" title="Start a new, empty schema"><span class="bi">&#10010;</span>New</button>
+            <button id="open" class="btn" title="Open an existing .tosd schema file"><span class="bi">&#128193;</span>Open</button>
+          </div>
+          <span class="spacer"></span>
+          <div class="tb-group">
+            <button id="revert" class="btn ghost" title="Discard changes and reload from disk">Revert</button>
+            <button id="save" class="btn primary" title="Save to disk">Save</button>
+          </div>
+        </div>
+      </div>
     </div>
     <div class="workspace">
       <div class="diagram-pane">
@@ -880,6 +903,7 @@ function boot() {
     $("#save").addEventListener("click", save);
     $("#revert").addEventListener("click", load);
     $("#new").addEventListener("click", newSchema);
+    $("#open").addEventListener("click", openSchema);
     $("#generate").addEventListener("click", openGenerateModal);
     $("#infer").addEventListener("click", openInferModal);
     $("#add-type").addEventListener("click", () => { state.view = "types"; addNode(state.model.types, ["types"]); });
@@ -1016,6 +1040,61 @@ function openGenerateModal() {
     overlay.addEventListener("click", (e) => { if (e.target === overlay) overlay.remove(); });
     document.body.append(overlay);
     ta.focus();
+}
+
+// --- Open existing schema modal ----------------------------------------
+function openSchema() {
+    const existing = $("#open-modal");
+    if (existing) existing.remove();
+
+    const overlay = el("div", { class: "modal-overlay", id: "open-modal" });
+    const dialog = el("div", { class: "modal" });
+    dialog.append(el("h3", { text: "\u{1F4C1} Open schema file" }));
+    dialog.append(el("p", { class: "hint", text: "Enter the path to an existing .tosd schema file (absolute or workspace-relative). It will be loaded into the editor, replacing the current schema." }));
+
+    const errBox = el("div", { class: "modal-err" });
+
+    const doOpen = async (input, openBtn) => {
+        const p = input.value.trim();
+        if (!p) { errBox.textContent = "Enter a file path."; return; }
+        errBox.textContent = "Opening\u2026";
+        if (openBtn) openBtn.disabled = true;
+        try {
+            const res = await fetch("open", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ path: p }),
+            });
+            const data = await res.json();
+            if (data.error) { errBox.textContent = data.error; if (openBtn) openBtn.disabled = false; return; }
+            state.path = data.path;
+            state.model = data.model;
+            state.dirty = false;
+            state.selected = (state.model.elements[0] || state.model.types[0]) ?? null;
+            renderAll();
+            schedulePreview();
+            overlay.remove();
+        } catch (e) { errBox.textContent = e.message; if (openBtn) openBtn.disabled = false; }
+    };
+
+    const pathRow = el("div", { class: "list-row" });
+    const pathInput = el("input", { type: "text", class: "mono", placeholder: "path/to/schema.tosd" });
+    pathInput.addEventListener("keydown", (e) => { if (e.key === "Enter") { e.preventDefault(); doOpen(pathInput, openBtn); } });
+    pathRow.append(pathInput);
+    dialog.append(pathRow);
+    dialog.append(errBox);
+
+    const actions = el("div", { class: "modal-actions" });
+    actions.append(el("button", { text: "Cancel", onclick: () => overlay.remove() }));
+    const openBtn = el("button", { class: "primary", text: "Open" });
+    openBtn.addEventListener("click", () => doOpen(pathInput, openBtn));
+    actions.append(openBtn);
+    dialog.append(actions);
+
+    overlay.append(dialog);
+    overlay.addEventListener("click", (e) => { if (e.target === overlay) overlay.remove(); });
+    document.body.append(overlay);
+    pathInput.focus();
 }
 
 // --- Infer-from-TOML modal ---------------------------------------------

--- a/.github/extensions/tosd-editor/client.js
+++ b/.github/extensions/tosd-editor/client.js
@@ -834,6 +834,7 @@ function boot() {
       <span class="spacer"></span>
       <span class="status" id="status"></span>
       <button id="new" title="Start a new, empty schema">New</button>
+      <button id="generate" title="Describe a config file and let Copilot generate the schema">&#10024; Generate</button>
       <button id="infer" title="Generate a schema from a sample TOML document">Infer from TOML</button>
       <button id="add-type">+ Type</button>
       <button id="add-element">+ Element</button>
@@ -878,6 +879,7 @@ function boot() {
     $("#save").addEventListener("click", save);
     $("#revert").addEventListener("click", load);
     $("#new").addEventListener("click", newSchema);
+    $("#generate").addEventListener("click", openGenerateModal);
     $("#infer").addEventListener("click", openInferModal);
     $("#add-type").addEventListener("click", () => { state.view = "types"; addNode(state.model.types, ["types"]); });
     $("#add-element").addEventListener("click", () => { state.view = "elements"; addNode(state.model.elements, ["elements"]); });
@@ -892,14 +894,44 @@ function boot() {
     $("#prop-close").addEventListener("click", clearSelection);
 
     $("#diagram").addEventListener("click", (e) => {
+        if (suppressDiagramClick) { suppressDiagramClick = false; return; }
         if (e.target.closest(".dg-box, .dg-root, .dg-comp, button")) return;
         if (state.selected) clearSelection();
     });
     document.addEventListener("keydown", (e) => {
         if (e.key === "Escape" && state.selected && !document.querySelector(".modal-overlay")) clearSelection();
     });
+    setupPanning();
 
     load();
+}
+
+// --- Pan / hand tool ----------------------------------------------------
+let suppressDiagramClick = false;
+function setupPanning() {
+    const dg = $("#diagram");
+    let pan = null;
+    dg.addEventListener("mousedown", (e) => {
+        if (e.button !== 0) return;
+        if (e.target.closest(".dg-box, .dg-root, .dg-comp, button, input, textarea")) return;
+        pan = { x: e.clientX, y: e.clientY, sl: dg.scrollLeft, st: dg.scrollTop, moved: false };
+        dg.classList.add("panning");
+        e.preventDefault();
+    });
+    window.addEventListener("mousemove", (e) => {
+        if (!pan) return;
+        const dx = e.clientX - pan.x;
+        const dy = e.clientY - pan.y;
+        if (Math.abs(dx) + Math.abs(dy) > 3) pan.moved = true;
+        dg.scrollLeft = pan.sl - dx;
+        dg.scrollTop = pan.st - dy;
+    });
+    window.addEventListener("mouseup", () => {
+        if (!pan) return;
+        if (pan.moved) suppressDiagramClick = true;
+        pan = null;
+        dg.classList.remove("panning");
+    });
 }
 
 function clearSelection() {
@@ -915,6 +947,74 @@ function newSchema() {
     state.selected = "__meta__";
     markDirty();
     renderAll();
+}
+
+// --- Generate-with-Copilot modal ---------------------------------------
+function openGenerateModal() {
+    const existing = $("#generate-modal");
+    if (existing) existing.remove();
+
+    const overlay = el("div", { class: "modal-overlay", id: "generate-modal" });
+    const dialog = el("div", { class: "modal" });
+    dialog.append(el("h3", { text: "\u2728 Generate schema with Copilot" }));
+    dialog.append(el("p", { class: "hint", text: "Describe the configuration file you want a schema for \u2014 its sections, fields, and any constraints. Copilot will draft the TOML Schema. The result replaces the current schema (not saved until you click Save)." }));
+
+    const ta = el("textarea", {
+        class: "modal-textarea",
+        placeholder: "e.g. A web service config with a [server] section (host string, port integer 1-65535), a [database] table with url and pool_size, an optional [logging] section with level one of debug/info/warn/error, and a list of [[routes]] each having path and handler.",
+    });
+    dialog.append(ta);
+
+    const errBox = el("div", { class: "modal-err" });
+    dialog.append(errBox);
+
+    const actions = el("div", { class: "modal-actions" });
+    const cancelBtn = el("button", { text: "Cancel", onclick: () => overlay.remove() });
+    const genBtn = el("button", { class: "primary", text: "Generate" });
+    genBtn.addEventListener("click", async () => {
+        const description = ta.value.trim();
+        if (!description) { errBox.textContent = "Describe the configuration first."; return; }
+        genBtn.disabled = true;
+        cancelBtn.disabled = true;
+        ta.disabled = true;
+        errBox.className = "modal-err working";
+        errBox.textContent = "Asking Copilot\u2026 this runs a Copilot turn and may take a moment.";
+        try {
+            const res = await fetch("generate", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ description }),
+            });
+            const data = await res.json();
+            if (data.error) {
+                errBox.className = "modal-err";
+                errBox.textContent = data.error;
+                genBtn.disabled = false;
+                cancelBtn.disabled = false;
+                ta.disabled = false;
+                return;
+            }
+            state.model = data.model;
+            state.view = "elements";
+            state.selected = (state.model.elements[0] || state.model.types[0]) ?? null;
+            markDirty();
+            renderAll();
+            overlay.remove();
+        } catch (e) {
+            errBox.className = "modal-err";
+            errBox.textContent = e.message;
+            genBtn.disabled = false;
+            cancelBtn.disabled = false;
+            ta.disabled = false;
+        }
+    });
+    actions.append(cancelBtn, genBtn);
+    dialog.append(actions);
+
+    overlay.append(dialog);
+    overlay.addEventListener("click", (e) => { if (e.target === overlay) overlay.remove(); });
+    document.body.append(overlay);
+    ta.focus();
 }
 
 // --- Infer-from-TOML modal ---------------------------------------------

--- a/.github/extensions/tosd-editor/client.js
+++ b/.github/extensions/tosd-editor/client.js
@@ -1,0 +1,982 @@
+// tosd-editor client SPA. Plain DOM, no build step. Talks to the extension's
+// loopback server: GET /state, POST /preview (model -> toml + issues),
+// POST /save (persist model to disk).
+
+const BUILTIN_TYPES = [
+    "any",
+    "string",
+    "integer",
+    "float",
+    "boolean",
+    "offset-date-time",
+    "local-date-time",
+    "local-date",
+    "local-time",
+    "array",
+    "table",
+    "collection",
+];
+const SIMPLE_TYPES = [
+    "any",
+    "string",
+    "integer",
+    "float",
+    "boolean",
+    "offset-date-time",
+    "local-date-time",
+    "local-date",
+    "local-time",
+];
+const NUMERIC_TEMPORAL = [
+    "integer",
+    "float",
+    "offset-date-time",
+    "local-date-time",
+    "local-date",
+    "local-time",
+];
+const ARRAY_TYPES = BUILTIN_TYPES.filter((t) => t !== "collection");
+
+const state = {
+    path: null,
+    model: null,
+    selected: null,
+    dirty: false,
+    showAll: false,
+    previewTab: "toml",
+    lastIssues: [],
+    view: "elements",
+    zoom: 1,
+};
+
+const $ = (sel, root = document) => root.querySelector(sel);
+function el(tag, attrs = {}, ...kids) {
+    const node = document.createElement(tag);
+    for (const [k, v] of Object.entries(attrs)) {
+        if (k === "class") node.className = v;
+        else if (k === "text") node.textContent = v;
+        else if (k.startsWith("on") && typeof v === "function") node.addEventListener(k.slice(2), v);
+        else if (v != null) node.setAttribute(k, v);
+    }
+    for (const kid of kids) {
+        if (kid == null) continue;
+        node.append(kid.nodeType ? kid : document.createTextNode(kid));
+    }
+    return node;
+}
+
+// --- Networking ---------------------------------------------------------
+async function load() {
+    const res = await fetch("state");
+    const data = await res.json();
+    state.path = data.path;
+    state.model = data.model;
+    state.dirty = false;
+    state.selected = (state.model.elements[0] || state.model.types[0]) ?? null;
+    renderAll();
+    schedulePreview();
+}
+
+let previewTimer = null;
+function schedulePreview() {
+    clearTimeout(previewTimer);
+    previewTimer = setTimeout(refreshPreview, 200);
+}
+
+async function refreshPreview() {
+    try {
+        const res = await fetch("preview", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(state.model),
+        });
+        const data = await res.json();
+        state.lastIssues = data.issues || [];
+        $("#preview").textContent = data.toml || "";
+        renderIssues();
+        updateValidityPill();
+    } catch (e) {
+        $("#preview").textContent = "// preview error: " + e.message;
+    }
+}
+
+async function save() {
+    const btn = $("#save");
+    btn.disabled = true;
+    try {
+        const res = await fetch("save", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(state.model),
+        });
+        const data = await res.json();
+        if (data.ok) {
+            state.dirty = false;
+            updateStatus("saved", "Saved");
+        } else {
+            updateStatus("dirty", "Save failed: " + (data.error || "unknown"));
+        }
+    } catch (e) {
+        updateStatus("dirty", "Save failed: " + e.message);
+    } finally {
+        btn.disabled = false;
+    }
+}
+
+function markDirty() {
+    state.dirty = true;
+    updateStatus("dirty", "Unsaved changes");
+    schedulePreview();
+}
+
+// --- Status / header ----------------------------------------------------
+function updateStatus(cls, text) {
+    const s = $("#status");
+    s.className = "status " + cls;
+    s.textContent = text;
+    $("#save").disabled = !state.dirty;
+}
+
+function updateValidityPill() {
+    const errs = state.lastIssues.filter((i) => i.level === "error").length;
+    const warns = state.lastIssues.filter((i) => i.level === "warning").length;
+    const pill = $("#validity");
+    if (errs > 0) {
+        pill.className = "pill err";
+        pill.textContent = `${errs} error${errs > 1 ? "s" : ""}`;
+    } else if (warns > 0) {
+        pill.className = "pill";
+        pill.textContent = `${warns} warning${warns > 1 ? "s" : ""}`;
+    } else {
+        pill.className = "pill ok";
+        pill.textContent = "valid";
+    }
+}
+
+// --- Render orchestration -----------------------------------------------
+function renderAll() {
+    $("#path").textContent = state.path || "(new schema)";
+    $("#path").title = state.path || "";
+    renderDiagram();
+    renderEditor();
+    updateStatus(state.dirty ? "dirty" : "saved", state.dirty ? "Unsaved changes" : "No changes");
+}
+
+// Back-compat alias: existing mutations call renderTree().
+function renderTree() {
+    renderDiagram();
+}
+
+function typeBadge(node) {
+    const p = node.props || {};
+    if (p.type) return p.type;
+    if (p.typeof) return "→ " + p.typeof.replace(/^types\./, "");
+    if (p.oneof) return "oneof";
+    if (p.anyof) return "anyof";
+    if (node.children && node.children.length) return "table";
+    return "?";
+}
+
+function typeCategory(node) {
+    const p = node.props || {};
+    const t = p.type;
+    if (t === "string") return "string";
+    if (t === "integer" || t === "float" || t === "number") return "number";
+    if (t === "boolean") return "boolean";
+    if (t === "datetime" || t === "date" || t === "time" || t === "offset-datetime" || t === "local-datetime" || t === "local-date" || t === "local-time") return "date";
+    if (t === "table" || t === "collection") return "table";
+    if (t === "array") return "array";
+    if (p.typeof) return "ref";
+    if (p.oneof || p.anyof) return "choice";
+    if (node.children && node.children.length) return "table";
+    return "any";
+}
+
+// --- Diagram (design view) ----------------------------------------------
+const DG = { BOX_W: 214, BOX_H: 58, H_GAP: 62, V_GAP: 16, PAD: 24 };
+
+function cardinality(node) {
+    const p = node.props || {};
+    const many = p.type === "array" || p.type === "collection";
+    if (many) {
+        const lo = p.minlength != null ? p.minlength : (p.optional ? 0 : 1);
+        const hi = p.maxlength != null ? p.maxlength : "\u221e";
+        return `${lo}\u2026${hi}`;
+    }
+    return p.optional ? "0\u20261" : "1";
+}
+
+function compositor(node) {
+    const p = node.props || {};
+    if (p.type === "array" || p.type === "collection") return { glyph: "\u21bb", cls: "repeat", title: "repeating items" };
+    if (p.oneof) return { glyph: "\u25c8", cls: "choice", title: "one of" };
+    if (p.anyof) return { glyph: "\u25c6", cls: "choice", title: "any of" };
+    return { glyph: "\u2630", cls: "sequence", title: "sequence" };
+}
+
+function visKids(n) {
+    if (n.__root) return n.children;
+    return n.__collapsed ? [] : (n.children || []);
+}
+
+function renderDiagram() {
+    const host = $("#diagram");
+    if (!host) return;
+    host.textContent = "";
+
+    const view = state.view || "elements";
+    document.querySelectorAll(".vtab").forEach((b) => b.classList.toggle("active", b.dataset.view === view));
+
+    const roots = state.model[view] || [];
+    const root = { __root: true, name: view, children: roots, props: {} };
+
+    const placed = [];
+    const links = [];
+    let cursorY = DG.PAD;
+
+    function layout(node, depth) {
+        const x = DG.PAD + depth * (DG.BOX_W + DG.H_GAP);
+        const kids = visKids(node);
+        let y;
+        if (!kids || kids.length === 0) {
+            y = cursorY + DG.BOX_H / 2;
+            cursorY += DG.BOX_H + DG.V_GAP;
+        } else {
+            const ys = kids.map((k) => layout(k, depth + 1));
+            y = (ys[0] + ys[ys.length - 1]) / 2;
+        }
+        node.__x = x;
+        node.__cy = y;
+        placed.push({ node, depth });
+        for (const k of kids) links.push({ from: node, to: k });
+        return y;
+    }
+    layout(root, 0);
+
+    let maxX = 0, maxY = 0;
+    for (const { node } of placed) {
+        maxX = Math.max(maxX, node.__x + DG.BOX_W);
+        maxY = Math.max(maxY, node.__cy + DG.BOX_H / 2);
+    }
+    const totalW = maxX + DG.PAD;
+    const totalH = Math.max(maxY + DG.PAD, cursorY + DG.PAD);
+    state.__totalW = totalW;
+    state.__totalH = totalH;
+
+    const inner = el("div", { class: "diagram-inner" });
+    inner.style.width = totalW + "px";
+    inner.style.height = totalH + "px";
+    inner.style.transform = "scale(" + (state.zoom || 1) + ")";
+
+    const SVGNS = "http://www.w3.org/2000/svg";
+    const svg = document.createElementNS(SVGNS, "svg");
+    svg.setAttribute("class", "dg-links");
+    svg.setAttribute("width", totalW);
+    svg.setAttribute("height", totalH);
+    for (const { from, to } of links) {
+        const x1 = from.__x + DG.BOX_W;
+        const y1 = from.__cy;
+        const x2 = to.__x;
+        const y2 = to.__cy;
+        const midX = x1 + DG.H_GAP / 2;
+        const path = document.createElementNS(SVGNS, "path");
+        path.setAttribute("d", `M ${x1} ${y1} H ${midX} V ${y2} H ${x2}`);
+        path.setAttribute("class", "dg-link" + (state.selected === to ? " active" : ""));
+        svg.appendChild(path);
+    }
+    inner.appendChild(svg);
+
+    for (const { node } of placed) {
+        const kids = visKids(node);
+        if (node.__root || !kids.length) continue;
+        const c = compositor(node);
+        const chip = el("div", { class: "dg-comp " + c.cls, title: c.title, text: c.glyph });
+        chip.style.left = (node.__x + DG.BOX_W + DG.H_GAP / 2 - 11) + "px";
+        chip.style.top = (node.__cy - 11) + "px";
+        inner.appendChild(chip);
+    }
+
+    for (const { node } of placed) {
+        inner.appendChild(node.__root ? rootBox(node) : diagramBox(node));
+    }
+
+    host.appendChild(inner);
+
+    if (!roots.length) {
+        const empty = el("div", { class: "dg-empty" });
+        empty.append(el("p", { text: "No " + view + " defined yet." }));
+        empty.append(el("button", {
+            class: "primary",
+            text: "+ Add " + (view === "types" ? "type" : "element"),
+            onclick: () => addNode(state.model[view], [view]),
+        }));
+        host.appendChild(empty);
+    }
+
+    const zl = $("#zoom-label");
+    if (zl) zl.textContent = Math.round((state.zoom || 1) * 100) + "%";
+    refreshTypeRefs();
+}
+
+function rootBox(node) {
+    const box = el("div", { class: "dg-root" });
+    box.style.left = node.__x + "px";
+    box.style.top = (node.__cy - DG.BOX_H / 2) + "px";
+    box.style.width = DG.BOX_W + "px";
+    box.style.height = DG.BOX_H + "px";
+    box.append(el("span", { class: "dg-root-label", text: "[" + node.name + "]" }));
+    const n = node.children.length;
+    box.append(el("span", { class: "dg-root-sub", text: n + " " + (n === 1 ? "entry" : "entries") }));
+    return box;
+}
+
+function diagramBox(node) {
+    const p = node.props || {};
+    const box = el("div", {
+        class: "dg-box" + (state.selected === node ? " selected" : "") + (p.optional ? " optional" : ""),
+        "data-cat": typeCategory(node),
+    });
+    box.style.left = node.__x + "px";
+    box.style.top = (node.__cy - DG.BOX_H / 2) + "px";
+    box.style.width = DG.BOX_W + "px";
+    box.style.height = DG.BOX_H + "px";
+    box.addEventListener("click", (e) => {
+        if (e.target.closest("button")) return;
+        selectNode(node);
+    });
+
+    const top = el("div", { class: "dg-top" });
+    top.append(el("span", { class: "dg-accent" }));
+    top.append(el("span", { class: "dg-name", text: node.name }));
+    top.append(el("span", { class: "dg-card", title: "cardinality", text: cardinality(node) }));
+    box.append(top);
+
+    const typeLine = el("div", { class: "dg-typeline" });
+    typeLine.append(el("span", { class: "dg-type", "data-cat": typeCategory(node), text: typeBadge(node) }));
+    if (p.typeof) {
+        typeLine.append(el("button", {
+            class: "dg-jump",
+            title: "Jump to " + p.typeof,
+            text: "\u2197",
+            onclick: (e) => { e.stopPropagation(); jumpToType(p.typeof); },
+        }));
+    }
+    box.append(typeLine);
+
+    const kids = node.children || [];
+    if (kids.length) {
+        box.append(el("button", {
+            class: "dg-expander",
+            text: node.__collapsed ? "+" : "\u2013",
+            title: node.__collapsed ? "Expand" : "Collapse",
+            onclick: (e) => { e.stopPropagation(); node.__collapsed = !node.__collapsed; renderDiagram(); },
+        }));
+    }
+
+    const acts = el("div", { class: "dg-actions" });
+    acts.append(el("button", { class: "icon", title: "Add child field", text: "+", onclick: (e) => { e.stopPropagation(); addChild(node); } }));
+    acts.append(el("button", { class: "icon", title: "Move up", text: "\u2191", onclick: (e) => { e.stopPropagation(); moveNode(node, -1); } }));
+    acts.append(el("button", { class: "icon", title: "Move down", text: "\u2193", onclick: (e) => { e.stopPropagation(); moveNode(node, 1); } }));
+    acts.append(el("button", { class: "icon danger", title: "Delete " + node.name, text: "\u2715", onclick: (e) => { e.stopPropagation(); deleteNode(node); } }));
+    box.append(acts);
+
+    return box;
+}
+
+function selectNode(node) {
+    state.selected = node;
+    renderDiagram();
+    renderEditor();
+}
+
+function jumpToType(ref) {
+    const name = String(ref).replace(/^types\./, "");
+    const target = (state.model.types || []).find((t) => t.name === name);
+    if (!target) return;
+    state.view = "types";
+    selectNode(target);
+}
+
+function moveNode(node, dir) {
+    const findList = (list) => {
+        if (list.includes(node)) return list;
+        for (const n of list) {
+            if (n.children) {
+                const r = findList(n.children);
+                if (r) return r;
+            }
+        }
+        return null;
+    };
+    const list = findList(state.model.elements) || findList(state.model.types);
+    if (!list) return;
+    const i = list.indexOf(node);
+    const j = i + dir;
+    if (j < 0 || j >= list.length) return;
+    [list[i], list[j]] = [list[j], list[i]];
+    markDirty();
+    renderDiagram();
+}
+
+function setZoom(z) {
+    state.zoom = Math.min(2, Math.max(0.3, z));
+    renderDiagram();
+}
+
+function fitZoom() {
+    const host = $("#diagram");
+    if (!host || !state.__totalW) return;
+    const z = Math.min(
+        (host.clientWidth - 16) / state.__totalW,
+        (host.clientHeight - 16) / state.__totalH,
+        1.4,
+    );
+    setZoom(z);
+}
+
+// --- Mutations ----------------------------------------------------------
+function uniqueName(siblings, base) {
+    let name = base;
+    let i = 1;
+    const taken = new Set(siblings.map((s) => s.name));
+    while (taken.has(name)) name = `${base}${++i}`;
+    return name;
+}
+
+function addNode(siblings, basePath) {
+    const isType = basePath[basePath.length - 1] === "types";
+    const node = {
+        name: uniqueName(siblings, isType ? "newType" : "newField"),
+        props: { type: "string" },
+        children: [],
+    };
+    siblings.push(node);
+    state.selected = node;
+    markDirty();
+    renderTree();
+    renderEditor();
+}
+
+function addChild(node) {
+    node.props = node.props || {};
+    if (!node.props.type && !node.props.typeof && !node.props.oneof && !node.props.anyof) {
+        node.props.type = "table";
+    }
+    const child = { name: uniqueName(node.children, "field"), props: { type: "string" }, children: [] };
+    node.children.push(child);
+    node.__collapsed = false;
+    state.selected = child;
+    markDirty();
+    renderTree();
+    renderEditor();
+}
+
+function deleteNode(node) {
+    const removeFrom = (list) => {
+        const idx = list.indexOf(node);
+        if (idx >= 0) {
+            list.splice(idx, 1);
+            return true;
+        }
+        return list.some((n) => n.children && removeFrom(n.children));
+    };
+    removeFrom(state.model.types);
+    removeFrom(state.model.elements);
+    if (state.selected === node) state.selected = null;
+    markDirty();
+    renderTree();
+    renderEditor();
+}
+
+// --- Editor -------------------------------------------------------------
+function renderEditor() {
+    const box = $("#editor");
+    box.textContent = "";
+    const closeBtn = $("#prop-close");
+    if (closeBtn) closeBtn.hidden = !state.selected;
+    if (state.selected === "__meta__") return renderMetaEditor(box);
+    const node = state.selected;
+    if (!node) {
+        box.append(el("div", { class: "empty", text: "Select a type or element on the left, or add a new one." }));
+        return;
+    }
+
+    const p = (node.props = node.props || {});
+
+    // Header: name + actions
+    const header = el("div", { class: "field" });
+    header.append(el("label", { text: "Name" }));
+    const nameInput = el("input", {
+        type: "text",
+        class: "mono",
+        value: node.name,
+        oninput: (e) => {
+            node.name = e.target.value;
+            markDirty();
+            // update diagram label lazily (avoid full re-render to keep focus)
+            const sel = document.querySelector(".dg-box.selected .dg-name");
+            if (sel) sel.textContent = node.name;
+        },
+    });
+    header.append(nameInput);
+    box.append(header);
+
+    const actions = el("div", { class: "field inline" });
+    actions.append(el("button", { text: "+ Add child", onclick: () => addChild(node) }));
+    actions.append(el("button", { class: "danger", text: "Delete", onclick: () => deleteNode(node) }));
+    box.append(actions);
+
+    // Type selector
+    box.append(
+        selectField("Type", p.type || "", ["", ...BUILTIN_TYPES], (v) => {
+            if (v) p.type = v;
+            else delete p.type;
+            renderEditor();
+            markDirty();
+        }, "The built-in kind of this definition."),
+    );
+
+    const t = p.type;
+
+    // typeof (reference) - relevant when no concrete type, or for collection items
+    if (!t || t === "collection") {
+        box.append(refField("typeof", "Type reference", p.typeof || "", (v) => setProp(p, "typeof", v)));
+    }
+
+    // Array-specific
+    if (t === "array") {
+        box.append(
+            selectField("arraytype", p.arraytype || "", ["", ...ARRAY_TYPES], (v) => setProp(p, "arraytype", v),
+                "Built-in type of each array item."),
+        );
+        box.append(refField("itemtype", "Item type (reference)", p.itemtype || "", (v) => setProp(p, "itemtype", v),
+            "Validate each item against a reusable type (required for arrays of tables)."));
+        box.append(listField("items", "Positional items (tuple)", p.items || [], (arr) => setListProp(p, "items", arr),
+            true, "Ordered type refs; fixed arity. Mutually exclusive with arraytype/itemtype."));
+    }
+
+    // collection alternatives
+    if (t === "collection" || p.oneof || p.anyof) {
+        box.append(listField("oneof", "oneof (exactly one)", p.oneof || [], (arr) => setListProp(p, "oneof", arr), true));
+        box.append(listField("anyof", "anyof (at least one)", p.anyof || [], (arr) => setListProp(p, "anyof", arr), true));
+    }
+
+    // string pattern + allowedvalues for simple types
+    if (t === "string") {
+        box.append(textField("pattern", "Pattern (regex)", p.pattern || "", (v) => setProp(p, "pattern", v), true,
+            "PCRE-compatible regular expression."));
+    }
+    if (SIMPLE_TYPES.includes(t) || t === "array") {
+        box.append(listField("allowedvalues", "Allowed values (enum)", p.allowedvalues || [],
+            (arr) => setListProp(p, "allowedvalues", arr), false,
+            "TOML value tokens, e.g. \"red\" or 80."));
+    }
+
+    // min / max for numeric/temporal (or arrays thereof)
+    const showRange = NUMERIC_TEMPORAL.includes(t) || (t === "array" && NUMERIC_TEMPORAL.includes(p.arraytype));
+    if (showRange) {
+        const row = el("div", { class: "row-2" });
+        row.append(textField("min", "min", p.min || "", (v) => setProp(p, "min", v), true));
+        row.append(textField("max", "max", p.max || "", (v) => setProp(p, "max", v), true));
+        box.append(row);
+    }
+
+    // length for string/array/collection
+    if (["string", "array", "collection"].includes(t)) {
+        const row = el("div", { class: "row-2" });
+        row.append(numField("minlength", "minlength", p.minlength, (v) => setNumProp(p, "minlength", v)));
+        row.append(numField("maxlength", "maxlength", p.maxlength, (v) => setNumProp(p, "maxlength", v)));
+        box.append(row);
+    }
+
+    // optional + default (always available)
+    box.append(checkboxField("optional", "Optional (may be omitted in the document)", !!p.optional, (v) => {
+        if (v) p.optional = true;
+        else delete p.optional;
+        markDirty();
+        renderTree();
+    }));
+    box.append(textField("default", "Default value (TOML token)", p.default || "", (v) => setProp(p, "default", v), true));
+
+    // Show-all advanced toggle
+    const toggle = el("button", {
+        class: "toggle-all",
+        text: state.showAll ? "Hide advanced properties" : "Show all properties",
+        onclick: () => {
+            state.showAll = !state.showAll;
+            renderEditor();
+        },
+    });
+    box.append(toggle);
+    if (state.showAll) box.append(advancedAll(p));
+
+    if (t === "table") {
+        box.append(el("div", { class: "field hint", text: "Table fields are managed as children in the tree. A table with no children is treated as open-ended." }));
+    }
+}
+
+function advancedAll(p) {
+    const wrap = el("div");
+    wrap.append(el("div", { class: "section-title", text: "All properties" }));
+    const allProps = ["type", "typeof", "arraytype", "itemtype", "pattern", "min", "max", "default"];
+    for (const key of allProps) {
+        wrap.append(textField(key, key, p[key] != null ? String(p[key]) : "", (v) => setProp(p, key, v), true));
+    }
+    for (const key of ["minlength", "maxlength"]) {
+        wrap.append(numField(key, key, p[key], (v) => setNumProp(p, key, v)));
+    }
+    for (const key of ["items", "oneof", "anyof", "allowedvalues"]) {
+        wrap.append(listField(key, key, p[key] || [], (arr) => setListProp(p, key, arr), key !== "allowedvalues"));
+    }
+    return wrap;
+}
+
+function setProp(p, key, v) {
+    if (v == null || v === "") delete p[key];
+    else p[key] = v;
+    markDirty();
+}
+function setNumProp(p, key, v) {
+    if (v === "" || v == null || Number.isNaN(v)) delete p[key];
+    else p[key] = v;
+    markDirty();
+}
+function setListProp(p, key, arr) {
+    const clean = arr.filter((s) => s !== "");
+    if (clean.length === 0) delete p[key];
+    else p[key] = clean;
+    markDirty();
+    renderTree();
+}
+
+// --- Field builders -----------------------------------------------------
+function textField(name, label, value, onchange, mono = false, hint) {
+    const f = el("div", { class: "field" });
+    f.append(labelEl(label, hint));
+    f.append(el("input", {
+        type: "text",
+        class: mono ? "mono" : "",
+        value,
+        placeholder: name,
+        oninput: (e) => onchange(e.target.value),
+    }));
+    return f;
+}
+
+function numField(name, label, value, onchange) {
+    const f = el("div", { class: "field" });
+    f.append(labelEl(label));
+    f.append(el("input", {
+        type: "number",
+        value: value != null ? value : "",
+        placeholder: name,
+        oninput: (e) => onchange(e.target.value === "" ? "" : Number(e.target.value)),
+    }));
+    return f;
+}
+
+function selectField(label, value, options, onchange, hint) {
+    const f = el("div", { class: "field" });
+    f.append(labelEl(label, hint));
+    const sel = el("select", { onchange: (e) => onchange(e.target.value) });
+    for (const opt of options) {
+        const o = el("option", { value: opt, text: opt === "" ? "(none)" : opt });
+        if (opt === value) o.selected = true;
+        sel.append(o);
+    }
+    f.append(sel);
+    return f;
+}
+
+function checkboxField(name, label, checked, onchange) {
+    const f = el("div", { class: "field inline" });
+    const cb = el("input", { type: "checkbox", onchange: (e) => onchange(e.target.checked) });
+    cb.checked = checked;
+    f.append(cb);
+    f.append(el("label", { text: label }));
+    return f;
+}
+
+function refField(name, label, value, onchange, hint) {
+    const f = el("div", { class: "field" });
+    f.append(labelEl(label, hint));
+    const input = el("input", {
+        type: "text",
+        class: "mono",
+        value,
+        placeholder: name,
+        list: "type-refs",
+        oninput: (e) => onchange(e.target.value),
+    });
+    f.append(input);
+    return f;
+}
+
+function listField(name, label, values, onchange, isRef, hint) {
+    const f = el("div", { class: "field" });
+    f.append(labelEl(label, hint));
+    const arr = [...values];
+    const container = el("div");
+    const rerender = () => {
+        container.textContent = "";
+        arr.forEach((val, idx) => {
+            const row = el("div", { class: "list-row" });
+            row.append(el("input", {
+                type: "text",
+                class: "mono",
+                value: val,
+                list: isRef ? "type-refs" : null,
+                oninput: (e) => {
+                    arr[idx] = e.target.value;
+                    onchange([...arr]);
+                },
+            }));
+            row.append(el("button", {
+                class: "icon danger",
+                text: "✕",
+                onclick: () => {
+                    arr.splice(idx, 1);
+                    onchange([...arr]);
+                    rerender();
+                },
+            }));
+            container.append(row);
+        });
+    };
+    rerender();
+    f.append(container);
+    f.append(el("button", {
+        class: "icon",
+        text: "+ add",
+        onclick: () => {
+            arr.push("");
+            onchange([...arr]);
+            rerender();
+        },
+    }));
+    return f;
+}
+
+function labelEl(text, hint) {
+    const l = el("label", {}, text);
+    if (hint) l.append(el("span", { class: "hint", text: hint }));
+    return l;
+}
+
+function refreshTypeRefs() {
+    const dl = $("#type-refs");
+    dl.textContent = "";
+    for (const b of BUILTIN_TYPES) dl.append(el("option", { value: b }));
+    for (const t of state.model.types) dl.append(el("option", { value: "types." + t.name }));
+}
+
+// --- Meta editor --------------------------------------------------------
+function renderMetaEditor(box) {
+    box.append(el("div", { class: "section-title", text: "Schema metadata" }));
+    box.append(textField("version", "version (SemVer)", state.model.version || "1.0.0", (v) => {
+        state.model.version = v;
+        markDirty();
+    }, true, "Full MAJOR.MINOR.PATCH, e.g. 1.0.0"));
+
+    box.append(el("div", { class: "section-title", text: "[toml-schema.meta] (custom metadata)" }));
+    const meta = state.model.meta || {};
+    const entries = Object.entries(meta).filter(([, v]) => typeof v !== "object" || v.__datetime || v.__inline || Array.isArray(v));
+    const container = el("div");
+    const arr = entries.map(([k, v]) => [k, typeof v === "string" ? v : JSON.stringify(v)]);
+    const commit = () => {
+        const obj = {};
+        for (const [k, v] of arr) {
+            if (k === "") continue;
+            obj[k] = v;
+        }
+        state.model.meta = Object.keys(obj).length ? obj : null;
+        markDirty();
+    };
+    const rerender = () => {
+        container.textContent = "";
+        arr.forEach((pair, idx) => {
+            const row = el("div", { class: "list-row" });
+            row.append(el("input", { type: "text", class: "mono", value: pair[0], placeholder: "key",
+                oninput: (e) => { arr[idx][0] = e.target.value; commit(); } }));
+            row.append(el("input", { type: "text", class: "mono", value: pair[1], placeholder: "value",
+                oninput: (e) => { arr[idx][1] = e.target.value; commit(); } }));
+            row.append(el("button", { class: "icon danger", text: "✕",
+                onclick: () => { arr.splice(idx, 1); commit(); rerender(); } }));
+            container.append(row);
+        });
+    };
+    rerender();
+    box.append(container);
+    box.append(el("button", { class: "icon", text: "+ add metadata", onclick: () => { arr.push(["", ""]); rerender(); } }));
+    box.append(el("div", { class: "field hint", text: "Values are stored as strings. Use the preview to confirm output." }));
+}
+
+// --- Issues -------------------------------------------------------------
+function renderIssues() {
+    const box = $("#issues");
+    box.textContent = "";
+    for (const issue of state.lastIssues) {
+        const row = el("div", { class: "issue " + issue.level });
+        row.append(el("span", { class: "lvl", text: issue.level === "error" ? "ERROR" : "WARN" }));
+        row.append(el("span", { text: issue.message }));
+        row.append(el("span", { class: "where mono", text: issue.path }));
+        box.append(row);
+    }
+}
+
+// --- Boot ---------------------------------------------------------------
+function boot() {
+    document.body.innerHTML = `
+    <div class="toolbar">
+      <span class="title"><span class="brand-mark">◆</span> TOML Schema Editor</span>
+      <span class="path" id="path"></span>
+      <span class="pill" id="validity"></span>
+      <span class="spacer"></span>
+      <span class="status" id="status"></span>
+      <button id="new" title="Start a new, empty schema">New</button>
+      <button id="infer" title="Generate a schema from a sample TOML document">Infer from TOML</button>
+      <button id="add-type">+ Type</button>
+      <button id="add-element">+ Element</button>
+      <button id="revert">Revert</button>
+      <button id="save" class="primary">Save</button>
+    </div>
+    <div class="workspace">
+      <div class="diagram-pane">
+        <div class="diagram-bar">
+          <div class="view-tabs">
+            <button class="vtab active" data-view="elements">Elements</button>
+            <button class="vtab" data-view="types">Types</button>
+          </div>
+          <button id="dg-add" class="icon" title="Add a top-level entry to this view">+ Add</button>
+          <button id="dg-meta" class="icon" title="Edit [toml-schema] metadata">&#9881; Metadata</button>
+          <span class="spacer"></span>
+          <div class="zoom">
+            <button id="zoom-out" class="icon" title="Zoom out">&#8722;</button>
+            <span id="zoom-label" class="zoom-label">100%</span>
+            <button id="zoom-in" class="icon" title="Zoom in">+</button>
+            <button id="zoom-fit" class="icon" title="Fit to view">Fit</button>
+          </div>
+        </div>
+        <div class="diagram-scroll" id="diagram"></div>
+      </div>
+      <div class="side">
+        <div class="panel side-panel">
+          <div class="panel-head"><h2>Properties</h2><span class="spacer"></span><button id="prop-close" class="icon" title="Close / deselect" hidden>&#10005;</button></div>
+          <div class="editor" id="editor"></div>
+        </div>
+        <div class="panel side-panel preview-panel">
+          <div class="panel-head"><h2>TOML Preview</h2><span class="spacer"></span></div>
+          <div class="preview-wrap">
+            <pre class="preview mono" id="preview"></pre>
+            <div class="issues" id="issues"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <datalist id="type-refs"></datalist>`;
+
+    $("#save").addEventListener("click", save);
+    $("#revert").addEventListener("click", load);
+    $("#new").addEventListener("click", newSchema);
+    $("#infer").addEventListener("click", openInferModal);
+    $("#add-type").addEventListener("click", () => { state.view = "types"; addNode(state.model.types, ["types"]); });
+    $("#add-element").addEventListener("click", () => { state.view = "elements"; addNode(state.model.elements, ["elements"]); });
+
+    document.querySelectorAll(".vtab").forEach((b) =>
+        b.addEventListener("click", () => { state.view = b.dataset.view; renderDiagram(); }));
+    $("#dg-add").addEventListener("click", () => addNode(state.model[state.view], [state.view]));
+    $("#dg-meta").addEventListener("click", () => { state.selected = "__meta__"; renderEditor(); renderDiagram(); });
+    $("#zoom-in").addEventListener("click", () => setZoom((state.zoom || 1) + 0.1));
+    $("#zoom-out").addEventListener("click", () => setZoom((state.zoom || 1) - 0.1));
+    $("#zoom-fit").addEventListener("click", fitZoom);
+    $("#prop-close").addEventListener("click", clearSelection);
+
+    $("#diagram").addEventListener("click", (e) => {
+        if (e.target.closest(".dg-box, .dg-root, .dg-comp, button")) return;
+        if (state.selected) clearSelection();
+    });
+    document.addEventListener("keydown", (e) => {
+        if (e.key === "Escape" && state.selected && !document.querySelector(".modal-overlay")) clearSelection();
+    });
+
+    load();
+}
+
+function clearSelection() {
+    state.selected = null;
+    renderEditor();
+    renderDiagram();
+}
+
+// --- New (empty) schema -------------------------------------------------
+function newSchema() {
+    if (state.dirty && !confirm("Discard unsaved changes and start a new schema?")) return;
+    state.model = { version: "1.0.0", meta: null, types: [], elements: [] };
+    state.selected = "__meta__";
+    markDirty();
+    renderAll();
+}
+
+// --- Infer-from-TOML modal ---------------------------------------------
+function openInferModal() {
+    const existing = $("#infer-modal");
+    if (existing) existing.remove();
+
+    const overlay = el("div", { class: "modal-overlay", id: "infer-modal" });
+    const dialog = el("div", { class: "modal" });
+    dialog.append(el("h3", { text: "Infer schema from a reference TOML document" }));
+    dialog.append(el("p", { class: "hint", text: "Paste a sample TOML document, or load one from a file path. The generated schema replaces the current one (it is not saved until you click Save)." }));
+
+    const pathRow = el("div", { class: "list-row" });
+    const pathInput = el("input", { type: "text", class: "mono", placeholder: "path/to/sample.toml (absolute or workspace-relative)" });
+    const loadBtn = el("button", { text: "Load file", onclick: async () => {
+        const p = pathInput.value.trim();
+        if (!p) return;
+        errBox.textContent = "Loading…";
+        try {
+            const res = await fetch("readfile?path=" + encodeURIComponent(p));
+            const data = await res.json();
+            if (data.error) { errBox.textContent = data.error; return; }
+            ta.value = data.content;
+            errBox.textContent = "";
+        } catch (e) { errBox.textContent = e.message; }
+    } });
+    pathRow.append(pathInput, loadBtn);
+    dialog.append(pathRow);
+
+    const ta = el("textarea", { class: "mono modal-textarea", placeholder: "# paste TOML here\ntitle = \"Example\"\n[owner]\nname = \"…\"" });
+    dialog.append(ta);
+
+    const errBox = el("div", { class: "modal-err" });
+    dialog.append(errBox);
+
+    const actions = el("div", { class: "modal-actions" });
+    actions.append(el("button", { text: "Cancel", onclick: () => overlay.remove() }));
+    actions.append(el("button", { class: "primary", text: "Infer schema", onclick: async () => {
+        const toml = ta.value;
+        if (!toml.trim()) { errBox.textContent = "Provide some TOML to infer from."; return; }
+        errBox.textContent = "Inferring…";
+        try {
+            const res = await fetch("infer", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ toml }),
+            });
+            const data = await res.json();
+            if (data.error) { errBox.textContent = data.error; return; }
+            state.model = data.model;
+            state.selected = (state.model.elements[0] || state.model.types[0]) ?? null;
+            markDirty();
+            renderAll();
+            overlay.remove();
+        } catch (e) { errBox.textContent = e.message; }
+    } }));
+    dialog.append(actions);
+
+    overlay.append(dialog);
+    overlay.addEventListener("click", (e) => { if (e.target === overlay) overlay.remove(); });
+    document.body.append(overlay);
+    ta.focus();
+}
+
+boot();

--- a/.github/extensions/tosd-editor/client.js
+++ b/.github/extensions/tosd-editor/client.js
@@ -432,6 +432,7 @@ function fitZoom() {
         1.4,
     );
     setZoom(z);
+    host.scrollTo({ left: 0, top: 0 });
 }
 
 // --- Mutations ----------------------------------------------------------

--- a/.github/extensions/tosd-editor/extension.mjs
+++ b/.github/extensions/tosd-editor/extension.mjs
@@ -194,6 +194,23 @@ async function startServer(instanceId, entry) {
                 return sendJson(res, 200, { toml, issues, error });
             }
 
+            if (req.method === "POST" && path === "/open") {
+                const body = JSON.parse(await readBody(req));
+                const target = resolvePath((body.path || "").trim());
+                if (!target) return sendJson(res, 200, { error: "Enter a file path." });
+                if (!existsSync(target)) return sendJson(res, 200, { error: "File not found: " + target });
+                if (!target.endsWith(".tosd")) return sendJson(res, 200, { error: "Not a .tosd schema file: " + target });
+                try {
+                    const text = await readFile(target, "utf8");
+                    const model = parseDocument(text);
+                    entry.path = target;
+                    entry.model = model;
+                    return sendJson(res, 200, { ok: true, path: target, model });
+                } catch (e) {
+                    return sendJson(res, 200, { error: "Failed to parse " + target + ": " + e.message });
+                }
+            }
+
             if (req.method === "GET" && path === "/readfile") {
                 const target = resolvePath(url.searchParams.get("path"));
                 if (!target || !existsSync(target)) return sendJson(res, 200, { error: "file not found" });

--- a/.github/extensions/tosd-editor/extension.mjs
+++ b/.github/extensions/tosd-editor/extension.mjs
@@ -69,8 +69,7 @@ async function findDefaultTosd() {
     return join(base, "untitled.tosd");
 }
 
-async function loadModelForPath(filePath) {
-    if (filePath && existsSync(filePath)) {
+async function loadModelForPath(filePath) {    if (filePath && existsSync(filePath)) {
         const text = await readFile(filePath, "utf8");
         try {
             return parseDocument(text);
@@ -82,7 +81,49 @@ async function loadModelForPath(filePath) {
     return blankModel();
 }
 
-// --- Static + JSON HTTP server -----------------------------------------
+// --- Copilot generation -------------------------------------------------
+// Build a focused instruction that asks the agent to emit a .tosd document.
+function buildGeneratePrompt(desc) {
+    return [
+        "I'm using the TOML Schema visual editor and want to generate a TOML Schema definition (.tosd) document for the configuration file described below.",
+        "",
+        "Description:",
+        desc.trim(),
+        "",
+        "Requirements:",
+        "- Reply with ONLY the .tosd document inside a single ```toml code block — no commentary before or after.",
+        '- Include a [toml-schema] table with version = "1.0.0".',
+        "- Describe the document's top-level structure under [elements]; use nested tables like [elements.<name>.<child>] for sub-tables.",
+        '- Put reusable definitions under [types.<name>] and reference them with typeof = "types.<name>" (use itemtype = "types.<name>" for arrays of tables).',
+        "- Use only TOSD property keys: type (string, integer, float, boolean, datetime, date, time, array, table, collection), optional, default, min, max, minlength, maxlength, pattern, allowedvalues, arraytype, itemtype, items, oneof, anyof.",
+        "- Mark fields that may be omitted with optional = true; everything is required by default.",
+    ].join("\n");
+}
+
+function extractTosd(text) {
+    if (!text) return null;
+    const fence = /```(?:toml|tosd)?\s*\r?\n([\s\S]*?)```/i.exec(text);
+    if (fence) return fence[1].trim();
+    if (/\[toml-schema\]/.test(text) && /\[elements\]/.test(text)) return text.trim();
+    return null;
+}
+
+async function generateFromDescription(description) {
+    const desc = (description || "").trim();
+    if (!desc) throw new Error("Describe the configuration first.");
+    const ev = await session.sendAndWait({ prompt: buildGeneratePrompt(desc) }, 180000);
+    const text = ev && ev.data ? (ev.data.content || "") : "";
+    const tosd = extractTosd(text);
+    if (!tosd) {
+        const e = new Error("Copilot did not return a schema. Try rephrasing or adding detail.");
+        e.raw = text.slice(0, 500);
+        throw e;
+    }
+    const model = parseDocument(tosd);
+    return { model, tosd };
+}
+
+
 function readBody(req) {
     return new Promise((resolveBody, reject) => {
         let data = "";
@@ -179,6 +220,16 @@ async function startServer(instanceId, entry) {
                 }
             }
 
+            if (req.method === "POST" && path === "/generate") {
+                const body = JSON.parse(await readBody(req));
+                try {
+                    const { model, tosd } = await generateFromDescription(body.description);
+                    return sendJson(res, 200, { model, tosd });
+                } catch (e) {
+                    return sendJson(res, 200, { error: e.message, raw: e.raw });
+                }
+            }
+
             if (req.method === "POST" && path === "/save") {
                 const model = JSON.parse(await readBody(req));
                 entry.model = model;
@@ -269,6 +320,37 @@ const canvas = createCanvas({
                 }
                 if (!tomlText) throw new CanvasError("bad_input", "Provide either `path` or `toml`.");
                 entry.model = inferModelFromToml(tomlText);
+                return {
+                    path: entry.path,
+                    toml: serializeDocument(entry.model),
+                    model: entry.model,
+                    issues: validateModel(entry.model),
+                };
+            },
+        },
+        {
+            name: "generate_from_description",
+            description: "Generate a TOML Schema from a natural-language description of a configuration file (uses Copilot) and load it into the editor, replacing the current schema.",
+            inputSchema: {
+                type: "object",
+                properties: {
+                    description: { type: "string", description: "Natural-language description of the configuration file and its fields." },
+                },
+                required: ["description"],
+                additionalProperties: false,
+            },
+            handler: async (ctx) => {
+                const entry = instances.get(ctx.instanceId);
+                if (!entry) throw new CanvasError("not_open", "Canvas instance is not open.");
+                const desc = ctx.input && ctx.input.description;
+                if (!desc) throw new CanvasError("bad_input", "Provide a `description`.");
+                let result;
+                try {
+                    result = await generateFromDescription(desc);
+                } catch (e) {
+                    throw new CanvasError("generate_failed", e.message);
+                }
+                entry.model = result.model;
                 return {
                     path: entry.path,
                     toml: serializeDocument(entry.model),

--- a/.github/extensions/tosd-editor/extension.mjs
+++ b/.github/extensions/tosd-editor/extension.mjs
@@ -1,0 +1,310 @@
+// Extension: tosd-editor
+// A rich visual editor for TOML Schema definition (.tosd) documents.
+//
+// Each open canvas instance boots a loopback HTTP server that serves a small
+// single-page editor (client.js / styles.css) and exposes JSON endpoints:
+//   GET  /state    -> { path, model }
+//   POST /preview  -> { toml, issues }   (model in body; does not write to disk)
+//   POST /save     -> { ok }             (model in body; writes the .tosd file)
+//
+// The editor model and TOML (de)serialization live in model.mjs / toml.mjs so
+// this file stays focused on wiring: file IO, HTTP routing, and canvas actions.
+
+import { createServer } from "node:http";
+import { readFile, writeFile, readdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, isAbsolute, resolve } from "node:path";
+import { joinSession, createCanvas, CanvasError } from "@github/copilot-sdk/extension";
+import { parseDocument, serializeDocument, validateModel } from "./model.mjs";
+import { inferModelFromToml } from "./infer.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+// instanceId -> { server, url, path, model }
+const instances = new Map();
+
+let workspacePath = process.cwd();
+
+function blankModel() {
+    return {
+        version: "1.0.0",
+        meta: null,
+        types: [],
+        elements: [{ name: "title", props: { type: "string" }, children: [] }],
+    };
+}
+
+function resolvePath(inputPath) {
+    if (!inputPath) return null;
+    return isAbsolute(inputPath) ? inputPath : resolve(findBaseDir(), inputPath);
+}
+
+// The extension process may be launched with its cwd set to the session-state
+// folder rather than the repo. Walk up to the nearest ancestor that looks like
+// a project root (contains .git) so relative paths and default discovery
+// resolve against the repo rather than the session folder.
+function findBaseDir() {
+    for (const start of [HERE, workspacePath, process.cwd()]) {
+        let dir = start;
+        for (let i = 0; i < 12 && dir; i++) {
+            if (existsSync(join(dir, ".git"))) return dir;
+            const parent = dirname(dir);
+            if (parent === dir) break;
+            dir = parent;
+        }
+    }
+    return workspacePath;
+}
+
+async function findDefaultTosd() {
+    const base = findBaseDir();
+    try {
+        const entries = await readdir(base);
+        const tosd = entries.find((e) => e.endsWith(".tosd"));
+        if (tosd) return join(base, tosd);
+    } catch {
+        /* ignore */
+    }
+    return join(base, "untitled.tosd");
+}
+
+async function loadModelForPath(filePath) {
+    if (filePath && existsSync(filePath)) {
+        const text = await readFile(filePath, "utf8");
+        try {
+            return parseDocument(text);
+        } catch (e) {
+            // Surface a parse failure as a blank model rather than crashing.
+            return blankModel();
+        }
+    }
+    return blankModel();
+}
+
+// --- Static + JSON HTTP server -----------------------------------------
+function readBody(req) {
+    return new Promise((resolveBody, reject) => {
+        let data = "";
+        req.on("data", (chunk) => (data += chunk));
+        req.on("end", () => resolveBody(data));
+        req.on("error", reject);
+    });
+}
+
+function sendJson(res, status, obj) {
+    const body = JSON.stringify(obj);
+    res.writeHead(status, { "Content-Type": "application/json; charset=utf-8" });
+    res.end(body);
+}
+
+async function sendFile(res, name, contentType) {
+    try {
+        const content = await readFile(join(HERE, name), "utf8");
+        res.writeHead(200, { "Content-Type": contentType });
+        res.end(content);
+    } catch {
+        res.writeHead(404);
+        res.end("not found");
+    }
+}
+
+const INDEX_HTML = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>TOML Schema Editor</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <script src="client.js"></script>
+  </body>
+</html>`;
+
+async function startServer(instanceId, entry) {
+    const server = createServer(async (req, res) => {
+        const url = new URL(req.url, "http://127.0.0.1");
+        const path = url.pathname;
+        try {
+            if (req.method === "GET" && (path === "/" || path === "/index.html")) {
+                res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+                res.end(INDEX_HTML);
+                return;
+            }
+            if (req.method === "GET" && path === "/client.js") return void (await sendFile(res, "client.js", "text/javascript; charset=utf-8"));
+            if (req.method === "GET" && path === "/styles.css") return void (await sendFile(res, "styles.css", "text/css; charset=utf-8"));
+
+            if (req.method === "GET" && path === "/state") {
+                return sendJson(res, 200, { path: entry.path, model: entry.model });
+            }
+
+            if (req.method === "POST" && path === "/preview") {
+                const model = JSON.parse(await readBody(req));
+                entry.model = model;
+                let toml = "";
+                let error = null;
+                try {
+                    toml = serializeDocument(model);
+                } catch (e) {
+                    error = e.message;
+                }
+                const issues = validateModel(model);
+                return sendJson(res, 200, { toml, issues, error });
+            }
+
+            if (req.method === "GET" && path === "/readfile") {
+                const target = resolvePath(url.searchParams.get("path"));
+                if (!target || !existsSync(target)) return sendJson(res, 200, { error: "file not found" });
+                try {
+                    return sendJson(res, 200, { content: await readFile(target, "utf8"), path: target });
+                } catch (e) {
+                    return sendJson(res, 200, { error: e.message });
+                }
+            }
+
+            if (req.method === "POST" && path === "/infer") {
+                const body = JSON.parse(await readBody(req));
+                try {
+                    let tomlText = body.toml;
+                    if (!tomlText && body.path) {
+                        const target = resolvePath(body.path);
+                        if (!target || !existsSync(target)) return sendJson(res, 200, { error: "file not found: " + body.path });
+                        tomlText = await readFile(target, "utf8");
+                    }
+                    const model = inferModelFromToml(tomlText || "");
+                    return sendJson(res, 200, { model });
+                } catch (e) {
+                    return sendJson(res, 200, { error: e.message });
+                }
+            }
+
+            if (req.method === "POST" && path === "/save") {
+                const model = JSON.parse(await readBody(req));
+                entry.model = model;
+                if (!entry.path) return sendJson(res, 200, { ok: false, error: "no file path for this schema" });
+                try {
+                    const toml = serializeDocument(model);
+                    await writeFile(entry.path, toml, "utf8");
+                    return sendJson(res, 200, { ok: true, path: entry.path });
+                } catch (e) {
+                    return sendJson(res, 200, { ok: false, error: e.message });
+                }
+            }
+
+            res.writeHead(404);
+            res.end("not found");
+        } catch (e) {
+            sendJson(res, 500, { error: e.message });
+        }
+    });
+
+    await new Promise((r) => server.listen(0, "127.0.0.1", r));
+    const addr = server.address();
+    const port = typeof addr === "object" && addr ? addr.port : 0;
+    entry.server = server;
+    entry.url = `http://127.0.0.1:${port}/`;
+    return entry;
+}
+
+// --- Canvas declaration -------------------------------------------------
+const canvas = createCanvas({
+    id: "tosd-editor",
+    displayName: "TOML Schema Editor",
+    description: "Visual editor for a TOML Schema definition (.tosd) document: edit types, elements, and constraints with a live TOML preview.",
+    inputSchema: {
+        type: "object",
+        properties: {
+            path: {
+                type: "string",
+                description: "Path to the .tosd file to edit (absolute, or relative to the workspace). If omitted, the first .tosd in the workspace root is used.",
+            },
+        },
+        additionalProperties: false,
+    },
+    actions: [
+        {
+            name: "get_document",
+            description: "Return the current edited schema as canonical TOML, the editor model, and any structural validation issues.",
+            handler: async (ctx) => {
+                const entry = instances.get(ctx.instanceId);
+                if (!entry) throw new CanvasError("not_open", "Canvas instance is not open.");
+                return {
+                    path: entry.path,
+                    toml: serializeDocument(entry.model),
+                    model: entry.model,
+                    issues: validateModel(entry.model),
+                };
+            },
+        },
+        {
+            name: "reload_from_disk",
+            description: "Discard in-memory edits and reload the schema from its file on disk.",
+            handler: async (ctx) => {
+                const entry = instances.get(ctx.instanceId);
+                if (!entry) throw new CanvasError("not_open", "Canvas instance is not open.");
+                entry.model = await loadModelForPath(entry.path);
+                return { ok: true, path: entry.path };
+            },
+        },
+        {
+            name: "infer_from_toml",
+            description: "Infer a TOML Schema from a sample/reference TOML document (by file path or inline content) and load it into the editor, replacing the current schema.",
+            inputSchema: {
+                type: "object",
+                properties: {
+                    path: { type: "string", description: "Path to a reference .toml file (absolute or workspace-relative)." },
+                    toml: { type: "string", description: "Inline TOML content to infer from (used when path is omitted)." },
+                },
+                additionalProperties: false,
+            },
+            handler: async (ctx) => {
+                const entry = instances.get(ctx.instanceId);
+                if (!entry) throw new CanvasError("not_open", "Canvas instance is not open.");
+                let tomlText = ctx.input && ctx.input.toml;
+                if (!tomlText && ctx.input && ctx.input.path) {
+                    const target = resolvePath(ctx.input.path);
+                    if (!target || !existsSync(target)) throw new CanvasError("not_found", "Reference TOML not found: " + ctx.input.path);
+                    tomlText = await readFile(target, "utf8");
+                }
+                if (!tomlText) throw new CanvasError("bad_input", "Provide either `path` or `toml`.");
+                entry.model = inferModelFromToml(tomlText);
+                return {
+                    path: entry.path,
+                    toml: serializeDocument(entry.model),
+                    model: entry.model,
+                    issues: validateModel(entry.model),
+                };
+            },
+        },
+    ],
+    open: async (ctx) => {
+        let entry = instances.get(ctx.instanceId);
+        if (!entry) {
+            const inputPath = ctx.input && ctx.input.path;
+            const filePath = resolvePath(inputPath) || (await findDefaultTosd());
+            const model = await loadModelForPath(filePath);
+            entry = { server: null, url: null, path: filePath, model };
+            instances.set(ctx.instanceId, entry);
+            await startServer(ctx.instanceId, entry);
+            session.log(`tosd-editor: editing ${filePath}`, { level: "info", ephemeral: true });
+        }
+        return {
+            title: `TOML Schema: ${entry.path ? entry.path.split("/").pop() : "untitled"}`,
+            status: entry.path && existsSync(entry.path) ? "loaded" : "new",
+            url: entry.url,
+        };
+    },
+    onClose: async (ctx) => {
+        const entry = instances.get(ctx.instanceId);
+        if (entry) {
+            instances.delete(ctx.instanceId);
+            if (entry.server) await new Promise((r) => entry.server.close(() => r()));
+        }
+    },
+});
+
+const session = await joinSession({ canvases: [canvas] });
+if (typeof session.workspacePath === "string" && session.workspacePath) {
+    workspacePath = session.workspacePath;
+}

--- a/.github/extensions/tosd-editor/infer.mjs
+++ b/.github/extensions/tosd-editor/infer.mjs
@@ -1,0 +1,181 @@
+// Infer a TOML Schema (editor model) from a sample/reference TOML document.
+//
+// The inference walks a parsed TOML document and produces:
+//   * one [elements] entry per top-level key, and
+//   * reusable [types] for arrays of tables (and nested arrays of tables),
+//     referenced via `itemtype`.
+//
+// Heuristics are intentionally conservative - the result is a faithful starting
+// point that the user refines in the editor. The reserved root [toml-schema]
+// table is ignored, matching how it is treated during document validation.
+
+import { parseToml, isPlainTable } from "./toml.mjs";
+
+export function inferModelFromToml(text) {
+    const root = parseToml(text || "");
+    const ctx = { types: [], usedNames: new Set() };
+
+    const elements = [];
+    for (const [key, value] of Object.entries(root)) {
+        if (key === "toml-schema") continue; // reserved metadata in TOML documents
+        elements.push(inferNode(key, value, ctx));
+    }
+
+    return {
+        version: "1.0.0",
+        meta: null,
+        types: ctx.types,
+        elements,
+    };
+}
+
+function inferNode(name, value, ctx) {
+    if (isTableLike(value)) {
+        const obj = tableObject(value);
+        return {
+            name,
+            props: { type: "table" },
+            children: Object.entries(obj).map(([k, v]) => inferNode(k, v, ctx)),
+        };
+    }
+    if (Array.isArray(value)) {
+        return { name, props: inferArrayProps(name, value, ctx), children: [] };
+    }
+    return { name, props: { type: scalarType(value) }, children: [] };
+}
+
+function inferArrayProps(name, arr, ctx) {
+    if (arr.length === 0) return { type: "array" };
+
+    const allTables = arr.every(isTableLike);
+    if (allTables) {
+        const typeName = synthTableType(name, arr.map(tableObject), ctx);
+        return { type: "array", arraytype: "table", itemtype: `types.${typeName}` };
+    }
+
+    const anyArray = arr.some((v) => Array.isArray(v));
+    if (anyArray) return { type: "array", arraytype: "array" };
+
+    const kinds = new Set(arr.map((v) => (isTableLike(v) ? "table" : Array.isArray(v) ? "array" : scalarType(v))));
+    if (kinds.size === 1) {
+        return { type: "array", arraytype: [...kinds][0] };
+    }
+    // Mixed scalar types: leave arraytype unset (items default to `any`).
+    return { type: "array" };
+}
+
+// Merge the shape of every table in an array of tables into one reusable type,
+// marking fields that are not present in every item as optional.
+function synthTableType(baseName, objects, ctx) {
+    const typeName = uniqueTypeName(baseName, ctx);
+    const node = { name: typeName, props: { type: "table" }, children: [] };
+    // Reserve the name immediately so nested synths don't collide.
+    ctx.types.push(node);
+
+    const order = [];
+    const seen = new Set();
+    const valuesByKey = new Map();
+    for (const obj of objects) {
+        for (const [k, v] of Object.entries(obj)) {
+            if (!seen.has(k)) {
+                seen.add(k);
+                order.push(k);
+                valuesByKey.set(k, []);
+            }
+            valuesByKey.get(k).push(v);
+        }
+    }
+
+    for (const key of order) {
+        const values = valuesByKey.get(key);
+        const present = values.length;
+        let child;
+
+        if (values.every(isTableLike)) {
+            const merged = mergeChildTable(key, values.map(tableObject), ctx);
+            child = merged;
+        } else if (values.every((v) => Array.isArray(v))) {
+            const combined = values.flat();
+            child = { name: key, props: inferArrayProps(key, combined, ctx), children: [] };
+        } else {
+            child = { name: key, props: { type: representativeScalarType(values) }, children: [] };
+        }
+
+        if (present < objects.length) child.props.optional = true;
+        node.children.push(child);
+    }
+
+    return typeName;
+}
+
+// A nested table field inside a synthesized type: merge its shape too.
+function mergeChildTable(key, objects, ctx) {
+    const order = [];
+    const seen = new Set();
+    const valuesByKey = new Map();
+    for (const obj of objects) {
+        for (const [k, v] of Object.entries(obj)) {
+            if (!seen.has(k)) {
+                seen.add(k);
+                order.push(k);
+                valuesByKey.set(k, []);
+            }
+            valuesByKey.get(k).push(v);
+        }
+    }
+    const children = [];
+    for (const k of order) {
+        const values = valuesByKey.get(k);
+        let child;
+        if (values.every(isTableLike)) {
+            child = mergeChildTable(k, values.map(tableObject), ctx);
+        } else if (values.every((v) => Array.isArray(v))) {
+            child = { name: k, props: inferArrayProps(k, values.flat(), ctx), children: [] };
+        } else {
+            child = { name: k, props: { type: representativeScalarType(values) }, children: [] };
+        }
+        if (values.length < objects.length) child.props.optional = true;
+        children.push(child);
+    }
+    return { name: key, props: { type: "table" }, children };
+}
+
+function representativeScalarType(values) {
+    const kinds = new Set(values.map((v) => (isTableLike(v) ? "table" : Array.isArray(v) ? "array" : scalarType(v))));
+    if (kinds.size === 1) return [...kinds][0];
+    // Integers seen alongside floats are best represented as float.
+    if ([...kinds].every((k) => k === "integer" || k === "float")) return "float";
+    return "any";
+}
+
+function scalarType(value) {
+    if (typeof value === "boolean") return "boolean";
+    if (typeof value === "number") return Number.isInteger(value) ? "integer" : "float";
+    if (value && value.__datetime) return value.__datetime;
+    return "string";
+}
+
+function isTableLike(value) {
+    return isPlainTable(value) || (value && value.__inline === true);
+}
+
+function tableObject(value) {
+    return value && value.__inline ? value.value : value;
+}
+
+function uniqueTypeName(baseName, ctx) {
+    let base = singularize(String(baseName).replace(/[^A-Za-z0-9]/g, "")) || "item";
+    base = base.charAt(0).toLowerCase() + base.slice(1) + "Type";
+    let name = base;
+    let i = 1;
+    while (ctx.usedNames.has(name)) name = base.replace(/Type$/, "") + ++i + "Type";
+    ctx.usedNames.add(name);
+    return name;
+}
+
+function singularize(word) {
+    if (/ies$/i.test(word)) return word.replace(/ies$/i, "y");
+    if (/ses$/i.test(word)) return word.replace(/es$/i, "");
+    if (/s$/i.test(word) && !/ss$/i.test(word)) return word.replace(/s$/i, "");
+    return word;
+}

--- a/.github/extensions/tosd-editor/model.mjs
+++ b/.github/extensions/tosd-editor/model.mjs
@@ -304,7 +304,7 @@ export function validateModel(model) {
         }
 
         if (p.pattern && p.type && p.type !== "string") {
-            issues.push({ level: "warning", path: label, message: "`pattern` only validates string values." });
+            issues.push({ level: "warning", path: label, message: `\`pattern\` is ignored on \`${p.type}\` — it only validates \`string\` values.` });
         }
 
         for (const ref of [p.typeof, p.itemtype]) {

--- a/.github/extensions/tosd-editor/model.mjs
+++ b/.github/extensions/tosd-editor/model.mjs
@@ -1,0 +1,336 @@
+// Converts between a parsed .tosd document and the editor model that the client
+// SPA consumes, and serializes the editor model back to canonical TOSD text.
+//
+// Editor model shape:
+//   {
+//     version: "1.0.0",
+//     meta:   { ...rawTomlTable } | null,   // [toml-schema.meta]
+//     types:    [ node, ... ],
+//     elements: [ node, ... ],
+//   }
+// node = { name, props: { <prop>: <editorValue> }, children: [ node, ... ] }
+//
+// Editor value encoding per property:
+//   type/typeof/arraytype/itemtype/pattern : plain string
+//   optional                               : boolean
+//   minlength/maxlength                    : number
+//   items/oneof/anyof                      : string[]  (type references)
+//   allowedvalues                          : string[]  (TOML value tokens)
+//   min/max/default                        : string    (TOML value token)
+
+import {
+    parseToml,
+    formatValue,
+    formatKeyPath,
+    parseValue,
+    isPlainTable,
+} from "./toml.mjs";
+
+export const PROP_ORDER = [
+    "type",
+    "typeof",
+    "arraytype",
+    "itemtype",
+    "items",
+    "oneof",
+    "anyof",
+    "allowedvalues",
+    "pattern",
+    "min",
+    "max",
+    "minlength",
+    "maxlength",
+    "optional",
+    "default",
+];
+
+const STRING_PROPS = new Set(["type", "typeof", "arraytype", "itemtype", "pattern"]);
+const INT_PROPS = new Set(["minlength", "maxlength"]);
+const BOOL_PROPS = new Set(["optional"]);
+const REFLIST_PROPS = new Set(["items", "oneof", "anyof"]);
+const VALUELIST_PROPS = new Set(["allowedvalues"]);
+const VALUE_PROPS = new Set(["min", "max", "default"]);
+
+const ALL_PROPS = new Set(PROP_ORDER);
+
+export const BUILTIN_TYPES = [
+    "any",
+    "string",
+    "integer",
+    "float",
+    "boolean",
+    "offset-date-time",
+    "local-date-time",
+    "local-date",
+    "local-time",
+    "array",
+    "table",
+    "collection",
+];
+
+// ---------------------------------------------------------------------------
+// Parse .tosd text -> editor model
+// ---------------------------------------------------------------------------
+
+export function parseDocument(text) {
+    const root = parseToml(text || "");
+    const meta = root["toml-schema"] || {};
+    const version = typeof meta.version === "string" ? meta.version : "1.0.0";
+    const metaTable = isPlainTable(meta.meta) ? meta.meta : null;
+
+    return {
+        version,
+        meta: metaTable,
+        types: tableToNodes(root["types"]),
+        elements: tableToNodes(root["elements"]),
+    };
+}
+
+function tableToNodes(table) {
+    if (!isPlainTable(table)) return [];
+    const nodes = [];
+    for (const [name, value] of Object.entries(table)) {
+        if (isPlainTable(value)) {
+            nodes.push(tableToNode(name, value));
+        }
+        // Non-table top-level entries under [types]/[elements] are not valid
+        // schema definitions; ignore them defensively.
+    }
+    return nodes;
+}
+
+function tableToNode(name, table) {
+    const node = { name, props: {}, children: [] };
+    for (const [key, value] of Object.entries(table)) {
+        if (isPlainTable(value)) {
+            node.children.push(tableToNode(key, value));
+        } else if (ALL_PROPS.has(key)) {
+            node.props[key] = decodeProp(key, value);
+        } else {
+            // A target document key that collides with nothing schema-specific
+            // but holds a scalar - treat it as a child definition placeholder so
+            // the information is not lost. Wrap as a node with a single prop.
+            node.children.push({ name: key, props: scalarToProps(value), children: [] });
+        }
+    }
+    return node;
+}
+
+function scalarToProps(value) {
+    // Best-effort: represent a stray scalar child as an implicit string-ish node.
+    return { type: typeofToken(value) };
+}
+
+function typeofToken(value) {
+    if (typeof value === "boolean") return "boolean";
+    if (typeof value === "number") return Number.isInteger(value) ? "integer" : "float";
+    if (value && value.__datetime) return value.__datetime;
+    return "string";
+}
+
+function decodeProp(key, value) {
+    if (STRING_PROPS.has(key)) return typeof value === "string" ? value : String(value);
+    if (BOOL_PROPS.has(key)) return Boolean(value);
+    if (INT_PROPS.has(key)) return Number(value);
+    if (REFLIST_PROPS.has(key)) return Array.isArray(value) ? value.map(String) : [];
+    if (VALUELIST_PROPS.has(key)) return Array.isArray(value) ? value.map(formatValue) : [];
+    if (VALUE_PROPS.has(key)) return formatValue(value);
+    return formatValue(value);
+}
+
+// ---------------------------------------------------------------------------
+// Editor model -> canonical .tosd text
+// ---------------------------------------------------------------------------
+
+export function serializeDocument(model) {
+    const lines = [];
+    lines.push("# Metadata");
+    lines.push("[toml-schema]");
+    lines.push(`version = ${formatValue(model.version || "1.0.0")}`);
+
+    if (model.meta && Object.keys(model.meta).length > 0) {
+        lines.push("");
+        emitRawTable(["toml-schema", "meta"], model.meta, lines);
+    }
+
+    lines.push("");
+    lines.push("# Types");
+    lines.push("[types]");
+    for (const node of model.types || []) {
+        lines.push("");
+        emitNode(node, ["types"], 1, lines);
+    }
+
+    lines.push("");
+    lines.push("# Elements");
+    lines.push("[elements]");
+    for (const node of model.elements || []) {
+        lines.push("");
+        emitNode(node, ["elements"], 1, lines);
+    }
+
+    return lines.join("\n") + "\n";
+}
+
+function emitNode(node, parentPath, depth, lines) {
+    const path = [...parentPath, node.name];
+    const indent = "    ".repeat(depth);
+    lines.push(`${indent}[${formatKeyPath(path)}]`);
+
+    for (const key of PROP_ORDER) {
+        if (!(key in node.props)) continue;
+        const raw = node.props[key];
+        if (raw === undefined || raw === null || raw === "") continue;
+        const typed = encodeProp(key, raw);
+        if (typed === undefined) continue;
+        lines.push(`${indent}${key} = ${formatValue(typed)}`);
+    }
+
+    for (const child of node.children || []) {
+        lines.push("");
+        emitNode(child, path, depth + 1, lines);
+    }
+}
+
+function encodeProp(key, raw) {
+    if (STRING_PROPS.has(key)) return String(raw);
+    if (BOOL_PROPS.has(key)) return Boolean(raw);
+    if (INT_PROPS.has(key)) return Math.trunc(Number(raw));
+    if (REFLIST_PROPS.has(key)) {
+        const arr = (Array.isArray(raw) ? raw : []).map(String).filter((s) => s !== "");
+        return arr.length ? arr : undefined;
+    }
+    if (VALUELIST_PROPS.has(key)) {
+        const arr = (Array.isArray(raw) ? raw : [])
+            .map((tok) => safeParseToken(tok))
+            .filter((v) => v !== undefined);
+        return arr.length ? arr : undefined;
+    }
+    if (VALUE_PROPS.has(key)) return safeParseToken(raw);
+    return safeParseToken(raw);
+}
+
+function safeParseToken(token) {
+    if (token === undefined || token === null) return undefined;
+    const s = String(token).trim();
+    if (s === "") return undefined;
+    try {
+        return parseValue(s);
+    } catch {
+        // Fall back to treating it as a bare string value.
+        return s;
+    }
+}
+
+// Generic emitter for the free-form [toml-schema.meta] table.
+function emitRawTable(pathParts, table, lines) {
+    lines.push(`[${formatKeyPath(pathParts)}]`);
+    const subTables = [];
+    for (const [key, value] of Object.entries(table)) {
+        if (isPlainTable(value)) {
+            subTables.push([key, value]);
+        } else {
+            lines.push(`${formatKeyMeta(key)} = ${formatValue(value)}`);
+        }
+    }
+    for (const [key, value] of subTables) {
+        lines.push("");
+        emitRawTable([...pathParts, key], value, lines);
+    }
+}
+
+function formatKeyMeta(key) {
+    return /^[A-Za-z0-9_-]+$/.test(key) ? key : `'${key}'`;
+}
+
+// ---------------------------------------------------------------------------
+// Lightweight structural validation surfaced in the editor.
+// ---------------------------------------------------------------------------
+
+const NUMERIC_OR_TEMPORAL = new Set([
+    "integer",
+    "float",
+    "offset-date-time",
+    "local-date-time",
+    "local-date",
+    "local-time",
+]);
+
+export function validateModel(model) {
+    const issues = [];
+    const typeNames = new Set((model.types || []).map((t) => t.name));
+
+    const refExists = (ref) => {
+        if (!ref) return true;
+        const name = ref.startsWith("types.") ? ref.slice(6) : ref;
+        if (BUILTIN_TYPES.includes(name)) return true;
+        return typeNames.has(name);
+    };
+
+    const walk = (node, pathLabel) => {
+        const p = node.props || {};
+        const label = pathLabel;
+
+        const exclusivity = ["type", "typeof", "oneof", "anyof"].filter((k) => p[k] != null && p[k] !== "" && !(Array.isArray(p[k]) && p[k].length === 0));
+        if (exclusivity.length === 0 && (!node.children || node.children.length === 0)) {
+            issues.push({ level: "warning", path: label, message: "No type, typeof, oneof, anyof, or children - defaults to an open table." });
+        }
+
+        if (p.items && (p.arraytype || p.itemtype)) {
+            issues.push({ level: "error", path: label, message: "`items` is mutually exclusive with `arraytype` and `itemtype`." });
+        }
+        if (p.items && (p.minlength != null || p.maxlength != null)) {
+            issues.push({ level: "error", path: label, message: "`items` is mutually exclusive with `minlength`/`maxlength`." });
+        }
+
+        const hasMin = p.min != null && p.min !== "";
+        const hasMax = p.max != null && p.max !== "";
+        if (hasMin || hasMax) {
+            const t = p.type;
+            const at = p.arraytype;
+            const ok = NUMERIC_OR_TEMPORAL.has(t) || (t === "array" && NUMERIC_OR_TEMPORAL.has(at));
+            if (t === "any") {
+                issues.push({ level: "error", path: label, message: "`min`/`max` cannot be applied to type `any`." });
+            } else if (!ok) {
+                issues.push({ level: "warning", path: label, message: "`min`/`max` only apply to numeric/temporal types, or arrays of them." });
+            }
+        }
+
+        if ((p.minlength != null || p.maxlength != null)) {
+            const t = p.type;
+            if (t && !["string", "array", "collection"].includes(t)) {
+                issues.push({ level: "warning", path: label, message: "`minlength`/`maxlength` only apply to string, array, or collection." });
+            }
+        }
+
+        if (p.pattern && p.type && p.type !== "string") {
+            issues.push({ level: "warning", path: label, message: "`pattern` only validates string values." });
+        }
+
+        for (const ref of [p.typeof, p.itemtype]) {
+            if (ref && !refExists(ref)) {
+                issues.push({ level: "error", path: label, message: `Unknown type reference: "${ref}".` });
+            }
+        }
+        for (const listKey of ["items", "oneof", "anyof"]) {
+            for (const ref of p[listKey] || []) {
+                if (ref && !refExists(ref)) {
+                    issues.push({ level: "error", path: label, message: `Unknown type reference in ${listKey}: "${ref}".` });
+                }
+            }
+        }
+
+        for (const child of node.children || []) {
+            walk(child, `${label}.${child.name}`);
+        }
+    };
+
+    for (const t of model.types || []) walk(t, `types.${t.name}`);
+    for (const e of model.elements || []) walk(e, `elements.${e.name}`);
+
+    if (!/^\d+\.\d+\.\d+/.test(model.version || "")) {
+        issues.push({ level: "error", path: "toml-schema.version", message: "version must be a full SemVer string (e.g. 1.0.0)." });
+    }
+
+    return issues;
+}

--- a/.github/extensions/tosd-editor/styles.css
+++ b/.github/extensions/tosd-editor/styles.css
@@ -257,11 +257,22 @@ button.danger:hover {
     min-height: 0;
     overflow: auto;
     position: relative;
+    cursor: grab;
     background-color: var(--tosd-subtle);
     background-image:
         radial-gradient(color-mix(in srgb, var(--tosd-muted) 22%, transparent) 1px, transparent 1px);
     background-size: 22px 22px;
     background-position: -1px -1px;
+}
+
+.diagram-scroll.panning {
+    cursor: grabbing;
+    user-select: none;
+}
+
+.diagram-scroll.panning .dg-box,
+.diagram-scroll.panning .dg-expander {
+    pointer-events: none;
 }
 
 .diagram-inner {
@@ -547,10 +558,12 @@ button.danger:hover {
 .preview-panel {
     background: var(--tosd-elevated);
 }
+
+.panel-head {
     display: flex;
     align-items: center;
     gap: 8px;
-    padding: 10px 14px;
+    padding: 12px 16px;
     position: sticky;
     top: 0;
     background: color-mix(in srgb, var(--tosd-bg) 88%, transparent);
@@ -566,6 +579,18 @@ button.danger:hover {
     text-transform: uppercase;
     letter-spacing: 0.07em;
     color: var(--tosd-muted);
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+}
+
+.panel-head h2::before {
+    content: "";
+    width: 3px;
+    height: 12px;
+    border-radius: 2px;
+    background: var(--tosd-accent);
+    opacity: 0.7;
 }
 
 .panel-head .spacer {
@@ -741,7 +766,7 @@ button.danger:hover {
 
 /* Editor ----------------------------------------------------------------- */
 .editor {
-    padding: 16px 18px;
+    padding: 18px 20px 28px;
 }
 
 .editor .empty {
@@ -1055,6 +1080,28 @@ pre.preview {
     font-size: 12px;
     min-height: 16px;
     margin-top: 6px;
+}
+
+.modal-err.working {
+    color: var(--tosd-accent);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.modal-err.working::before {
+    content: "";
+    width: 13px;
+    height: 13px;
+    border-radius: 50%;
+    border: 2px solid color-mix(in srgb, var(--tosd-accent) 30%, transparent);
+    border-top-color: var(--tosd-accent);
+    animation: tosd-spin 0.7s linear infinite;
+    flex: 0 0 auto;
+}
+
+@keyframes tosd-spin {
+    to { transform: rotate(360deg); }
 }
 
 .modal-actions {

--- a/.github/extensions/tosd-editor/styles.css
+++ b/.github/extensions/tosd-editor/styles.css
@@ -1,0 +1,1092 @@
+:root {
+    --tosd-gap: 12px;
+    --tosd-radius: 8px;
+    --tosd-radius-sm: 6px;
+    --tosd-accent: var(--true-color-blue, #0969da);
+    --tosd-accent-soft: var(--bb-11-10, rgba(9, 105, 218, 0.1));
+    --tosd-error: var(--true-color-red, #cf222e);
+    --tosd-warn: var(--true-color-orange, #bc4c00);
+    --tosd-ok: var(--true-color-green, #1a7f37);
+    --tosd-muted: var(--text-color-muted, #59636e);
+    --tosd-border: var(--border-color-default, #d1d9e0);
+    --tosd-border-soft: color-mix(in srgb, var(--tosd-border) 55%, transparent);
+    --tosd-bg: var(--background-color-default, #ffffff);
+    --tosd-subtle: var(--background-color-muted, #f6f8fa);
+    --tosd-elevated: color-mix(in srgb, var(--tosd-subtle) 50%, var(--tosd-bg));
+    --tosd-shadow: 0 1px 2px rgba(31, 35, 40, 0.06), 0 1px 3px rgba(31, 35, 40, 0.05);
+
+    /* Type category accents */
+    --cat-string: var(--true-color-blue, #0969da);
+    --cat-number: var(--true-color-green, #1a7f37);
+    --cat-boolean: var(--true-color-purple, #8250df);
+    --cat-date: var(--true-color-orange, #bc4c00);
+    --cat-table: var(--true-color-pink, #bf3989);
+    --cat-array: var(--true-color-coral, #d1242f);
+    --cat-ref: var(--true-color-teal, #1b7c83);
+    --cat-choice: var(--true-color-yellow, #9a6700);
+    --cat-any: var(--text-color-muted, #59636e);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html,
+body {
+    margin: 0;
+    height: 100%;
+}
+
+body {
+    background:
+        radial-gradient(1200px 400px at 100% -10%, color-mix(in srgb, var(--tosd-accent) 5%, transparent), transparent),
+        var(--tosd-bg);
+    color: var(--text-color-default, #1f2328);
+    font-family: var(--font-sans, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
+    font-size: var(--text-body-medium, 14px);
+    line-height: var(--leading-body-medium, 20px);
+    display: flex;
+    flex-direction: column;
+    -webkit-font-smoothing: antialiased;
+}
+
+code,
+.mono {
+    font-family: var(--font-mono, "SFMono-Regular", Consolas, "Liberation Mono", monospace);
+    font-size: var(--text-code-inline, 12px);
+}
+
+/* Toolbar ---------------------------------------------------------------- */
+.toolbar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--tosd-border);
+    background: linear-gradient(180deg, var(--tosd-bg), var(--tosd-subtle));
+    flex: 0 0 auto;
+}
+
+.toolbar .title {
+    font-weight: var(--font-weight-semibold, 600);
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    letter-spacing: -0.01em;
+}
+
+.brand-mark {
+    color: var(--tosd-accent);
+    font-size: 13px;
+    transform: translateY(0.5px);
+    filter: drop-shadow(0 1px 1px color-mix(in srgb, var(--tosd-accent) 40%, transparent));
+}
+
+.toolbar .path {
+    color: var(--tosd-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 36ch;
+    padding: 2px 8px;
+    background: var(--tosd-subtle);
+    border: 1px solid var(--tosd-border-soft);
+    border-radius: 20px;
+    font-size: 12px;
+}
+
+.toolbar .spacer {
+    flex: 1 1 auto;
+}
+
+.status {
+    font-size: 12px;
+    color: var(--tosd-muted);
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.status::before {
+    content: "";
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: currentColor;
+    opacity: 0.7;
+}
+
+.status.dirty {
+    color: var(--tosd-warn);
+}
+
+.status.saved {
+    color: var(--tosd-ok);
+}
+
+button {
+    font: inherit;
+    cursor: pointer;
+    border: 1px solid var(--tosd-border);
+    background: var(--tosd-bg);
+    color: inherit;
+    border-radius: var(--tosd-radius-sm);
+    padding: 5px 11px;
+    transition: background 0.12s ease, border-color 0.12s ease, box-shadow 0.12s ease, transform 0.04s ease;
+}
+
+button:hover {
+    background: var(--tosd-subtle);
+    border-color: color-mix(in srgb, var(--tosd-border) 70%, var(--tosd-muted));
+}
+
+button:active {
+    transform: translateY(0.5px);
+}
+
+button:focus-visible {
+    outline: 2px solid var(--color-focus-outline, var(--tosd-accent));
+    outline-offset: 1px;
+}
+
+button.primary {
+    background: var(--tosd-accent);
+    border-color: color-mix(in srgb, var(--tosd-accent) 80%, #000);
+    color: var(--color-white, #fff);
+    box-shadow: var(--tosd-shadow);
+}
+
+button.primary:hover {
+    background: color-mix(in srgb, var(--tosd-accent) 88%, #000);
+}
+
+button.primary:disabled {
+    opacity: 0.45;
+    cursor: default;
+    box-shadow: none;
+}
+
+button.icon {
+    padding: 2px 7px;
+    line-height: 1;
+    border-radius: 5px;
+}
+
+button.danger:hover {
+    color: var(--tosd-error);
+    border-color: var(--tosd-error);
+    background: color-mix(in srgb, var(--tosd-error) 8%, transparent);
+}
+
+/* Workspace layout ------------------------------------------------------ */
+.workspace {
+    flex: 1 1 auto;
+    display: grid;
+    grid-template-columns: 1fr minmax(300px, 32%);
+    min-height: 0;
+}
+
+.diagram-pane {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    min-height: 0;
+    border-right: 1px solid var(--tosd-border);
+}
+
+.diagram-bar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--tosd-border);
+    background: color-mix(in srgb, var(--tosd-subtle) 70%, var(--tosd-bg));
+    flex: 0 0 auto;
+}
+
+.diagram-bar .spacer {
+    flex: 1;
+}
+
+.view-tabs {
+    display: inline-flex;
+    background: var(--tosd-subtle);
+    border: 1px solid var(--tosd-border);
+    border-radius: 8px;
+    padding: 2px;
+    gap: 2px;
+}
+
+.vtab {
+    border: none;
+    background: none;
+    padding: 3px 12px;
+    border-radius: 6px;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--tosd-muted);
+}
+
+.vtab:hover {
+    background: color-mix(in srgb, var(--tosd-muted) 12%, transparent);
+}
+
+.vtab.active {
+    background: var(--tosd-bg);
+    color: var(--tosd-accent);
+    box-shadow: var(--tosd-shadow);
+}
+
+.zoom {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.zoom-label {
+    font-size: 11px;
+    color: var(--tosd-muted);
+    min-width: 38px;
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+}
+
+/* Diagram canvas --------------------------------------------------------- */
+.diagram-scroll {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: auto;
+    position: relative;
+    background-color: var(--tosd-subtle);
+    background-image:
+        radial-gradient(color-mix(in srgb, var(--tosd-muted) 22%, transparent) 1px, transparent 1px);
+    background-size: 22px 22px;
+    background-position: -1px -1px;
+}
+
+.diagram-inner {
+    position: relative;
+    transform-origin: top left;
+}
+
+.dg-links {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    overflow: visible;
+}
+
+.dg-link {
+    fill: none;
+    stroke: color-mix(in srgb, var(--tosd-muted) 55%, transparent);
+    stroke-width: 1.5;
+}
+
+.dg-link.active {
+    stroke: var(--tosd-accent);
+    stroke-width: 2;
+}
+
+/* Boxes ------------------------------------------------------------------ */
+.dg-box,
+.dg-root {
+    position: absolute;
+    box-sizing: border-box;
+    border-radius: 10px;
+    background: var(--tosd-bg);
+    border: 1px solid var(--tosd-border);
+    box-shadow: var(--tosd-shadow);
+    cursor: pointer;
+    overflow: hidden;
+    transition: box-shadow 0.12s ease, border-color 0.12s ease, transform 0.05s ease;
+}
+
+.dg-box {
+    --cat: var(--cat-any);
+    padding: 7px 10px 0 13px;
+}
+
+.dg-box[data-cat="string"] { --cat: var(--cat-string); }
+.dg-box[data-cat="number"] { --cat: var(--cat-number); }
+.dg-box[data-cat="boolean"] { --cat: var(--cat-boolean); }
+.dg-box[data-cat="date"] { --cat: var(--cat-date); }
+.dg-box[data-cat="table"] { --cat: var(--cat-table); }
+.dg-box[data-cat="array"] { --cat: var(--cat-array); }
+.dg-box[data-cat="ref"] { --cat: var(--cat-ref); }
+.dg-box[data-cat="choice"] { --cat: var(--cat-choice); }
+
+.dg-box::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 5px;
+    background: var(--cat);
+}
+
+.dg-box:hover {
+    border-color: color-mix(in srgb, var(--cat) 60%, var(--tosd-border));
+    box-shadow: 0 2px 6px rgba(31, 35, 40, 0.12);
+}
+
+.dg-box.selected {
+    border-color: var(--tosd-accent);
+    box-shadow: 0 0 0 2px var(--tosd-accent-soft), 0 2px 8px rgba(31, 35, 40, 0.14);
+}
+
+.dg-box.optional {
+    border-style: dashed;
+}
+
+.dg-top {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.dg-accent {
+    display: none;
+}
+
+.dg-name {
+    font-weight: 600;
+    font-size: 13px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    flex: 1 1 auto;
+}
+
+.dg-card {
+    flex: 0 0 auto;
+    font-size: 10px;
+    font-weight: 600;
+    color: var(--tosd-muted);
+    background: var(--tosd-subtle);
+    border: 1px solid var(--tosd-border-soft);
+    border-radius: 20px;
+    padding: 0 6px;
+    font-variant-numeric: tabular-nums;
+    margin-right: 16px;
+}
+
+.dg-typeline {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    margin-top: 4px;
+}
+
+.dg-type {
+    font-size: 10.5px;
+    font-weight: 600;
+    font-family: var(--font-mono, monospace);
+    color: var(--cat-any);
+    background: color-mix(in srgb, var(--cat-any) 12%, transparent);
+    border-radius: 5px;
+    padding: 1px 6px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 150px;
+}
+
+.dg-type[data-cat="string"] { color: var(--cat-string); background: color-mix(in srgb, var(--cat-string) 12%, transparent); }
+.dg-type[data-cat="number"] { color: var(--cat-number); background: color-mix(in srgb, var(--cat-number) 12%, transparent); }
+.dg-type[data-cat="boolean"] { color: var(--cat-boolean); background: color-mix(in srgb, var(--cat-boolean) 12%, transparent); }
+.dg-type[data-cat="date"] { color: var(--cat-date); background: color-mix(in srgb, var(--cat-date) 12%, transparent); }
+.dg-type[data-cat="table"] { color: var(--cat-table); background: color-mix(in srgb, var(--cat-table) 12%, transparent); }
+.dg-type[data-cat="array"] { color: var(--cat-array); background: color-mix(in srgb, var(--cat-array) 12%, transparent); }
+.dg-type[data-cat="ref"] { color: var(--cat-ref); background: color-mix(in srgb, var(--cat-ref) 12%, transparent); }
+.dg-type[data-cat="choice"] { color: var(--cat-choice); background: color-mix(in srgb, var(--cat-choice) 12%, transparent); }
+
+.dg-jump {
+    border: none;
+    background: none;
+    padding: 0 2px;
+    font-size: 12px;
+    color: var(--cat-ref);
+    line-height: 1;
+}
+
+.dg-jump:hover {
+    background: none;
+    transform: scale(1.2);
+}
+
+.dg-expander {
+    position: absolute;
+    right: -1px;
+    top: 50%;
+    transform: translate(50%, -50%);
+    width: 18px;
+    height: 18px;
+    padding: 0;
+    border-radius: 50%;
+    background: var(--tosd-bg);
+    border: 1px solid var(--tosd-border);
+    color: var(--tosd-muted);
+    font-size: 13px;
+    line-height: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 2;
+    box-shadow: var(--tosd-shadow);
+}
+
+.dg-expander:hover {
+    border-color: var(--tosd-accent);
+    color: var(--tosd-accent);
+}
+
+.dg-actions {
+    position: absolute;
+    top: 4px;
+    right: 6px;
+    display: flex;
+    gap: 2px;
+    opacity: 0;
+    transition: opacity 0.1s ease;
+}
+
+.dg-box:hover .dg-actions {
+    opacity: 1;
+}
+
+.dg-actions button.icon {
+    padding: 0 5px;
+    font-size: 11px;
+    line-height: 1.5;
+    background: color-mix(in srgb, var(--tosd-bg) 85%, transparent);
+    backdrop-filter: blur(2px);
+}
+
+/* Root + compositor ------------------------------------------------------ */
+.dg-root {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 2px;
+    padding: 0 14px;
+    cursor: default;
+    background: linear-gradient(180deg, var(--tosd-bg), var(--tosd-subtle));
+    border-color: color-mix(in srgb, var(--tosd-accent) 35%, var(--tosd-border));
+}
+
+.dg-root-label {
+    font-family: var(--font-mono, monospace);
+    font-weight: 700;
+    font-size: 13px;
+    color: var(--tosd-accent);
+}
+
+.dg-root-sub {
+    font-size: 11px;
+    color: var(--tosd-muted);
+}
+
+.dg-comp {
+    position: absolute;
+    width: 22px;
+    height: 22px;
+    border-radius: 6px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+    background: var(--tosd-bg);
+    border: 1px solid var(--tosd-border);
+    color: var(--tosd-muted);
+    box-shadow: var(--tosd-shadow);
+    z-index: 1;
+}
+
+.dg-comp.choice {
+    color: var(--cat-choice);
+    border-color: color-mix(in srgb, var(--cat-choice) 45%, var(--tosd-border));
+}
+
+.dg-comp.repeat {
+    color: var(--cat-array);
+    border-color: color-mix(in srgb, var(--cat-array) 45%, var(--tosd-border));
+}
+
+.dg-empty {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    color: var(--tosd-muted);
+}
+
+/* Side column ------------------------------------------------------------ */
+.side {
+    display: grid;
+    grid-template-rows: 1fr 1fr;
+    min-height: 0;
+    min-width: 0;
+}
+
+.side-panel {
+    min-height: 0;
+    overflow: auto;
+    display: flex;
+    flex-direction: column;
+    background: var(--tosd-bg);
+}
+
+.side-panel:first-child {
+    border-bottom: 1px solid var(--tosd-border);
+}
+
+.preview-panel {
+    background: var(--tosd-elevated);
+}
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 14px;
+    position: sticky;
+    top: 0;
+    background: color-mix(in srgb, var(--tosd-bg) 88%, transparent);
+    backdrop-filter: blur(6px);
+    border-bottom: 1px solid var(--tosd-border);
+    z-index: 1;
+}
+
+.panel-head h2 {
+    margin: 0;
+    font-size: 11px;
+    font-weight: var(--font-weight-semibold, 600);
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    color: var(--tosd-muted);
+}
+
+.panel-head .spacer {
+    flex: 1;
+}
+
+/* Tree ------------------------------------------------------------------- */
+.tree {
+    padding: 8px 8px 24px;
+}
+
+.tree-section {
+    margin-bottom: 10px;
+}
+
+.tree-section > .section-label {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--tosd-muted);
+    padding: 8px 8px 4px;
+    font-weight: var(--font-weight-semibold, 600);
+}
+
+.node-row {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    padding: 4px 7px;
+    border-radius: var(--tosd-radius-sm);
+    cursor: pointer;
+    white-space: nowrap;
+    position: relative;
+    transition: background 0.1s ease;
+}
+
+.node-row:hover {
+    background: var(--tosd-subtle);
+}
+
+.node-row.selected {
+    background: var(--tosd-accent-soft);
+    box-shadow: inset 2px 0 0 var(--tosd-accent);
+}
+
+.node-row .twisty {
+    width: 15px;
+    text-align: center;
+    color: var(--tosd-muted);
+    flex: 0 0 auto;
+    user-select: none;
+    font-size: 10px;
+    border-radius: 4px;
+    transition: background 0.1s ease;
+}
+
+.node-row .twisty:hover {
+    background: color-mix(in srgb, var(--tosd-muted) 18%, transparent);
+}
+
+.meta-icon {
+    font-size: 12px !important;
+    color: var(--tosd-accent) !important;
+}
+
+.node-row .name {
+    font-weight: 500;
+    flex: 0 1 auto;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.node-row .badge {
+    font-size: 10.5px;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    color: var(--cat-any);
+    background: color-mix(in srgb, var(--cat-any) 11%, transparent);
+    border: 1px solid color-mix(in srgb, var(--cat-any) 26%, transparent);
+    border-radius: 20px;
+    padding: 0 7px;
+    flex: 0 0 auto;
+    font-family: var(--font-mono, monospace);
+}
+
+.node-row .badge[data-cat="string"] {
+    color: var(--cat-string);
+    background: color-mix(in srgb, var(--cat-string) 11%, transparent);
+    border-color: color-mix(in srgb, var(--cat-string) 26%, transparent);
+}
+
+.node-row .badge[data-cat="number"] {
+    color: var(--cat-number);
+    background: color-mix(in srgb, var(--cat-number) 11%, transparent);
+    border-color: color-mix(in srgb, var(--cat-number) 26%, transparent);
+}
+
+.node-row .badge[data-cat="boolean"] {
+    color: var(--cat-boolean);
+    background: color-mix(in srgb, var(--cat-boolean) 11%, transparent);
+    border-color: color-mix(in srgb, var(--cat-boolean) 26%, transparent);
+}
+
+.node-row .badge[data-cat="date"] {
+    color: var(--cat-date);
+    background: color-mix(in srgb, var(--cat-date) 11%, transparent);
+    border-color: color-mix(in srgb, var(--cat-date) 26%, transparent);
+}
+
+.node-row .badge[data-cat="table"] {
+    color: var(--cat-table);
+    background: color-mix(in srgb, var(--cat-table) 11%, transparent);
+    border-color: color-mix(in srgb, var(--cat-table) 26%, transparent);
+}
+
+.node-row .badge[data-cat="array"] {
+    color: var(--cat-array);
+    background: color-mix(in srgb, var(--cat-array) 11%, transparent);
+    border-color: color-mix(in srgb, var(--cat-array) 26%, transparent);
+}
+
+.node-row .badge[data-cat="ref"] {
+    color: var(--cat-ref);
+    background: color-mix(in srgb, var(--cat-ref) 11%, transparent);
+    border-color: color-mix(in srgb, var(--cat-ref) 26%, transparent);
+}
+
+.node-row .badge[data-cat="choice"] {
+    color: var(--cat-choice);
+    background: color-mix(in srgb, var(--cat-choice) 11%, transparent);
+    border-color: color-mix(in srgb, var(--cat-choice) 26%, transparent);
+}
+
+.node-row .opt {
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--tosd-warn);
+    background: color-mix(in srgb, var(--tosd-warn) 12%, transparent);
+    border-radius: 4px;
+    padding: 0 4px;
+    flex: 0 0 auto;
+}
+
+.row-actions {
+    margin-left: auto;
+    display: flex;
+    gap: 2px;
+    opacity: 0;
+    flex: 0 0 auto;
+    padding-left: 6px;
+    transition: opacity 0.1s ease;
+}
+
+.node-row:hover .row-actions,
+.node-row.selected .row-actions {
+    opacity: 1;
+}
+
+.row-actions button.icon {
+    padding: 0 6px;
+    font-size: 11px;
+    line-height: 1.6;
+    background: color-mix(in srgb, var(--tosd-bg) 80%, transparent);
+}
+
+.children {
+    margin-left: 15px;
+    border-left: 1.5px solid var(--tosd-border-soft);
+    padding-left: 5px;
+}
+
+/* Editor ----------------------------------------------------------------- */
+.editor {
+    padding: 16px 18px;
+}
+
+.editor .empty {
+    color: var(--tosd-muted);
+    padding: 40px 16px;
+    text-align: center;
+    border: 1.5px dashed var(--tosd-border);
+    border-radius: var(--tosd-radius);
+    background: var(--tosd-subtle);
+}
+
+.field {
+    margin-bottom: 14px;
+}
+
+.field label {
+    display: block;
+    font-size: 12px;
+    font-weight: var(--font-weight-semibold, 600);
+    margin-bottom: 5px;
+}
+
+.field .hint {
+    font-weight: 400;
+    color: var(--tosd-muted);
+    margin-left: 6px;
+}
+
+.field input[type="text"],
+.field input[type="number"],
+.field select {
+    width: 100%;
+    padding: 6px 9px;
+    border: 1px solid var(--tosd-border);
+    border-radius: var(--tosd-radius-sm);
+    background: var(--tosd-bg);
+    color: inherit;
+    font: inherit;
+    transition: border-color 0.12s ease, box-shadow 0.12s ease;
+}
+
+.field input[type="text"]:focus,
+.field input[type="number"]:focus,
+.field select:focus {
+    outline: none;
+    border-color: var(--tosd-accent);
+    box-shadow: 0 0 0 3px var(--tosd-accent-soft);
+}
+
+.field input.mono {
+    font-family: var(--font-mono, monospace);
+}
+
+.field.inline {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.field.inline label {
+    margin: 0;
+}
+
+.field.inline input[type="checkbox"] {
+    width: 16px;
+    height: 16px;
+    accent-color: var(--tosd-accent);
+    cursor: pointer;
+}
+
+.row-2 {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+}
+
+.list-row {
+    display: flex;
+    gap: 6px;
+    margin-bottom: 6px;
+}
+
+.list-row input {
+    flex: 1;
+    padding: 6px 9px;
+    border: 1px solid var(--tosd-border);
+    border-radius: var(--tosd-radius-sm);
+    background: var(--tosd-bg);
+    color: inherit;
+    font: inherit;
+}
+
+.list-row input:focus {
+    outline: none;
+    border-color: var(--tosd-accent);
+    box-shadow: 0 0 0 3px var(--tosd-accent-soft);
+}
+
+.section-title {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--tosd-muted);
+    font-weight: var(--font-weight-semibold, 600);
+    margin: 20px 0 10px;
+    border-top: 1px solid var(--tosd-border);
+    padding-top: 14px;
+}
+
+.toggle-all {
+    background: none;
+    border: none;
+    color: var(--tosd-accent);
+    padding: 0;
+    margin-top: 4px;
+}
+
+.toggle-all:hover {
+    background: none;
+    text-decoration: underline;
+}
+
+/* Preview + issues ------------------------------------------------------- */
+.preview-wrap {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    flex: 1;
+}
+
+pre.preview {
+    margin: 0;
+    padding: 14px 16px;
+    overflow: auto;
+    flex: 1;
+    background:
+        linear-gradient(180deg, color-mix(in srgb, var(--tosd-subtle) 60%, var(--tosd-bg)), var(--tosd-subtle));
+    white-space: pre;
+    font-family: var(--font-mono, monospace);
+    font-size: 12px;
+    line-height: 1.6;
+    tab-size: 4;
+}
+
+.issues {
+    border-top: 1px solid var(--tosd-border);
+    max-height: 40%;
+    overflow: auto;
+    padding: 6px 0;
+    background: var(--tosd-bg);
+}
+
+.issues:empty {
+    display: none;
+}
+
+.issue {
+    display: flex;
+    gap: 8px;
+    padding: 6px 14px;
+    font-size: 12px;
+    align-items: baseline;
+}
+
+.issue + .issue {
+    border-top: 1px solid var(--tosd-border-soft);
+}
+
+.issue .lvl {
+    font-weight: 600;
+    flex: 0 0 auto;
+    text-transform: uppercase;
+    font-size: 10px;
+    letter-spacing: 0.04em;
+    padding: 1px 6px;
+    border-radius: 4px;
+}
+
+.issue.error .lvl {
+    color: var(--tosd-error);
+    background: color-mix(in srgb, var(--tosd-error) 12%, transparent);
+}
+
+.issue.warning .lvl {
+    color: var(--tosd-warn);
+    background: color-mix(in srgb, var(--tosd-warn) 12%, transparent);
+}
+
+.issue .where {
+    color: var(--tosd-muted);
+    font-family: var(--font-mono, monospace);
+}
+
+.tabs {
+    display: flex;
+    gap: 4px;
+}
+
+.tab {
+    padding: 2px 8px;
+    font-size: 12px;
+    border-radius: var(--tosd-radius-sm);
+    border: 1px solid transparent;
+}
+
+.tab.active {
+    border-color: var(--tosd-border);
+    background: var(--tosd-subtle);
+}
+
+.pill {
+    font-size: 10.5px;
+    font-weight: 600;
+    border-radius: 20px;
+    padding: 1px 9px;
+    border: 1px solid var(--tosd-border);
+    color: var(--tosd-muted);
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+}
+
+.pill::before {
+    content: "";
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: currentColor;
+}
+
+.pill.err {
+    color: var(--tosd-error);
+    border-color: color-mix(in srgb, var(--tosd-error) 40%, transparent);
+    background: color-mix(in srgb, var(--tosd-error) 8%, transparent);
+}
+
+.pill.ok {
+    color: var(--tosd-ok);
+    border-color: color-mix(in srgb, var(--tosd-ok) 40%, transparent);
+    background: color-mix(in srgb, var(--tosd-ok) 8%, transparent);
+}
+
+/* Infer modal ------------------------------------------------------------ */
+.modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: color-mix(in srgb, #1f2328 48%, transparent);
+    backdrop-filter: blur(2px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 100;
+    animation: tosd-fade 0.12s ease;
+}
+
+@keyframes tosd-fade {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+.modal {
+    background: var(--tosd-bg);
+    border: 1px solid var(--tosd-border);
+    border-radius: 12px;
+    padding: 20px 22px;
+    width: min(640px, 92vw);
+    max-height: 86vh;
+    overflow: auto;
+    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.32);
+    animation: tosd-pop 0.14s ease;
+}
+
+@keyframes tosd-pop {
+    from { transform: translateY(6px) scale(0.99); opacity: 0; }
+    to { transform: none; opacity: 1; }
+}
+
+.modal h3 {
+    margin: 0 0 6px;
+    font-size: var(--text-title-small, 16px);
+}
+
+.modal p.hint {
+    color: var(--tosd-muted);
+    margin: 0 0 12px;
+}
+
+.modal-textarea {
+    width: 100%;
+    min-height: 240px;
+    resize: vertical;
+    padding: 10px 12px;
+    border: 1px solid var(--tosd-border);
+    border-radius: var(--tosd-radius-sm);
+    background: var(--tosd-subtle);
+    color: inherit;
+    font-family: var(--font-mono, monospace);
+    font-size: 12px;
+    line-height: 1.5;
+    margin-top: 8px;
+}
+
+.modal-textarea:focus {
+    outline: none;
+    border-color: var(--tosd-accent);
+    box-shadow: 0 0 0 3px var(--tosd-accent-soft);
+}
+
+.modal-err {
+    color: var(--tosd-error);
+    font-size: 12px;
+    min-height: 16px;
+    margin-top: 6px;
+}
+
+.modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 14px;
+}
+
+/* Scrollbars ------------------------------------------------------------- */
+.side-panel::-webkit-scrollbar,
+.diagram-scroll::-webkit-scrollbar,
+.modal::-webkit-scrollbar,
+pre.preview::-webkit-scrollbar,
+.issues::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+}
+
+.side-panel::-webkit-scrollbar-thumb,
+.diagram-scroll::-webkit-scrollbar-thumb,
+.modal::-webkit-scrollbar-thumb,
+pre.preview::-webkit-scrollbar-thumb,
+.issues::-webkit-scrollbar-thumb {
+    background: color-mix(in srgb, var(--tosd-muted) 30%, transparent);
+    border-radius: 10px;
+    border: 2px solid transparent;
+    background-clip: padding-box;
+}
+
+.side-panel::-webkit-scrollbar-thumb:hover,
+pre.preview::-webkit-scrollbar-thumb:hover {
+    background: color-mix(in srgb, var(--tosd-muted) 50%, transparent);
+    background-clip: padding-box;
+}

--- a/.github/extensions/tosd-editor/styles.css
+++ b/.github/extensions/tosd-editor/styles.css
@@ -59,52 +59,119 @@ code,
 /* Toolbar ---------------------------------------------------------------- */
 .toolbar {
     display: flex;
-    align-items: center;
-    gap: 10px;
+    flex-direction: column;
+    gap: 8px;
     padding: 10px 14px;
     border-bottom: 1px solid var(--tosd-border);
     background: linear-gradient(180deg, var(--tosd-bg), var(--tosd-subtle));
     flex: 0 0 auto;
 }
 
-.toolbar .title {
-    font-weight: var(--font-weight-semibold, 600);
+.tb-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    overflow-x: auto;
+    scrollbar-width: none;
+}
+
+.tb-row::-webkit-scrollbar {
+    display: none;
+}
+
+.tb-row-actions {
+    padding-top: 8px;
+    border-top: 1px solid var(--tosd-border-soft);
+}
+
+.tb-brand {
     display: inline-flex;
     align-items: center;
-    gap: 7px;
-    letter-spacing: -0.01em;
+    gap: 8px;
+    flex: 0 0 auto;
+    white-space: nowrap;
 }
 
 .brand-mark {
     color: var(--tosd-accent);
-    font-size: 13px;
-    transform: translateY(0.5px);
-    filter: drop-shadow(0 1px 1px color-mix(in srgb, var(--tosd-accent) 40%, transparent));
+    font-size: 15px;
+    line-height: 1;
+    filter: drop-shadow(0 1px 2px color-mix(in srgb, var(--tosd-accent) 45%, transparent));
 }
 
-.toolbar .path {
-    color: var(--tosd-muted);
+.brand-text {
+    font-size: 14px;
+    font-weight: 500;
+    letter-spacing: -0.01em;
+    color: var(--text-color-default);
+}
+
+.brand-text b {
+    font-weight: var(--font-weight-semibold, 700);
+}
+
+.tb-sep {
+    width: 1px;
+    align-self: stretch;
+    margin: 4px 0;
+    background: var(--tosd-border);
+    flex: 0 0 auto;
+}
+
+.tb-info {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.path-field {
+    color: var(--text-color-default);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    max-width: 36ch;
-    padding: 2px 8px;
-    background: var(--tosd-subtle);
-    border: 1px solid var(--tosd-border-soft);
-    border-radius: 20px;
+    flex: 1 1 320px;
+    min-width: 180px;
+    max-width: 520px;
+    padding: 5px 10px;
+    background: var(--tosd-bg);
+    border: 1px solid var(--tosd-border);
+    border-radius: 6px;
+    font-family: var(--font-mono, monospace);
     font-size: 12px;
+    box-shadow: var(--tosd-shadow);
+    cursor: text;
+}
+
+.path-field:read-only {
+    background: var(--tosd-subtle);
+}
+
+.path-field:focus {
+    outline: 2px solid var(--color-focus-outline, var(--tosd-accent));
+    outline-offset: 1px;
+    border-color: var(--tosd-accent);
 }
 
 .toolbar .spacer {
     flex: 1 1 auto;
+    min-width: 8px;
 }
 
 .status {
     font-size: 12px;
+    font-weight: 500;
     color: var(--tosd-muted);
     display: inline-flex;
     align-items: center;
     gap: 6px;
+    white-space: nowrap;
+    flex: 0 0 auto;
+    padding: 3px 10px;
+    border-radius: 20px;
+    border: 1px solid var(--tosd-border-soft);
+    background: var(--tosd-bg);
 }
 
 .status::before {
@@ -113,15 +180,81 @@ code,
     height: 7px;
     border-radius: 50%;
     background: currentColor;
-    opacity: 0.7;
+    flex: 0 0 auto;
 }
 
 .status.dirty {
     color: var(--tosd-warn);
+    border-color: color-mix(in srgb, var(--tosd-warn) 35%, transparent);
+    background: color-mix(in srgb, var(--tosd-warn) 8%, transparent);
 }
 
 .status.saved {
     color: var(--tosd-ok);
+    border-color: color-mix(in srgb, var(--tosd-ok) 35%, transparent);
+    background: color-mix(in srgb, var(--tosd-ok) 8%, transparent);
+}
+
+/* Toolbar action buttons ------------------------------------------------- */
+.tb-actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex: 1 1 auto;
+    width: 100%;
+}
+
+.tb-group {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    height: 30px;
+    padding: 0 12px;
+    white-space: nowrap;
+    border-radius: 7px;
+    font-size: 13px;
+    font-weight: 500;
+    flex: 0 0 auto;
+}
+
+.btn .bi {
+    font-size: 13px;
+    line-height: 1;
+    opacity: 0.85;
+}
+
+.btn.ghost {
+    border-color: transparent;
+    background: transparent;
+    color: var(--tosd-muted);
+}
+
+.btn.ghost:hover {
+    background: var(--tosd-subtle);
+    border-color: var(--tosd-border);
+    color: var(--text-color-default);
+}
+
+.btn.accent {
+    border-color: color-mix(in srgb, var(--tosd-accent) 45%, var(--tosd-border));
+    background: color-mix(in srgb, var(--tosd-accent) 8%, var(--tosd-bg));
+    color: var(--tosd-accent);
+    font-weight: 600;
+}
+
+.btn.accent:hover {
+    background: color-mix(in srgb, var(--tosd-accent) 15%, var(--tosd-bg));
+    border-color: var(--tosd-accent);
+}
+
+.btn.accent .bi {
+    opacity: 1;
 }
 
 button {

--- a/.github/extensions/tosd-editor/toml.mjs
+++ b/.github/extensions/tosd-editor/toml.mjs
@@ -1,0 +1,496 @@
+// Self-contained TOML parser + serializer focused on the TOML Schema
+// definition (.tosd) subset. .tosd documents are valid TOML 1.0 documents
+// composed of table headers and scalar/array/inline-table values.
+//
+// Design notes:
+//   * Table headers ([a.b.c]) produce nested plain objects. A plain object in
+//     the resulting tree therefore always represents a sub-table — i.e. a child
+//     schema definition.
+//   * Inline tables ({ a = 1 }) are tagged as { __inline: true, value: {...} }
+//     so they are never confused with sub-tables (relevant only for `default`).
+//   * Date/time values are tagged as { __datetime: kind, value: "..." } so the
+//     serializer emits them bare instead of quoting them.
+//
+// This is intentionally pragmatic, not a 100% conformant TOML implementation,
+// but it round-trips every construct used by TOML Schema documents.
+
+export class TomlError extends Error {}
+
+const DATETIME_RE =
+    /^(\d{4}-\d{2}-\d{2}([Tt ]\d{2}:\d{2}:\d{2}(\.\d+)?([Zz]|[+-]\d{2}:\d{2})?)?|\d{2}:\d{2}:\d{2}(\.\d+)?)$/;
+
+function classifyDatetime(raw) {
+    // raw is the already-trimmed token text.
+    if (/^\d{2}:\d{2}:\d{2}(\.\d+)?$/.test(raw)) return "local-time";
+    if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) return "local-date";
+    if (/[Zz]|[+-]\d{2}:\d{2}$/.test(raw) && /[Tt ]/.test(raw)) return "offset-date-time";
+    if (/[Tt ]/.test(raw)) return "local-date-time";
+    return null;
+}
+
+// ---------------------------------------------------------------------------
+// Parser
+// ---------------------------------------------------------------------------
+
+export function parseToml(text) {
+    const root = {};
+    let current = root;
+
+    const lines = splitLogicalLines(text);
+    for (const line of lines) {
+        const trimmed = stripComment(line).trim();
+        if (trimmed === "") continue;
+
+        if (trimmed.startsWith("[")) {
+            if (trimmed.startsWith("[[")) {
+                const name = trimmed.slice(2, trimmed.lastIndexOf("]]")).trim();
+                const path = parseKeyPath(name);
+                current = enterArrayTable(root, path);
+            } else {
+                const name = trimmed.slice(1, trimmed.lastIndexOf("]")).trim();
+                const path = parseKeyPath(name);
+                current = enterTable(root, path);
+            }
+            continue;
+        }
+
+        const eq = findTopLevelEquals(trimmed);
+        if (eq < 0) throw new TomlError(`Invalid line (no '='): ${line}`);
+        const keyText = trimmed.slice(0, eq).trim();
+        const valueText = trimmed.slice(eq + 1).trim();
+        const keyPath = parseKeyPath(keyText);
+        const value = parseValue(valueText);
+        assignKey(current, keyPath, value);
+    }
+
+    return root;
+}
+
+// Joins physical lines so that multi-line arrays / inline structures / multi-line
+// strings are treated as a single logical line for the simple line scanner above.
+function splitLogicalLines(text) {
+    const out = [];
+    const raw = text.split(/\r?\n/);
+    let buf = null;
+    let depth = 0;
+    let inMultiline = null; // '"""' or "'''"
+
+    for (let i = 0; i < raw.length; i++) {
+        let line = raw[i];
+
+        if (inMultiline) {
+            buf += "\n" + line;
+            if (line.includes(inMultiline)) {
+                inMultiline = null;
+                if (depth === 0) {
+                    out.push(buf);
+                    buf = null;
+                }
+            }
+            continue;
+        }
+
+        const open = openMultiline(line);
+        if (open) {
+            inMultiline = open;
+            buf = (buf === null ? "" : buf + "\n") + line;
+            continue;
+        }
+
+        if (buf !== null) {
+            buf += "\n" + line;
+            depth += bracketDelta(line);
+            if (depth <= 0) {
+                out.push(buf);
+                buf = null;
+                depth = 0;
+            }
+            continue;
+        }
+
+        const delta = bracketDelta(line);
+        if (delta > 0 && !line.trim().startsWith("[")) {
+            buf = line;
+            depth = delta;
+            continue;
+        }
+        out.push(line);
+    }
+    if (buf !== null) out.push(buf);
+    return out;
+}
+
+// Detect an unterminated multi-line string opener on a line (outside comments).
+function openMultiline(line) {
+    const code = stripComment(line);
+    for (const delim of ['"""', "'''"]) {
+        const first = code.indexOf(delim);
+        if (first >= 0) {
+            const rest = code.slice(first + 3);
+            if (!rest.includes(delim)) return delim;
+        }
+    }
+    return null;
+}
+
+// Net change of [ and { brackets on a line, ignoring those inside strings/comments.
+function bracketDelta(line) {
+    const code = removeStrings(stripComment(line));
+    let d = 0;
+    for (const ch of code) {
+        if (ch === "[" || ch === "{") d++;
+        else if (ch === "]" || ch === "}") d--;
+    }
+    return d;
+}
+
+function removeStrings(s) {
+    return s.replace(/"(?:\\.|[^"\\])*"/g, '""').replace(/'[^']*'/g, "''");
+}
+
+function stripComment(line) {
+    let inBasic = false;
+    let inLiteral = false;
+    for (let i = 0; i < line.length; i++) {
+        const ch = line[i];
+        if (inBasic) {
+            if (ch === "\\") i++;
+            else if (ch === '"') inBasic = false;
+        } else if (inLiteral) {
+            if (ch === "'") inLiteral = false;
+        } else if (ch === '"') inBasic = true;
+        else if (ch === "'") inLiteral = true;
+        else if (ch === "#") return line.slice(0, i);
+    }
+    return line;
+}
+
+function findTopLevelEquals(s) {
+    let inBasic = false;
+    let inLiteral = false;
+    for (let i = 0; i < s.length; i++) {
+        const ch = s[i];
+        if (inBasic) {
+            if (ch === "\\") i++;
+            else if (ch === '"') inBasic = false;
+        } else if (inLiteral) {
+            if (ch === "'") inLiteral = false;
+        } else if (ch === '"') inBasic = true;
+        else if (ch === "'") inLiteral = true;
+        else if (ch === "=") return i;
+    }
+    return -1;
+}
+
+export function parseKeyPath(text) {
+    const parts = [];
+    let i = 0;
+    const s = text.trim();
+    while (i < s.length) {
+        while (i < s.length && /\s/.test(s[i])) i++;
+        if (s[i] === '"' || s[i] === "'") {
+            const quote = s[i];
+            i++;
+            let buf = "";
+            while (i < s.length && s[i] !== quote) {
+                if (quote === '"' && s[i] === "\\") {
+                    buf += unescapeChar(s, i);
+                    i += escapeLen(s, i);
+                } else {
+                    buf += s[i];
+                    i++;
+                }
+            }
+            i++; // closing quote
+            parts.push(buf);
+        } else {
+            let buf = "";
+            while (i < s.length && s[i] !== "." && !/\s/.test(s[i])) {
+                buf += s[i];
+                i++;
+            }
+            if (buf !== "") parts.push(buf);
+        }
+        while (i < s.length && /\s/.test(s[i])) i++;
+        if (s[i] === ".") i++;
+    }
+    return parts;
+}
+
+function enterTable(root, path) {
+    let node = root;
+    for (const key of path) {
+        if (node[key] === undefined) node[key] = {};
+        node = node[key];
+    }
+    return node;
+}
+
+function enterArrayTable(root, path) {
+    let node = root;
+    for (let i = 0; i < path.length - 1; i++) {
+        const key = path[i];
+        if (node[key] === undefined) node[key] = {};
+        node = node[key];
+    }
+    const last = path[path.length - 1];
+    if (!Array.isArray(node[last])) node[last] = [];
+    const entry = {};
+    node[last].push(entry);
+    return entry;
+}
+
+function assignKey(table, path, value) {
+    let node = table;
+    for (let i = 0; i < path.length - 1; i++) {
+        const key = path[i];
+        if (node[key] === undefined) node[key] = {};
+        node = node[key];
+    }
+    node[path[path.length - 1]] = value;
+}
+
+export function parseValue(text) {
+    const s = text.trim();
+    if (s === "") throw new TomlError("Empty value");
+
+    if (s.startsWith('"""') || s.startsWith("'''")) return parseMultilineString(s);
+    if (s[0] === '"') return parseBasicString(s);
+    if (s[0] === "'") return parseLiteralString(s);
+    if (s[0] === "[") return parseArray(s);
+    if (s[0] === "{") return parseInlineTable(s);
+
+    if (s === "true") return true;
+    if (s === "false") return false;
+
+    if (DATETIME_RE.test(s)) {
+        const kind = classifyDatetime(s);
+        if (kind) return { __datetime: kind, value: s };
+    }
+
+    const num = parseNumber(s);
+    if (num !== undefined) return num;
+
+    throw new TomlError(`Cannot parse value: ${text}`);
+}
+
+function parseNumber(s) {
+    if (/^[+-]?(inf|nan)$/.test(s)) {
+        if (s.endsWith("nan")) return NaN;
+        return s[0] === "-" ? -Infinity : Infinity;
+    }
+    const cleaned = s.replace(/_/g, "");
+    if (/^[+-]?0x[0-9a-fA-F]+$/.test(cleaned)) return parseInt(cleaned, 16);
+    if (/^[+-]?0o[0-7]+$/.test(cleaned)) return parseInt(cleaned.replace(/0o/, ""), 8);
+    if (/^[+-]?0b[01]+$/.test(cleaned)) return parseInt(cleaned.replace(/0b/, ""), 2);
+    if (/^[+-]?\d+$/.test(cleaned)) return parseInt(cleaned, 10);
+    if (/^[+-]?(\d+(\.\d+)?([eE][+-]?\d+)?)$/.test(cleaned)) return parseFloat(cleaned);
+    return undefined;
+}
+
+function parseBasicString(s) {
+    const { value } = readBasicString(s, 0);
+    return value;
+}
+
+function readBasicString(s, start) {
+    let i = start + 1;
+    let buf = "";
+    while (i < s.length && s[i] !== '"') {
+        if (s[i] === "\\") {
+            buf += unescapeChar(s, i);
+            i += escapeLen(s, i);
+        } else {
+            buf += s[i];
+            i++;
+        }
+    }
+    return { value: buf, end: i + 1 };
+}
+
+function parseLiteralString(s) {
+    const { value } = readLiteralString(s, 0);
+    return value;
+}
+
+function readLiteralString(s, start) {
+    let i = start + 1;
+    let buf = "";
+    while (i < s.length && s[i] !== "'") {
+        buf += s[i];
+        i++;
+    }
+    return { value: buf, end: i + 1 };
+}
+
+function parseMultilineString(s) {
+    const delim = s.slice(0, 3);
+    const closeIdx = s.indexOf(delim, 3);
+    let inner = s.slice(3, closeIdx);
+    if (inner.startsWith("\n")) inner = inner.slice(1);
+    else if (inner.startsWith("\r\n")) inner = inner.slice(2);
+    if (delim === "'''") return inner;
+    // Basic multiline: process escapes and line-ending backslash trimming.
+    inner = inner.replace(/\\\s*\n\s*/g, "");
+    let buf = "";
+    for (let i = 0; i < inner.length; i++) {
+        if (inner[i] === "\\") {
+            buf += unescapeChar(inner, i);
+            i += escapeLen(inner, i) - 1;
+        } else buf += inner[i];
+    }
+    return buf;
+}
+
+function escapeLen(s, i) {
+    const c = s[i + 1];
+    if (c === "u") return 6;
+    if (c === "U") return 10;
+    return 2;
+}
+
+function unescapeChar(s, i) {
+    const c = s[i + 1];
+    switch (c) {
+        case "n": return "\n";
+        case "t": return "\t";
+        case "r": return "\r";
+        case '"': return '"';
+        case "\\": return "\\";
+        case "b": return "\b";
+        case "f": return "\f";
+        case "/": return "/";
+        case "u": return String.fromCodePoint(parseInt(s.slice(i + 2, i + 6), 16));
+        case "U": return String.fromCodePoint(parseInt(s.slice(i + 2, i + 10), 16));
+        default: return c;
+    }
+}
+
+function parseArray(s) {
+    const inner = s.slice(1, s.lastIndexOf("]"));
+    const tokens = splitTopLevel(inner);
+    return tokens.filter((t) => t.trim() !== "").map((t) => parseValue(t.trim()));
+}
+
+function parseInlineTable(s) {
+    const inner = s.slice(1, s.lastIndexOf("}"));
+    const tokens = splitTopLevel(inner);
+    const obj = {};
+    for (const tok of tokens) {
+        const t = tok.trim();
+        if (t === "") continue;
+        const eq = findTopLevelEquals(t);
+        const key = parseKeyPath(t.slice(0, eq).trim());
+        const val = parseValue(t.slice(eq + 1).trim());
+        assignKey(obj, key, val);
+    }
+    return { __inline: true, value: obj };
+}
+
+// Split a comma-separated list, respecting nested brackets/braces and strings.
+function splitTopLevel(text) {
+    const out = [];
+    let depth = 0;
+    let buf = "";
+    let inBasic = false;
+    let inLiteral = false;
+    for (let i = 0; i < text.length; i++) {
+        const ch = text[i];
+        if (inBasic) {
+            buf += ch;
+            if (ch === "\\") {
+                buf += text[i + 1] ?? "";
+                i++;
+            } else if (ch === '"') inBasic = false;
+            continue;
+        }
+        if (inLiteral) {
+            buf += ch;
+            if (ch === "'") inLiteral = false;
+            continue;
+        }
+        if (ch === '"') { inBasic = true; buf += ch; continue; }
+        if (ch === "'") { inLiteral = true; buf += ch; continue; }
+        if (ch === "[" || ch === "{") { depth++; buf += ch; continue; }
+        if (ch === "]" || ch === "}") { depth--; buf += ch; continue; }
+        if (ch === "," && depth === 0) { out.push(buf); buf = ""; continue; }
+        if (ch === "#" && depth === 0) break; // trailing comment in multiline arrays
+        buf += ch;
+    }
+    if (buf.trim() !== "") out.push(buf);
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// Serializer (value-level)
+// ---------------------------------------------------------------------------
+
+const BARE_KEY_RE = /^[A-Za-z0-9_-]+$/;
+
+export function formatKeyPath(parts) {
+    return parts.map(formatKey).join(".");
+}
+
+export function formatKey(key) {
+    if (BARE_KEY_RE.test(key) && key !== "") return key;
+    // Prefer literal quoting unless the key contains a single quote.
+    if (!key.includes("'")) return `'${key}'`;
+    return `"${escapeBasic(key)}"`;
+}
+
+export function formatValue(value) {
+    if (value === null || value === undefined) return '""';
+    if (typeof value === "boolean") return value ? "true" : "false";
+    if (typeof value === "number") return formatNumber(value);
+    if (typeof value === "string") return formatString(value);
+    if (Array.isArray(value)) return "[ " + value.map(formatValue).join(", ") + " ]";
+    if (value.__datetime) return value.value;
+    if (value.__inline) return formatInline(value.value);
+    if (typeof value === "object") return formatInline(value);
+    return '""';
+}
+
+function formatInline(obj) {
+    const parts = Object.entries(obj).map(([k, v]) => `${formatKey(k)} = ${formatValue(v)}`);
+    return "{ " + parts.join(", ") + " }";
+}
+
+function formatNumber(n) {
+    if (Number.isNaN(n)) return "nan";
+    if (n === Infinity) return "inf";
+    if (n === -Infinity) return "-inf";
+    return String(n);
+}
+
+function formatString(s) {
+    // Use a literal string when it avoids backslash noise (e.g. regex patterns)
+    // and the content has no single quotes or newlines.
+    if (!s.includes("'") && !s.includes("\n") && !s.includes("\r")) {
+        return `'${s}'`;
+    }
+    return `"${escapeBasic(s)}"`;
+}
+
+function escapeBasic(s) {
+    return s.replace(/[\\"\n\r\t]/g, (ch) => {
+        switch (ch) {
+            case "\\": return "\\\\";
+            case '"': return '\\"';
+            case "\n": return "\\n";
+            case "\r": return "\\r";
+            case "\t": return "\\t";
+            default: return ch;
+        }
+    });
+}
+
+// Helpers exposed for the model layer.
+export function isPlainTable(value) {
+    return (
+        value !== null &&
+        typeof value === "object" &&
+        !Array.isArray(value) &&
+        !value.__datetime &&
+        !value.__inline
+    );
+}


### PR DESCRIPTION
## Overview

Adds a rich, XMLSpy-style visual editor for TOML Schema definition (`.tosd`) documents as a Copilot CLI **canvas extension** under `.github/extensions/tosd-editor/`. The editor runs a per-instance loopback HTTP server and serves a single-page app that reads/writes the schema file on disk.

## Features

- **Graphical design view** — a connected-box diagram (elements & types) with elbow connectors, compositor glyphs, cardinality badges, expand/collapse, type-ref jumping, zoom, **Fit** (resets to top-left), and a **pan/hand tool** to drag the canvas.
- **Contextual property editor** — edit a node's type and constraints, with a close/deselect affordance (✕, click-empty-canvas, or Escape).
- **Live TOML preview + inline validation** — serialized schema and lint issues update as you edit.
- **Schema inference** — infer a schema from a sample TOML document (paste or load from a path).
- **Copilot generation** — describe a configuration file in natural language and let Copilot draft the schema (`session.sendAndWait`).
- **File operations** — `New` (empty schema), **`Open`** an existing `.tosd` by path (validated `/open` endpoint), `Save`, and `Revert`.
- **Two-row toolbar** — an info row (brand, read-only **copyable path field**, validity pill, dirty/saved status chip) and an action row of grouped, non-wrapping buttons separated by vertical dividers.
- **Polished theme** — color-coded type badges, accent-bar selection, frosted sticky headers, custom scrollbars, animated modals; uses the app's canvas theme tokens.

## Notable finding (tracked separately)

While building the editor, its lint flagged a long-standing smell in the checked-in `config.tosd`: a `pattern` on a `collection` type, which is semantically dead (per `SPEC.md`, `pattern` only validates `string` input). Git history shows it was a deliberate-but-never-formalized attempt to constrain collection **keys**. This is captured in #57 (proposal to add a dedicated `keypattern` property), with an XSD/JSON-Schema prior-art comparison. The lint message in this PR was clarified to name the offending type and state that the pattern is ignored; the example file itself is intentionally left unchanged pending the #57 decision.

## Files

- `extension.mjs` — canvas declaration + loopback server; `/state`, `/preview`, `/save`, `/open`, `/readfile`, `/infer`, `/generate` endpoints; `get_document` / `reload_from_disk` / `infer_from_toml` / `generate_from_description` actions.
- `client.js` — the single-page editor (diagram engine, property editor, modals, pan, generate, open).
- `styles.css` — full visual theme.
- `model.mjs`, `toml.mjs`, `infer.mjs` — model parse/serialize/validate, TOML helpers, schema inference.

## Testing

- `node --check` on all `.mjs`/`client.js`; CSS brace-balance verified.
- jsdom headless smoke tests confirm the diagram renders, the toolbar wires up, the path field is a read-only input, and the Open modal opens with no runtime errors.
- `/open` endpoint manually exercised for valid, missing, non-`.tosd`, and empty-path cases.

Relates to #57.