### PR TITLE
Define named type reference constraint semantics

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -567,6 +567,33 @@ A `collection` may be represented as subtables of a common table in a TOML docum
 
 A type reference applies a built-in type or inherits the rules of a named reusable type. Both `[types]` definitions and `[elements]` definitions may use type references. The `type` property selects the current node's type; built-in and named references use the same syntax.
 
+When `type` selects a named reusable definition, the reference inherits that definition's validation rules as-is. The referencing definition MAY also declare `optional` and `description`, but it MUST NOT declare any other sibling property or child definition. In particular, validation constraints such as `pattern`, `keypattern`, `min`, `max`, `minlength`, `maxlength`, `allowedvalues`, `arraytype`, `itemtype`, and `items` cannot be added or overridden at the reference site. Parsers MUST reject such schemas at schema-load time.
+
+To specialize validation rules, declare another named reusable definition rather than adding constraints to a reference:
+
+```toml
+[types.lowercaseName]
+type = "string"
+pattern = "^[a-z]+$"
+
+[elements.name]
+type = "types.lowercaseName"
+description = "Display name"
+optional = true
+```
+
+The following is invalid because `pattern` attempts to override the referenced definition:
+
+```toml
+[types.name]
+type = "string"
+pattern = "^[a-z]+$"
+
+[elements.name]
+type = "types.name"
+pattern = "^[A-Z]+$" # invalid
+```
+
 ```toml
 [types]
 

--- a/examples/hugo.tosd
+++ b/examples/hugo.tosd
@@ -772,28 +772,48 @@ type = "table"
     optional = true
 
 [types.privacyGoogleAnalytics]
-type = "types.privacyDisqus"
+type = "table"
+
+    [types.privacyGoogleAnalytics.disable]
+    type = "boolean"
+    optional = true
 
     [types.privacyGoogleAnalytics.respectDoNotTrack]
     type = "boolean"
     optional = true
 
 [types.privacySimple]
-type = "types.privacyDisqus"
+type = "table"
+
+    [types.privacySimple.disable]
+    type = "boolean"
+    optional = true
 
     [types.privacySimple.simple]
     type = "boolean"
     optional = true
 
 [types.privacyDnt]
-type = "types.privacySimple"
+type = "table"
+
+    [types.privacyDnt.disable]
+    type = "boolean"
+    optional = true
+
+    [types.privacyDnt.simple]
+    type = "boolean"
+    optional = true
 
     [types.privacyDnt.enableDNT]
     type = "boolean"
     optional = true
 
 [types.privacyYouTube]
-type = "types.privacyDisqus"
+type = "table"
+
+    [types.privacyYouTube.disable]
+    type = "boolean"
+    optional = true
 
     [types.privacyYouTube.privacyEnhanced]
     type = "boolean"
@@ -840,7 +860,17 @@ type = "table"
     optional = true
 
 [types.securityHttp]
-type = "types.securityAllowDeny"
+type = "table"
+
+    [types.securityHttp.allow]
+    type = "array"
+    arraytype = "string"
+    optional = true
+
+    [types.securityHttp.deny]
+    type = "array"
+    arraytype = "string"
+    optional = true
 
     [types.securityHttp.mediaTypes]
     type = "array"

--- a/examples/netlify.tosd
+++ b/examples/netlify.tosd
@@ -146,7 +146,39 @@ arraytype = "table"
 itemtype = "types.integration"
 
 [types.context]
-type = "types.build"
+type = "table"
+
+    [types.context.base]
+    type = "string"
+    optional = true
+
+    [types.context.publish]
+    type = "string"
+    optional = true
+
+    [types.context.command]
+    type = "string"
+    optional = true
+
+    [types.context.ignore]
+    type = "string"
+    optional = true
+
+    [types.context.functions]
+    type = "string"
+    optional = true
+
+    [types.context.edge_functions]
+    type = "string"
+    optional = true
+
+    [types.context.environment]
+    type = "types.environment"
+    optional = true
+
+    [types.context.processing]
+    type = "types.processing"
+    optional = true
 
     [types.context.plugins]
     type = "types.plugins"

--- a/reference-implementations/go/schema.go
+++ b/reference-implementations/go/schema.go
@@ -37,6 +37,8 @@ var definitionKeys = map[string]bool{
 	"oneof": true, "anyof": true,
 }
 
+var namedReferenceKeys = map[string]bool{"type": true, "description": true, "optional": true}
+
 const currentTomlSchemaVersion = "1.0.0"
 
 var semverPattern = regexp.MustCompile(`^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-((?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$`)
@@ -244,6 +246,13 @@ func parseDefinition(name string, table map[string]any) (Definition, error) {
 			typeName = builtInType
 		} else {
 			reference = normalizeReference(typeSelector)
+		}
+	}
+	if reference != "" {
+		for key := range table {
+			if !namedReferenceKeys[key] {
+				return Definition{}, fmt.Errorf("%s named type reference cannot define %s", name, key)
+			}
 		}
 	}
 	description, err := getString(table, "description")
@@ -726,34 +735,22 @@ func (v *validator) resolve(definition Definition, seenReferences map[string]boo
 	if err != nil {
 		return Definition{}, err
 	}
-	typeName := definition.typeName
-	if typeName == "" {
-		typeName = referenced.typeName
-	}
-	children := referenced.children
-	if len(definition.children) > 0 {
-		children = map[string]Definition{}
-		for key, child := range referenced.children {
-			children[key] = child
-		}
-		for key, child := range definition.children {
-			children[key] = child
-		}
-	}
 	return Definition{
-		name: definition.name, typeName: typeName, description: definition.description,
-		arrayType:     firstSchemaType(definition.arrayType, referenced.arrayType),
-		itemReference: firstNonEmpty(definition.itemReference, referenced.itemReference),
-		items:         firstStringSlice(definition.items, referenced.items),
+		name: definition.name, typeName: referenced.typeName, description: definition.description,
+		arrayType:     referenced.arrayType,
+		itemReference: referenced.itemReference,
+		items:         referenced.items,
 		optional:      definition.optional || referenced.optional,
-		allowedValues: firstAnySlice(definition.allowedValues, referenced.allowedValues),
-		pattern:       firstPattern(definition.pattern, referenced.pattern),
-		keyPattern:    firstPattern(definition.keyPattern, referenced.keyPattern),
-		min:           firstAny(definition.min, referenced.min), max: firstAny(definition.max, referenced.max),
-		minLength: firstIntPointer(definition.minLength, referenced.minLength),
-		maxLength: firstIntPointer(definition.maxLength, referenced.maxLength),
-		oneOf:     firstStringSlice(definition.oneOf, referenced.oneOf),
-		anyOf:     firstStringSlice(definition.anyOf, referenced.anyOf), children: children,
+		allowedValues: referenced.allowedValues,
+		pattern:       referenced.pattern,
+		keyPattern:    referenced.keyPattern,
+		min:           referenced.min,
+		max:           referenced.max,
+		minLength:     referenced.minLength,
+		maxLength:     referenced.maxLength,
+		oneOf:         referenced.oneOf,
+		anyOf:         referenced.anyOf,
+		children:      referenced.children,
 	}, nil
 }
 
@@ -1106,53 +1103,4 @@ func compareLocalTime(left, right toml.LocalTime) int {
 		}
 	}
 	return 0
-}
-
-func firstNonEmpty(left, right string) string {
-	if left != "" {
-		return left
-	}
-	return right
-}
-
-func firstSchemaType(left, right SchemaType) SchemaType {
-	if left != "" {
-		return left
-	}
-	return right
-}
-
-func firstAny(left, right any) any {
-	if left != nil {
-		return left
-	}
-	return right
-}
-
-func firstPattern(left, right *regexp.Regexp) *regexp.Regexp {
-	if left != nil {
-		return left
-	}
-	return right
-}
-
-func firstIntPointer(left, right *int) *int {
-	if left != nil {
-		return left
-	}
-	return right
-}
-
-func firstAnySlice(left, right []any) []any {
-	if len(left) > 0 {
-		return left
-	}
-	return right
-}
-
-func firstStringSlice(left, right []string) []string {
-	if len(left) > 0 {
-		return left
-	}
-	return right
 }

--- a/reference-implementations/go/schema_test.go
+++ b/reference-implementations/go/schema_test.go
@@ -21,6 +21,16 @@ func TestValidatesCheckedInExample(t *testing.T) {
 	}
 }
 
+func TestLoadsExamplesMigratedFromReferenceSpecialization(t *testing.T) {
+	for _, name := range []string{"hugo.tosd", "netlify.tosd"} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := LoadSchema(filepath.Join(fixture("examples"), name)); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
 func TestAcceptsStringDescriptionsAndRejectsOtherValues(t *testing.T) {
 	dir := t.TempDir()
 	describedSchema := write(t, dir, "described.tosd", `
@@ -451,6 +461,70 @@ typeof = "types.nameType"
 
 	if _, err := LoadSchema(schemaPath); err == nil {
 		t.Fatal("expected the retired typeof property to be rejected")
+	}
+}
+
+func TestAllowsOptionalAndDescriptionOnNamedTypeReference(t *testing.T) {
+	dir := t.TempDir()
+	schemaPath := write(t, dir, "named-reference-metadata.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[types.nameType]
+type = "string"
+pattern = "^[a-z]+$"
+
+[elements.name]
+type = "types.nameType"
+description = "Optional display name."
+optional = true
+`)
+	documentPath := write(t, dir, "named-reference-metadata.toml", "# name is optional\n")
+
+	schema, err := LoadSchema(schemaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result := schema.ValidateFile(documentPath); !result.Valid() {
+		t.Fatalf("expected optional named reference to validate: %#v", result.Errors)
+	}
+}
+
+func TestRejectsConstraintsAndChildrenOnNamedTypeReference(t *testing.T) {
+	invalidSiblings := []string{
+		`arraytype = "string"`,
+		`itemtype = "string"`,
+		`items = [ "string" ]`,
+		`allowedvalues = [ "name" ]`,
+		`pattern = "^[a-z]+$"`,
+		`keypattern = "^[a-z]+$"`,
+		`min = 1`,
+		`max = 1`,
+		`minlength = 1`,
+		`maxlength = 1`,
+		`default = "name"`,
+		"[elements.name.child]\ntype = \"string\"",
+	}
+
+	for index, invalidSibling := range invalidSiblings {
+		t.Run(fmt.Sprintf("sibling-%d", index), func(t *testing.T) {
+			dir := t.TempDir()
+			schemaPath := write(t, dir, "named-reference-constraint.tosd", fmt.Sprintf(`
+[toml-schema]
+version = "1.0.0"
+
+[types.nameType]
+type = "string"
+
+[elements.name]
+type = "types.nameType"
+%s
+`, invalidSibling))
+
+			if _, err := LoadSchema(schemaPath); err == nil || !strings.Contains(err.Error(), "named type reference") {
+				t.Fatalf("expected named reference sibling rejection, got %v", err)
+			}
+		})
 	}
 }
 

--- a/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
@@ -28,6 +28,7 @@ final class SchemaLoader {
             "keypattern", "optional", "default", "min", "max", "minlength", "maxlength",
             "oneof", "anyof"
     );
+    private static final Set<String> NAMED_REFERENCE_KEYS = Set.of("type", "description", "optional");
 
     TomlSchema load(Path schemaPath) {
         TomlParseResult parsed;
@@ -97,6 +98,13 @@ final class SchemaLoader {
         String normalizedReference = typeSelector != null && type == null
                 ? normalizeReference(typeSelector)
                 : null;
+        if (normalizedReference != null) {
+            for (String key : table.keySet()) {
+                if (!NAMED_REFERENCE_KEYS.contains(key)) {
+                    throw new SchemaException(name + " named type reference cannot define " + key);
+                }
+            }
+        }
         String description = getString(table, "description");
         SchemaType arrayType = getSchemaType(table, "arraytype");
         String itemReference = normalizeReference(getString(table, "itemtype"));

--- a/reference-implementations/java/src/main/java/org/tomlschema/TomlSchemaValidator.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/TomlSchemaValidator.java
@@ -267,32 +267,25 @@ final class TomlSchemaValidator {
             return definition;
         }
         SchemaDefinition referenced = resolveReference(definition.reference(), seenReferences);
-        SchemaType type = definition.type() == null ? referenced.type() : definition.type();
-        Map<String, SchemaDefinition> children = referenced.children();
-        if (!definition.children().isEmpty()) {
-            java.util.LinkedHashMap<String, SchemaDefinition> merged = new java.util.LinkedHashMap<>(referenced.children());
-            merged.putAll(definition.children());
-            children = merged;
-        }
         return new SchemaDefinition(
                 definition.name(),
-                type,
+                referenced.type(),
                 null,
                 definition.description(),
-                definition.arrayType() == null ? referenced.arrayType() : definition.arrayType(),
-                definition.itemReference() == null ? referenced.itemReference() : definition.itemReference(),
-                definition.items().isEmpty() ? referenced.items() : definition.items(),
+                referenced.arrayType(),
+                referenced.itemReference(),
+                referenced.items(),
                 definition.optional() || referenced.optional(),
-                definition.allowedValues().isEmpty() ? referenced.allowedValues() : definition.allowedValues(),
-                definition.pattern() == null ? referenced.pattern() : definition.pattern(),
-                definition.keyPattern() == null ? referenced.keyPattern() : definition.keyPattern(),
-                definition.min() == null ? referenced.min() : definition.min(),
-                definition.max() == null ? referenced.max() : definition.max(),
-                definition.minLength() == null ? referenced.minLength() : definition.minLength(),
-                definition.maxLength() == null ? referenced.maxLength() : definition.maxLength(),
-                definition.oneOf().isEmpty() ? referenced.oneOf() : definition.oneOf(),
-                definition.anyOf().isEmpty() ? referenced.anyOf() : definition.anyOf(),
-                children
+                referenced.allowedValues(),
+                referenced.pattern(),
+                referenced.keyPattern(),
+                referenced.min(),
+                referenced.max(),
+                referenced.minLength(),
+                referenced.maxLength(),
+                referenced.oneOf(),
+                referenced.anyOf(),
+                referenced.children()
         );
     }
 

--- a/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
+++ b/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
@@ -29,6 +29,13 @@ class TomlSchemaTest {
     }
 
     @Test
+    void loadsExamplesMigratedFromReferenceSpecialization() {
+        for (String schema : List.of("examples/hugo.tosd", "examples/netlify.tosd")) {
+            assertDoesNotThrow(() -> TomlSchema.load(fixture(schema)), schema);
+        }
+    }
+
+    @Test
     void acceptsStringDescriptionsAndRejectsOtherValues() throws IOException {
         Path describedSchema = write("described.tosd", """
                 [toml-schema]
@@ -258,6 +265,61 @@ class TomlSchemaTest {
                 """);
 
         assertThrows(SchemaException.class, () -> TomlSchema.load(schema));
+    }
+
+    @Test
+    void allowsOptionalAndDescriptionOnNamedTypeReference() throws IOException {
+        Path schema = write("named-reference-metadata.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [types.nameType]
+                type = "string"
+                pattern = "^[a-z]+$"
+
+                [elements.name]
+                type = "types.nameType"
+                description = "Optional display name."
+                optional = true
+                """);
+        Path document = write("named-reference-metadata.toml", "# name is optional\n");
+
+        assertTrue(TomlSchema.load(schema).validate(document).isValid());
+    }
+
+    @Test
+    void rejectsConstraintsAndChildrenOnNamedTypeReference() throws IOException {
+        List<String> invalidSiblings = List.of(
+                "arraytype = \"string\"",
+                "itemtype = \"string\"",
+                "items = [ \"string\" ]",
+                "allowedvalues = [ \"name\" ]",
+                "pattern = \"^[a-z]+$\"",
+                "keypattern = \"^[a-z]+$\"",
+                "min = 1",
+                "max = 1",
+                "minlength = 1",
+                "maxlength = 1",
+                "default = \"name\"",
+                "[elements.name.child]\ntype = \"string\""
+        );
+
+        for (String invalidSibling : invalidSiblings) {
+            Path schema = write("named-reference-constraint.tosd", """
+                    [toml-schema]
+                    version = "1.0.0"
+
+                    [types.nameType]
+                    type = "string"
+
+                    [elements.name]
+                    type = "types.nameType"
+                    %s
+                    """.formatted(invalidSibling));
+
+            SchemaException error = assertThrows(SchemaException.class, () -> TomlSchema.load(schema));
+            assertTrue(error.getMessage().contains("named type reference"), error::getMessage);
+        }
     }
 
     @Test

--- a/reference-implementations/rust/src/schema.rs
+++ b/reference-implementations/rust/src/schema.rs
@@ -327,6 +327,13 @@ fn parse_definition(name: &str, table: &Table) -> Result<Definition, String> {
         .as_deref()
         .filter(|_| type_name.is_none())
         .map(|selector| normalize_reference(selector.to_string()));
+    if reference.is_some() {
+        for key in table.keys() {
+            if !matches!(key.as_str(), "type" | "description" | "optional") {
+                return Err(format!("{name} named type reference cannot define {key}"));
+            }
+        }
+    }
     let description = get_string(name, table, "description")?;
     let array_type = get_schema_type(name, table, "arraytype")?;
     let item_reference = get_string(name, table, "itemtype")?;
@@ -862,57 +869,25 @@ impl<'schema> Validator<'schema> {
         }
         let reference = definition.reference.as_deref().unwrap();
         let referenced = self.resolve_reference(reference, seen)?;
-        let type_name = definition.type_name.or(referenced.type_name);
-        let children = if definition.children.is_empty() {
-            referenced.children.clone()
-        } else {
-            let mut merged = referenced.children.clone();
-            for (key, child) in &definition.children {
-                merged.insert(key.clone(), child.clone());
-            }
-            merged
-        };
         Ok(Definition {
             name: definition.name.clone(),
-            type_name,
+            type_name: referenced.type_name,
             reference: None,
             description: definition.description.clone(),
-            array_type: definition.array_type.or(referenced.array_type),
-            item_reference: definition
-                .item_reference
-                .clone()
-                .or(referenced.item_reference.clone()),
-            items: if definition.items.is_empty() {
-                referenced.items.clone()
-            } else {
-                definition.items.clone()
-            },
+            array_type: referenced.array_type,
+            item_reference: referenced.item_reference,
+            items: referenced.items,
             optional: definition.optional || referenced.optional,
-            allowed_values: if definition.allowed_values.is_empty() {
-                referenced.allowed_values.clone()
-            } else {
-                definition.allowed_values.clone()
-            },
-            pattern: definition.pattern.clone().or(referenced.pattern.clone()),
-            key_pattern: definition
-                .key_pattern
-                .clone()
-                .or(referenced.key_pattern.clone()),
-            min: definition.min.clone().or(referenced.min.clone()),
-            max: definition.max.clone().or(referenced.max.clone()),
-            min_length: definition.min_length.or(referenced.min_length),
-            max_length: definition.max_length.or(referenced.max_length),
-            one_of: if definition.one_of.is_empty() {
-                referenced.one_of.clone()
-            } else {
-                definition.one_of.clone()
-            },
-            any_of: if definition.any_of.is_empty() {
-                referenced.any_of.clone()
-            } else {
-                definition.any_of.clone()
-            },
-            children,
+            allowed_values: referenced.allowed_values,
+            pattern: referenced.pattern,
+            key_pattern: referenced.key_pattern,
+            min: referenced.min,
+            max: referenced.max,
+            min_length: referenced.min_length,
+            max_length: referenced.max_length,
+            one_of: referenced.one_of,
+            any_of: referenced.any_of,
+            children: referenced.children,
         })
     }
 

--- a/reference-implementations/rust/tests/integration.rs
+++ b/reference-implementations/rust/tests/integration.rs
@@ -59,6 +59,15 @@ fn validates_checked_in_example() {
 }
 
 #[test]
+fn loads_examples_migrated_from_reference_specialization() {
+    for name in ["hugo.tosd", "netlify.tosd"] {
+        let path = fixture("examples").join(name);
+        Schema::load(&path)
+            .unwrap_or_else(|error| panic!("failed to load {}: {error}", path.display()));
+    }
+}
+
+#[test]
 fn accepts_string_descriptions_and_rejects_other_values() {
     let directory = tempfile_dir("descriptions");
     let described_schema = write_file(
@@ -614,6 +623,82 @@ typeof = "types.nameType"
 
     let error = Schema::load(&schema_path).expect_err("expected retired typeof rejection");
     assert!(error.contains("typeof"));
+}
+
+#[test]
+fn allows_optional_and_description_on_named_type_reference() {
+    let directory = tempfile_dir("named-reference-metadata");
+    let schema_path = write_file(
+        &directory,
+        "schema.tosd",
+        r#"
+[toml-schema]
+version = "1.0.0"
+
+[types.nameType]
+type = "string"
+pattern = "^[a-z]+$"
+
+[elements.name]
+type = "types.nameType"
+description = "Optional display name."
+optional = true
+"#,
+    );
+    let document_path = write_file(&directory, "document.toml", "# name is optional\n");
+
+    let schema = Schema::load(&schema_path).expect("expected named reference metadata to load");
+    let result = schema.validate_file(&document_path);
+    assert!(
+        result.valid(),
+        "expected optional named reference to validate: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn rejects_constraints_and_children_on_named_type_reference() {
+    let invalid_siblings = [
+        r#"arraytype = "string""#,
+        r#"itemtype = "string""#,
+        r#"items = [ "string" ]"#,
+        r#"allowedvalues = [ "name" ]"#,
+        r#"pattern = "^[a-z]+$""#,
+        r#"keypattern = "^[a-z]+$""#,
+        "min = 1",
+        "max = 1",
+        "minlength = 1",
+        "maxlength = 1",
+        r#"default = "name""#,
+        "[elements.name.child]\ntype = \"string\"",
+    ];
+
+    for (index, invalid_sibling) in invalid_siblings.iter().enumerate() {
+        let directory = tempfile_dir(&format!("named-reference-constraint-{index}"));
+        let schema_path = write_file(
+            &directory,
+            "schema.tosd",
+            &format!(
+                r#"
+[toml-schema]
+version = "1.0.0"
+
+[types.nameType]
+type = "string"
+
+[elements.name]
+type = "types.nameType"
+{invalid_sibling}
+"#
+            ),
+        );
+
+        let error = Schema::load(&schema_path).expect_err("expected named reference rejection");
+        assert!(
+            error.contains("named type reference"),
+            "unexpected error for {invalid_sibling}: {error}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Named reusable type references previously had undefined behavior when the reference site also declared validation constraints or child definitions, leaving implementations to merge or override rules inconsistently.

This change defines named references as inheriting validation rules as-is. Reference sites may add only `optional` and `description`; Java, Go, and Rust now reject other sibling properties and child definitions at schema-load time, and their resolver merge paths have been removed. Equivalent conformance coverage keeps the implementations aligned.

The Hugo and Netlify example schemas that relied on child merging are migrated to standalone reusable definitions while preserving their effective fields.

Fixes: #64