### PR TITLE
Add `keypattern` property for collection key validation

### DIFF
--- a/.github/extensions/tosd-editor/client.js
+++ b/.github/extensions/tosd-editor/client.js
@@ -567,6 +567,11 @@ function renderEditor() {
         box.append(textField("pattern", "Pattern (regex)", p.pattern || "", (v) => setProp(p, "pattern", v), true,
             "PCRE-compatible regular expression."));
     }
+    // collection key pattern
+    if (t === "collection") {
+        box.append(textField("keypattern", "Key pattern (regex)", p.keypattern || "", (v) => setProp(p, "keypattern", v), true,
+            "PCRE-compatible regex every dynamic entry key must match."));
+    }
     if (SIMPLE_TYPES.includes(t) || t === "array") {
         box.append(listField("allowedvalues", "Allowed values (enum)", p.allowedvalues || [],
             (arr) => setListProp(p, "allowedvalues", arr), false,
@@ -619,7 +624,7 @@ function renderEditor() {
 function advancedAll(p) {
     const wrap = el("div");
     wrap.append(el("div", { class: "section-title", text: "All properties" }));
-    const allProps = ["type", "typeof", "arraytype", "itemtype", "pattern", "min", "max", "default"];
+    const allProps = ["type", "typeof", "arraytype", "itemtype", "pattern", "keypattern", "min", "max", "default"];
     for (const key of allProps) {
         wrap.append(textField(key, key, p[key] != null ? String(p[key]) : "", (v) => setProp(p, key, v), true));
     }

--- a/.github/extensions/tosd-editor/model.mjs
+++ b/.github/extensions/tosd-editor/model.mjs
@@ -11,7 +11,7 @@
 // node = { name, props: { <prop>: <editorValue> }, children: [ node, ... ] }
 //
 // Editor value encoding per property:
-//   type/typeof/arraytype/itemtype/pattern : plain string
+//   type/typeof/arraytype/itemtype/pattern/keypattern : plain string
 //   optional                               : boolean
 //   minlength/maxlength                    : number
 //   items/oneof/anyof                      : string[]  (type references)
@@ -36,6 +36,7 @@ export const PROP_ORDER = [
     "anyof",
     "allowedvalues",
     "pattern",
+    "keypattern",
     "min",
     "max",
     "minlength",
@@ -44,7 +45,7 @@ export const PROP_ORDER = [
     "default",
 ];
 
-const STRING_PROPS = new Set(["type", "typeof", "arraytype", "itemtype", "pattern"]);
+const STRING_PROPS = new Set(["type", "typeof", "arraytype", "itemtype", "pattern", "keypattern"]);
 const INT_PROPS = new Set(["minlength", "maxlength"]);
 const BOOL_PROPS = new Set(["optional"]);
 const REFLIST_PROPS = new Set(["items", "oneof", "anyof"]);
@@ -305,6 +306,10 @@ export function validateModel(model) {
 
         if (p.pattern && p.type && p.type !== "string") {
             issues.push({ level: "warning", path: label, message: `\`pattern\` is ignored on \`${p.type}\` — it only validates \`string\` values.` });
+        }
+
+        if (p.keypattern && p.type && p.type !== "collection") {
+            issues.push({ level: "warning", path: label, message: `\`keypattern\` only applies to \`collection\` — it validates dynamic entry keys.` });
         }
 
         for (const ref of [p.typeof, p.itemtype]) {

--- a/SPEC.md
+++ b/SPEC.md
@@ -36,6 +36,7 @@ The schema format follows the TOML specification, meaning that a TOML Schema is 
   - [Alternative Types - `oneof` and `anyof`](#alternative-types---oneof-and-anyof)
   - [Optionality - `optional`](#optionality---optional)
   - [Pattern - `pattern`](#pattern---pattern)
+  - [Key Pattern - `keypattern`](#key-pattern---keypattern)
 - [Parsers](#parsers)
 - [Filename Extension](#filename-extension)
 - [MIME Type](#mime-type)
@@ -243,6 +244,7 @@ oneof = [ "<type-reference>", ... ]
 anyof = [ "<type-reference>", ... ]
 allowedvalues = [ <array-with-enumeration-of-allowed-values> ]
 pattern = "<string-regex-for-string-validation>"
+keypattern = "<string-regex-for-collection-key-validation>"
 optional = true|false
 min = <integer | float | offset-date-time | local-date-time | local-date | local-time>
 max = <integer | float | offset-date-time | local-date-time | local-date | local-time>
@@ -493,6 +495,8 @@ The types allowed in a collection may be defined with **only one** of the follow
  - `oneof`: one type of a provided array of types. Only one type must return `true` in the validation. Parser must throw an error if more than one type is valid for the input.
  - `anyof`: any type of a provided array of types. Parser stops validating at the first return of a `true` validation. Parser should throw an error if input is not valid for any type.
 
+A `collection` may additionally constrain the **keys** (entry names) of its dynamic children with `keypattern`. See [Key Pattern - `keypattern`](#key-pattern---keypattern).
+
 
 **Example:**
 The below example shows a table `servers` that is a `collection`.
@@ -640,6 +644,42 @@ Parsers must only skip a structure validation if the structure is optional in th
 This property is only used for validating `string` input. Parsers must validate the input with the provided regular expression.
 
 Parsers must support Perl/PCRE syntax. Parsers may support more extensions and other syntaxes.
+
+### Key Pattern - `keypattern`
+
+This property may only be used on a `collection`. It constrains the **keys** (entry names) of the
+collection's dynamic children: every dynamically keyed entry must match the provided regular
+expression. It does not validate entry *values* — that is the role of `typeof`, `oneof`, or
+`anyof`. It is therefore orthogonal to those properties and may be combined with them.
+
+`keypattern` is invalid on any non-`collection` type (scalars, `array`, plain `table`), and a
+parser must reject a schema that uses it elsewhere.
+
+Keys that are explicitly declared as fixed child definitions of the collection (schema-restricted
+key-value pairs) are validated by their own definitions and are not subject to `keypattern`. Only
+dynamic, user-provided keys are matched against the pattern.
+
+Parsers must support Perl/PCRE syntax, the same flavor as [`pattern`](#pattern---pattern).
+
+**Example:**
+
+```toml
+[types.listOfServersType]
+type       = "collection"
+typeof     = "types.serverType"
+minlength  = 1
+keypattern = "^server_[0-9]+$"
+```
+
+Against a TOML document:
+
+```toml
+[servers.server_01]   # accepted
+[servers.server_02]   # accepted
+[servers.alpha]       # rejected: key does not match ^server_[0-9]+$
+```
+
+This mirrors JSON Schema's `propertyNames: { pattern: ... }`, applied to TOML maps.
 
 ## Parsers
 

--- a/config.tosd
+++ b/config.tosd
@@ -68,7 +68,7 @@ version = "1.0.0"
     type = "collection"
     typeof = "types.serverType"
     minlength = 1
-    pattern = "[a-zA-Z]*"
+    keypattern = "^[a-zA-Z][a-zA-Z0-9_]*$"
 
     [types.listOfServerGroupsType]
     type = "collection"

--- a/reference-implementations/go/schema.go
+++ b/reference-implementations/go/schema.go
@@ -88,6 +88,7 @@ type Definition struct {
 	optional      bool
 	allowedValues []any
 	pattern       *regexp.Regexp
+	keyPattern    *regexp.Regexp
 	min           any
 	max           any
 	minLength     *int
@@ -259,6 +260,10 @@ func parseDefinition(name string, table map[string]any) (Definition, error) {
 	if err != nil {
 		return Definition{}, err
 	}
+	keyPattern, err := getPatternKey(name, table, "keypattern")
+	if err != nil {
+		return Definition{}, err
+	}
 	minLength, err := getIntegerPointer(table, "minlength")
 	if err != nil {
 		return Definition{}, err
@@ -326,6 +331,9 @@ func parseDefinition(name string, table map[string]any) (Definition, error) {
 	}
 	min := propertyValue(table, "min")
 	max := propertyValue(table, "max")
+	if keyPattern != nil && typeName != TypeCollection {
+		return Definition{}, fmt.Errorf("%s can only define keypattern when type is collection", name)
+	}
 	if err := validateRangeConstraints(name, typeName, arrayType, normalizeReference(itemReference), min, max); err != nil {
 		return Definition{}, err
 	}
@@ -333,7 +341,7 @@ func parseDefinition(name string, table map[string]any) (Definition, error) {
 		name: name, typeName: typeName, reference: normalizeReference(reference),
 		arrayType: arrayType, itemReference: normalizeReference(itemReference), optional: optional,
 		items:         normalizeReferences(items),
-		allowedValues: allowedValues, pattern: pattern, min: min, max: max,
+		allowedValues: allowedValues, pattern: pattern, keyPattern: keyPattern, min: min, max: max,
 		minLength: minLength, maxLength: maxLength, oneOf: normalizeReferences(oneOf), anyOf: normalizeReferences(anyOf),
 		children: children,
 	}, nil
@@ -536,6 +544,9 @@ func (v *validator) validateCollection(path string, table map[string]any, defini
 			continue
 		}
 		dynamicEntries++
+		if definition.keyPattern != nil && !matchesEntireString(definition.keyPattern, key) {
+			v.add(childPath, "key does not match keypattern "+definition.keyPattern.String())
+		}
 		if definition.reference == "" {
 			v.add(childPath, "collection entry has no typeof reference")
 			continue
@@ -715,6 +726,7 @@ func (v *validator) resolve(definition Definition, seenReferences map[string]boo
 		optional:      definition.optional || referenced.optional,
 		allowedValues: firstAnySlice(definition.allowedValues, referenced.allowedValues),
 		pattern:       firstPattern(definition.pattern, referenced.pattern),
+		keyPattern:    firstPattern(definition.keyPattern, referenced.keyPattern),
 		min:           firstAny(definition.min, referenced.min), max: firstAny(definition.max, referenced.max),
 		minLength: firstIntPointer(definition.minLength, referenced.minLength),
 		maxLength: firstIntPointer(definition.maxLength, referenced.maxLength),
@@ -825,13 +837,17 @@ func getIntegerPointer(table map[string]any, key string) (*int, error) {
 }
 
 func getPattern(name string, table map[string]any) (*regexp.Regexp, error) {
-	pattern, err := getString(table, "pattern")
+	return getPatternKey(name, table, "pattern")
+}
+
+func getPatternKey(name string, table map[string]any, key string) (*regexp.Regexp, error) {
+	pattern, err := getString(table, key)
 	if err != nil || pattern == "" {
 		return nil, err
 	}
 	compiled, err := regexp.Compile(pattern)
 	if err != nil {
-		return nil, fmt.Errorf("%s has invalid pattern: %w", name, err)
+		return nil, fmt.Errorf("%s has invalid %s: %w", name, key, err)
 	}
 	return compiled, nil
 }

--- a/reference-implementations/go/schema.go
+++ b/reference-implementations/go/schema.go
@@ -32,7 +32,7 @@ const (
 
 var definitionKeys = map[string]bool{
 	"type": true, "typeof": true, "arraytype": true, "itemtype": true, "items": true,
-	"allowedvalues": true, "pattern": true, "optional": true, "default": true, "min": true,
+	"allowedvalues": true, "pattern": true, "keypattern": true, "optional": true, "default": true, "min": true,
 	"max": true, "minlength": true, "maxlength": true,
 	"oneof": true, "anyof": true,
 }

--- a/reference-implementations/go/schema_test.go
+++ b/reference-implementations/go/schema_test.go
@@ -298,6 +298,96 @@ typeof = "types.item"
 	}
 }
 
+func TestValidatesCollectionKeysAgainstKeyPattern(t *testing.T) {
+	dir := t.TempDir()
+	schemaPath := write(t, dir, "keypattern.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[types.serverType]
+type = "table"
+
+    [types.serverType.ip]
+    type = "string"
+
+[elements.servers]
+type = "collection"
+typeof = "types.serverType"
+keypattern = "^server_[0-9]+$"
+`)
+	validDocument := write(t, dir, "valid.toml", `
+[servers.server_01]
+ip = "10.0.0.1"
+
+[servers.server_02]
+ip = "10.0.0.2"
+`)
+	invalidDocument := write(t, dir, "invalid.toml", `
+[servers.server_01]
+ip = "10.0.0.1"
+
+[servers.alpha]
+ip = "10.0.0.2"
+`)
+
+	schema, err := LoadSchema(schemaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result := schema.ValidateFile(validDocument); !result.Valid() {
+		t.Fatalf("expected valid keys to pass, got %#v", result.Errors)
+	}
+	result := schema.ValidateFile(invalidDocument)
+	if result.Valid() {
+		t.Fatal("expected non-matching key to be rejected")
+	}
+	if !hasPath(result, "$.servers.alpha") {
+		t.Fatalf("expected keypattern error on $.servers.alpha, got %#v", result.Errors)
+	}
+	if hasPath(result, "$.servers.server_01") {
+		t.Fatalf("did not expect error on matching key, got %#v", result.Errors)
+	}
+}
+
+func TestRejectsKeyPatternOnNonCollection(t *testing.T) {
+	dir := t.TempDir()
+	schemaPath := write(t, dir, "keypattern-scalar.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[elements.name]
+type = "string"
+keypattern = "^[a-z]+$"
+`)
+
+	if _, err := LoadSchema(schemaPath); err == nil {
+		t.Fatal("expected keypattern on a scalar to be rejected")
+	}
+}
+
+func TestRejectsInvalidKeyPatternRegex(t *testing.T) {
+	dir := t.TempDir()
+	schemaPath := write(t, dir, "keypattern-invalid-regex.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[types.itemType]
+type = "table"
+
+    [types.itemType.value]
+    type = "string"
+
+[elements.items]
+type = "collection"
+typeof = "types.itemType"
+keypattern = "("
+`)
+
+	if _, err := LoadSchema(schemaPath); err == nil {
+		t.Fatal("expected invalid keypattern regex to be rejected")
+	}
+}
+
 func TestRejectsOccurrenceAliases(t *testing.T) {
 	dir := t.TempDir()
 	aliases := []string{"minoccurs", "maxoccurs"}

--- a/reference-implementations/java/src/main/java/org/tomlschema/SchemaDefinition.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/SchemaDefinition.java
@@ -14,6 +14,7 @@ record SchemaDefinition(
         boolean optional,
         List<Object> allowedValues,
         Pattern pattern,
+        Pattern keyPattern,
         Object min,
         Object max,
         Integer minLength,

--- a/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
@@ -25,7 +25,7 @@ final class SchemaLoader {
     static final Set<String> TOP_LEVEL_KEYS = Set.of("toml-schema", "types", "elements");
     static final Set<String> DEFINITION_KEYS = Set.of(
             "type", "typeof", "arraytype", "itemtype", "items", "allowedvalues", "pattern",
-            "optional", "default", "min", "max", "minlength", "maxlength",
+            "keypattern", "optional", "default", "min", "max", "minlength", "maxlength",
             "oneof", "anyof"
     );
 
@@ -97,7 +97,8 @@ final class SchemaLoader {
         String itemReference = normalizeReference(getString(table, "itemtype"));
         List<String> items = getStringArrayValues(table, "items").stream().map(this::normalizeReference).toList();
         Boolean optional = getBoolean(table, "optional");
-        Pattern pattern = getPattern(name, table);
+        Pattern pattern = getPattern(name, table, "pattern");
+        Pattern keyPattern = getPattern(name, table, "keypattern");
         Integer minLength = getInteger(table, "minlength");
         Integer maxLength = getInteger(table, "maxlength");
         List<Object> allowedValues = getArrayValues(table, "allowedvalues");
@@ -145,6 +146,9 @@ final class SchemaLoader {
                 throw new SchemaException(name + " cannot define minlength or maxlength together with items");
             }
         }
+        if (keyPattern != null && type != SchemaType.COLLECTION) {
+            throw new SchemaException(name + " can only define keypattern when type is collection");
+        }
         Object min = getPropertyValue(table, "min");
         Object max = getPropertyValue(table, "max");
         validateRangeConstraints(name, type, arrayType, itemReference, min, max);
@@ -158,6 +162,7 @@ final class SchemaLoader {
                 optional != null && optional,
                 allowedValues,
                 pattern,
+                keyPattern,
                 min,
                 max,
                 minLength,
@@ -214,15 +219,15 @@ final class SchemaLoader {
         return longValue.intValue();
     }
 
-    private Pattern getPattern(String definitionName, TomlTable table) {
-        String pattern = getString(table, "pattern");
+    private Pattern getPattern(String definitionName, TomlTable table, String key) {
+        String pattern = getString(table, key);
         if (pattern == null) {
             return null;
         }
         try {
             return Pattern.compile(pattern);
         } catch (PatternSyntaxException e) {
-            throw new SchemaException(definitionName + " has invalid pattern: " + pattern, e);
+            throw new SchemaException(definitionName + " has invalid " + key + ": " + pattern, e);
         }
     }
 

--- a/reference-implementations/java/src/main/java/org/tomlschema/TomlSchemaValidator.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/TomlSchemaValidator.java
@@ -112,6 +112,9 @@ final class TomlSchemaValidator {
                 continue;
             }
             dynamicEntries++;
+            if (definition.keyPattern() != null && !definition.keyPattern().matcher(key).matches()) {
+                add(childPath, "key does not match keypattern " + definition.keyPattern().pattern());
+            }
             String reference = definition.reference();
             if (reference == null) {
                 add(childPath, "collection entry has no typeof reference");
@@ -282,6 +285,7 @@ final class TomlSchemaValidator {
                 definition.optional() || referenced.optional(),
                 definition.allowedValues().isEmpty() ? referenced.allowedValues() : definition.allowedValues(),
                 definition.pattern() == null ? referenced.pattern() : definition.pattern(),
+                definition.keyPattern() == null ? referenced.keyPattern() : definition.keyPattern(),
                 definition.min() == null ? referenced.min() : definition.min(),
                 definition.max() == null ? referenced.max() : definition.max(),
                 definition.minLength() == null ? referenced.minLength() : definition.minLength(),
@@ -318,6 +322,7 @@ final class TomlSchemaValidator {
                 List.of(),
                 false,
                 List.of(),
+                null,
                 null,
                 null,
                 null,

--- a/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
+++ b/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
@@ -143,6 +143,85 @@ class TomlSchemaTest {
     }
 
     @Test
+    void validatesCollectionKeysAgainstKeyPattern() throws IOException {
+        Path schema = write("keypattern.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [types.serverType]
+                type = "table"
+
+                    [types.serverType.ip]
+                    type = "string"
+
+                [elements.servers]
+                type = "collection"
+                typeof = "types.serverType"
+                keypattern = "^server_[0-9]+$"
+                """);
+        Path validDocument = write("keypattern-valid.toml", """
+                [servers.server_01]
+                ip = "10.0.0.1"
+
+                [servers.server_02]
+                ip = "10.0.0.2"
+                """);
+        Path invalidDocument = write("keypattern-invalid.toml", """
+                [servers.server_01]
+                ip = "10.0.0.1"
+
+                [servers.alpha]
+                ip = "10.0.0.2"
+                """);
+
+        TomlSchema tomlSchema = TomlSchema.load(schema);
+
+        assertTrue(tomlSchema.validate(validDocument).isValid());
+        ValidationResult invalidResult = tomlSchema.validate(invalidDocument);
+        assertFalse(invalidResult.isValid());
+        assertTrue(invalidResult.errors().stream()
+                .anyMatch(error -> error.path().equals("$.servers.alpha")
+                        && error.message().contains("keypattern")));
+        assertTrue(invalidResult.errors().stream()
+                .noneMatch(error -> error.path().equals("$.servers.server_01")));
+    }
+
+    @Test
+    void rejectsKeyPatternOnNonCollection() throws IOException {
+        Path schema = write("keypattern-scalar.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.name]
+                type = "string"
+                keypattern = "^[a-z]+$"
+                """);
+
+        assertThrows(SchemaException.class, () -> TomlSchema.load(schema));
+    }
+
+    @Test
+    void rejectsInvalidKeyPatternRegex() throws IOException {
+        Path schema = write("keypattern-invalid-regex.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [types.itemType]
+                type = "table"
+
+                    [types.itemType.value]
+                    type = "string"
+
+                [elements.items]
+                type = "collection"
+                typeof = "types.itemType"
+                keypattern = "["
+                """);
+
+        assertThrows(SchemaException.class, () -> TomlSchema.load(schema));
+    }
+
+    @Test
     void rejectsOccurrenceAliases() throws IOException {
         Path minOccurs = write("minoccurs-alias.tosd", """
                 [toml-schema]

--- a/reference-implementations/rust/src/schema.rs
+++ b/reference-implementations/rust/src/schema.rs
@@ -127,6 +127,7 @@ pub struct Definition {
     optional: bool,
     allowed_values: Vec<Value>,
     pattern: Option<Regex>,
+    key_pattern: Option<Regex>,
     min: Option<Value>,
     max: Option<Value>,
     min_length: Option<i64>,
@@ -326,6 +327,7 @@ fn parse_definition(name: &str, table: &Table) -> Result<Definition, String> {
     let items = get_string_array_values(name, table, "items")?;
     let optional = get_bool(name, table, "optional")?.unwrap_or(false);
     let pattern = get_pattern(name, table)?;
+    let key_pattern = get_pattern_key(name, table, "keypattern")?;
     let min_length = get_unsigned_integer(name, table, "minlength")?;
     let max_length = get_unsigned_integer(name, table, "maxlength")?;
     let allowed_values = get_array_values(name, table, "allowedvalues")?;
@@ -380,6 +382,11 @@ fn parse_definition(name: &str, table: &Table) -> Result<Definition, String> {
             ));
         }
     }
+    if key_pattern.is_some() && type_name != Some(SchemaType::Collection) {
+        return Err(format!(
+            "{name} can only define keypattern when type is collection"
+        ));
+    }
     let min = property_value(table, "min").cloned();
     let max = property_value(table, "max").cloned();
     validate_range_constraints(
@@ -401,6 +408,7 @@ fn parse_definition(name: &str, table: &Table) -> Result<Definition, String> {
         optional,
         allowed_values,
         pattern,
+        key_pattern,
         min,
         max,
         min_length,
@@ -642,6 +650,14 @@ impl<'schema> Validator<'schema> {
                 continue;
             }
             dynamic_entries += 1;
+            if let Some(key_pattern) = &definition.key_pattern {
+                if !matches_entire_string(key_pattern, key) {
+                    self.add(
+                        &child_path,
+                        &format!("key does not match keypattern {}", key_pattern.as_str()),
+                    );
+                }
+            }
             let reference = match definition.reference.as_deref() {
                 Some(reference) => reference,
                 None => {
@@ -857,6 +873,7 @@ impl<'schema> Validator<'schema> {
                 definition.allowed_values.clone()
             },
             pattern: definition.pattern.clone().or(referenced.pattern.clone()),
+            key_pattern: definition.key_pattern.clone().or(referenced.key_pattern.clone()),
             min: definition.min.clone().or(referenced.min.clone()),
             max: definition.max.clone().or(referenced.max.clone()),
             min_length: definition.min_length.or(referenced.min_length),
@@ -1176,12 +1193,16 @@ fn get_unsigned_integer(name: &str, table: &Table, key: &str) -> Result<Option<i
 }
 
 fn get_pattern(name: &str, table: &Table) -> Result<Option<Regex>, String> {
-    let Some(pattern) = get_string(name, table, "pattern")? else {
+    get_pattern_key(name, table, "pattern")
+}
+
+fn get_pattern_key(name: &str, table: &Table, key: &str) -> Result<Option<Regex>, String> {
+    let Some(pattern) = get_string(name, table, key)? else {
         return Ok(None);
     };
     Regex::new(&pattern)
         .map(Some)
-        .map_err(|error| format!("{name} has invalid pattern: {error}"))
+        .map_err(|error| format!("{name} has invalid {key}: {error}"))
 }
 
 fn get_array_values(name: &str, table: &Table, key: &str) -> Result<Vec<Value>, String> {

--- a/reference-implementations/rust/src/schema.rs
+++ b/reference-implementations/rust/src/schema.rs
@@ -97,6 +97,7 @@ pub const DEFINITION_KEYS: &[&str] = &[
     "items",
     "allowedvalues",
     "pattern",
+    "keypattern",
     "optional",
     "default",
     "min",

--- a/reference-implementations/rust/tests/integration.rs
+++ b/reference-implementations/rust/tests/integration.rs
@@ -412,6 +412,109 @@ typeof = "types.item"
 }
 
 #[test]
+fn validates_collection_keys_against_key_pattern() {
+    let directory = tempfile_dir("keypattern");
+    let schema_path = write_file(
+        &directory,
+        "schema.tosd",
+        r#"
+[toml-schema]
+version = "1.0.0"
+
+[types.serverType]
+type = "table"
+
+    [types.serverType.ip]
+    type = "string"
+
+[elements.servers]
+type = "collection"
+typeof = "types.serverType"
+keypattern = "^server_[0-9]+$"
+"#,
+    );
+    let valid_document = write_file(
+        &directory,
+        "valid.toml",
+        r#"
+[servers.server_01]
+ip = "10.0.0.1"
+
+[servers.server_02]
+ip = "10.0.0.2"
+"#,
+    );
+    let invalid_document = write_file(
+        &directory,
+        "invalid.toml",
+        r#"
+[servers.server_01]
+ip = "10.0.0.1"
+
+[servers.alpha]
+ip = "10.0.0.2"
+"#,
+    );
+
+    let schema = Schema::load(&schema_path).expect("load schema");
+    assert!(
+        schema.validate_file(&valid_document).valid(),
+        "expected matching keys to pass"
+    );
+    let result = schema.validate_file(&invalid_document);
+    assert!(!result.valid(), "expected non-matching key to be rejected");
+    assert!(has_path(&result, "$.servers.alpha"));
+    assert!(!has_path(&result, "$.servers.server_01"));
+}
+
+#[test]
+fn rejects_key_pattern_on_non_collection() {
+    let directory = tempfile_dir("keypattern-scalar");
+    let schema_path = write_file(
+        &directory,
+        "schema.tosd",
+        r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.name]
+type = "string"
+keypattern = "^[a-z]+$"
+"#,
+    );
+
+    let error = Schema::load(&schema_path).expect_err("expected keypattern on scalar rejection");
+    assert!(error.contains("keypattern"));
+}
+
+#[test]
+fn rejects_invalid_key_pattern_regex() {
+    let directory = tempfile_dir("keypattern-invalid-regex");
+    let schema_path = write_file(
+        &directory,
+        "schema.tosd",
+        r#"
+[toml-schema]
+version = "1.0.0"
+
+[types.itemType]
+type = "table"
+
+    [types.itemType.value]
+    type = "string"
+
+[elements.items]
+type = "collection"
+typeof = "types.itemType"
+keypattern = "("
+"#,
+    );
+
+    let error = Schema::load(&schema_path).expect_err("expected invalid keypattern regex rejection");
+    assert!(error.contains("invalid keypattern"));
+}
+
+#[test]
 fn rejects_occurrence_aliases() {
     let directory = tempfile_dir("occurrence-aliases");
     for alias in ["minoccurs", "maxoccurs"] {

--- a/toml-schema.abnf
+++ b/toml-schema.abnf
@@ -22,11 +22,11 @@ metadata-table    = toml-table-header-toml-schema-meta *toml-keyval
 schema-definition = schema-definition-table *definition-property *schema-definition
 
 schema-key = type / typeof / arraytype / itemtype / items / oneof / anyof
-           / allowedvalues / pattern / optional / default / min / max
+           / allowedvalues / pattern / keypattern / optional / default / min / max
            / minlength / maxlength
 
 definition-property = type / typeof / arraytype / itemtype / items / oneof / anyof
-                    / allowedvalues / pattern / optional / default / min / max
+                    / allowedvalues / pattern / keypattern / optional / default / min / max
                     / minlength / maxlength
 
 version       = "version" keyval-sep semver-string
@@ -39,6 +39,7 @@ oneof         = "oneof" keyval-sep type-reference-array
 anyof         = "anyof" keyval-sep type-reference-array
 allowedvalues = "allowedvalues" keyval-sep toml-array
 pattern       = "pattern" keyval-sep toml-string
+keypattern    = "keypattern" keyval-sep toml-string ; collection dynamic-entry keys must match this regular expression
 optional      = "optional" keyval-sep toml-boolean
 default       = "default" keyval-sep toml-value
 min           = "min" keyval-sep range-boundary


### PR DESCRIPTION
## Summary

Introduces a dedicated `keypattern` property that constrains the **keys** (entry names) of a `collection` against a Perl/PCRE-compatible regular expression, replacing the historical, never-formalized practice of putting `pattern` on a collection to mean "applies to the key." `pattern` is spec-defined to validate `string` *values* only, so a conformant parser ignored it on a collection. `keypattern` is the direct TOML analog of JSON Schema's `propertyNames: { pattern: ... }`.

Closes #57.

## Decisions (from issue open questions)

- **Scope:** `collection` only (not open-ended `table`).
- **All three reference implementations** (Java, Go, Rust) fully implement and validate `keypattern`.
- **`keyminlength`/`keymaxlength`:** deferred to a future issue.
- Only *dynamic* entry keys are matched; schema-defined fixed children are validated by their own definitions. Matching is anchored (the whole key must match), consistent with how `pattern` is applied.

## Changes

- **`SPEC.md`** — new "Key Pattern - `keypattern`" subsection (applicability, semantics, PCRE flavor, invalid on non-collection), worked example, collection-section cross-reference, TOC entry, and skeleton property listing.
- **`toml-schema.abnf`** — added `keypattern` rule and included it in `schema-key` / `definition-property`.
- **Reference implementations (Java, Go, Rust)** — each one: parses + compiles `keypattern`, adds it to its definition-key vocabulary (keeping the ABNF conformance guards green), rejects it on non-collection types, propagates it through `typeof` reference resolution, and validates every dynamic collection entry key against the pattern. Each adds tests: matching keys pass, non-matching keys fail (and valid keys are not flagged), `keypattern` on a scalar is rejected, and an invalid regex is rejected.
- **TOSD visual editor** (`model.mjs`, `client.js`) — recognizes `keypattern` (parse/serialize), lints misuse on non-collection, and exposes a key-pattern field in the collection property editor.
- **`config.tosd`** — replaced the dead `pattern = "[a-zA-Z]*"` on `types.listOfServersType` with `keypattern = "^[a-zA-Z][a-zA-Z0-9_]*$"`, which matches the checked-in `config.toml` keys (`alpha`, `beta`, `rp1`, `rp2`) so the worked example lints clean and demonstrates the feature. (The issue's illustrative `^server_[0-9]+$` would have rejected those keys, so it is used in spec examples only.)

## Verification

- Java `mvn test` — all pass, including new keypattern tests
- Go `go vet ./...` + `go test ./...` — all pass
- Rust `cargo test` — all 23 tests pass
- Packaged the CLI jar and re-validated the worked example both ways (explicit schema and via `[toml-schema].location`) — `config.toml is valid`
- Smoke-tested the editor model: `config.tosd` lints with zero issues, `keypattern` round-trips through serialization, and misuse on a non-collection raises a warning