### PR TITLE
Clarify nested array type semantics

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -403,7 +403,9 @@ If `allowedvalues` does not match the conditions of `minlength`, `maxlength`, `m
 
 If `arraytype` is not defined, then the type of array elements is `any`, and any data type can be used and mixed together.
 
-If `type` is `array` and `arraytype` is of type `array`, then automatically any data type can be used and mixed together.
+If `type` is `array` and `arraytype` is `array`, every item MUST be an array. The
+contents of those nested arrays are unconstrained; only omitting `arraytype`
+permits non-array and array items to be mixed in the outer array.
 
 ##### Array Item Schemas and Arrays of Tables
 

--- a/reference-implementations/go/schema_test.go
+++ b/reference-implementations/go/schema_test.go
@@ -311,6 +311,47 @@ entries = [
 	}
 }
 
+func TestRequiresArrayItemsWhenArrayTypeIsArray(t *testing.T) {
+	dir := t.TempDir()
+	schemaPath := write(t, dir, "nested-arrays.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[elements.nested]
+type = "array"
+arraytype = "array"
+
+[elements.mixed]
+type = "array"
+`)
+	validPath := write(t, dir, "valid-nested-arrays.toml", `
+nested = [[1, "two"], [true, false]]
+mixed = [1, "two", [true]]
+`)
+	invalidPath := write(t, dir, "invalid-nested-arrays.toml", `
+nested = [[1], "not-an-array"]
+mixed = [1, "two", [true]]
+`)
+
+	schema, err := LoadSchema(schemaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	validResult := schema.ValidateFile(validPath)
+	if !validResult.Valid() {
+		t.Fatalf("expected nested arrays and unconstrained mixed items to be valid, got %#v", validResult.Errors)
+	}
+
+	invalidResult := schema.ValidateFile(invalidPath)
+	if invalidResult.Valid() {
+		t.Fatal("expected arraytype array to reject a non-array item")
+	}
+	if !hasPath(invalidResult, "$.nested[1]") {
+		t.Fatalf("expected nested item type error, got %#v", invalidResult.Errors)
+	}
+}
+
 func TestSupportsBuiltInTypeReferences(t *testing.T) {
 	dir := t.TempDir()
 	schemaPath := write(t, dir, "schema.tosd", `

--- a/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
+++ b/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
@@ -425,6 +425,38 @@ class TomlSchemaTest {
     }
 
     @Test
+    void requiresArrayItemsWhenArrayTypeIsArray() throws IOException {
+        Path schema = write("nested-arrays.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.nested]
+                type = "array"
+                arraytype = "array"
+
+                [elements.mixed]
+                type = "array"
+                """);
+        Path valid = write("valid-nested-arrays.toml", """
+                nested = [[1, "two"], [true, false]]
+                mixed = [1, "two", [true]]
+                """);
+        Path invalid = write("invalid-nested-arrays.toml", """
+                nested = [[1], "not-an-array"]
+                mixed = [1, "two", [true]]
+                """);
+
+        TomlSchema loadedSchema = TomlSchema.load(schema);
+
+        ValidationResult validResult = loadedSchema.validate(valid);
+        assertTrue(validResult.isValid(), () -> validResult.errors().toString());
+
+        ValidationResult invalidResult = loadedSchema.validate(invalid);
+        assertFalse(invalidResult.isValid());
+        assertTrue(invalidResult.errors().stream().anyMatch(error -> error.path().equals("$.nested[1]")));
+    }
+
+    @Test
     void validatesArrayOfTablesWithItemSchema() throws IOException {
         Path schema = write("products.tosd", """
                 [toml-schema]

--- a/reference-implementations/rust/tests/integration.rs
+++ b/reference-implementations/rust/tests/integration.rs
@@ -426,6 +426,55 @@ entries = [
 }
 
 #[test]
+fn requires_array_items_when_arraytype_is_array() {
+    let directory = tempfile_dir("nested-arrays");
+    let schema_path = write_file(
+        &directory,
+        "nested-arrays.tosd",
+        r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.nested]
+type = "array"
+arraytype = "array"
+
+[elements.mixed]
+type = "array"
+"#,
+    );
+    let valid_path = write_file(
+        &directory,
+        "valid-nested-arrays.toml",
+        r#"
+nested = [[1, "two"], [true, false]]
+mixed = [1, "two", [true]]
+"#,
+    );
+    let invalid_path = write_file(
+        &directory,
+        "invalid-nested-arrays.toml",
+        r#"
+nested = [[1], "not-an-array"]
+mixed = [1, "two", [true]]
+"#,
+    );
+
+    let schema = Schema::load(&schema_path).expect("load schema");
+
+    let valid_result = schema.validate_file(&valid_path);
+    assert!(
+        valid_result.valid(),
+        "expected nested arrays and unconstrained mixed items to be valid, got {:#?}",
+        valid_result.errors
+    );
+
+    let invalid_result = schema.validate_file(&invalid_path);
+    assert!(!invalid_result.valid());
+    assert!(has_path(&invalid_result, "$.nested[1]"));
+}
+
+#[test]
 fn supports_built_in_type_references() {
     let directory = tempfile_dir("built-in-references");
     let schema_path = write_file(


### PR DESCRIPTION
The specification currently contradicts itself about whether `arraytype = "array"` requires nested arrays or permits arbitrary outer-array items. This change makes the intended distinction explicit: every outer item must be an array, while the contents of those nested arrays remain unconstrained; omitting `arraytype` is the behavior that permits mixed outer items.

Equivalent Java, Go, and Rust conformance cases cover valid nested arrays, mixed items when `arraytype` is omitted, and rejection of a non-array outer item.

Fixes: #66