### PR TITLE
Define TOML schema reference metadata semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ A TOML document can point to a schema with reserved metadata:
 
 ```toml
 [toml-schema]
-version = "1.0.0"
 location = "config.tosd"
+version = "1.0.0" # optional expected schema-language version
 ```
 
 See [SPEC.md](SPEC.md#toml-reference-of-a-toml-schema) for the full behavior.

--- a/REFERENCE_IMPLEMENTATIONS.md
+++ b/REFERENCE_IMPLEMENTATIONS.md
@@ -45,6 +45,8 @@ Validate using `[toml-schema].location` from the TOML document:
 java -jar reference-implementations/java/target/toml-schema-1.0.0-rc.2.jar validate config.toml
 ```
 
+For document-driven lookup, the Java CLI resolves a relative `[toml-schema].location` from the TOML document's directory. The document's `[toml-schema].version` is optional; when present, the CLI rejects a major-version mismatch with the resolved schema and warns about other unequal versions.
+
 Validate the example schema against the TOML Schema self-schema:
 
 ```shell
@@ -202,7 +204,7 @@ Every reference implementation should:
 
 1. Parse TOML documents with a TOML 1.0-compliant parser rather than reimplementing TOML parsing.
 1. Treat `.tosd` schemas as valid TOML documents.
-1. Require `[toml-schema].version` to be a SemVer string compatible with the implementation's supported TOML Schema version.
+1. Require a schema document's `[toml-schema].version` to be a SemVer string compatible with the implementation's supported TOML Schema version.
 1. Validate the checked-in `config.toml` document against `config.tosd`.
 1. Support schema lookup through `[toml-schema].location`.
 1. Validate `config.tosd` against `toml-schema.tosd`.

--- a/SPEC.md
+++ b/SPEC.md
@@ -168,7 +168,7 @@ version = "1.0.0"
 
 ### Supported Properties
 
- - `version`: the version of this schema file. **Type:** string.
+ - `version`: the TOML Schema language version used by this schema document. **Type:** string.
    - **Required**.
  - `toml-schema.meta`: table reserved for any custom user-provided metadata.
    - **Optional**.
@@ -770,11 +770,19 @@ A TOML file can include this indication to reference which schema file to use fo
 
 ```toml
 [toml-schema]
-version = "1.0.0"
 location = "<uri>"
+version = "1.0.0" # optional
 ```
 
-Where `<uri>` can be a remote URL (e.g. https) or a local file.
+`location` identifies the schema document. It is REQUIRED when a validator is asked to discover a schema from the TOML document. Its value MUST be a non-empty string containing either an absolute URI, such as an HTTPS URL, or a relative URI reference, such as a local schema filename.
+
+An absolute `location` MUST be used unchanged. A relative `location` MUST be resolved against the referencing TOML document's location, not against the validator's current working directory or the resolved schema's location. For a TOML document stored in a local file, this means resolving a relative location from the document's parent directory.
+
+A validator that receives a TOML document without a base location, for example through standard input, cannot resolve a relative `location`. It MUST either obtain an explicit base URI from the caller or report that schema discovery failed. An absolute `location` does not require a document base. Implementations MAY limit the URI schemes they can retrieve, but MUST report an unsupported scheme rather than reinterpret its value as a relative local path.
+
+`version` is OPTIONAL. When present, it denotes the expected TOML Schema **language version** in the resolved schema document's `[toml-schema].version`; it is not an application version or an author-defined revision of that schema. Its value MUST be a string containing a full SemVer version in `MAJOR.MINOR.PATCH` form, with the same syntax defined by [Schema Versioning](#schema-versioning).
+
+After resolving and loading the schema, a validator MUST compare these two language versions when the referencing document provides `version`. A different major version is incompatible and schema discovery MUST fail. Any other unequal version, including a minor, patch, pre-release, or build metadata difference, MUST produce a warning but MUST NOT by itself cause validation to fail. Compatibility between the resolved schema and the validator remains governed by [Schema Versioning](#schema-versioning).
 
 The root `[toml-schema]` table is reserved for schema metadata. Validators should use it to locate schema information and should not treat it as application data unless the schema explicitly defines `[elements.toml-schema]`.
 

--- a/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
@@ -40,13 +40,13 @@ final class SchemaLoader {
         if (parsed.hasErrors()) {
             throw new SchemaException("Unable to parse schema " + schemaPath + ": " + formatParseErrors(parsed.errors()));
         }
-        validateTopLevel(parsed);
+        String version = validateTopLevel(parsed);
         Map<String, SchemaDefinition> types = parseDefinitions("types", parsed.getTable("types"), false);
         Map<String, SchemaDefinition> elements = parseDefinitions("elements", parsed.getTable("elements"), true);
-        return new TomlSchema(schemaPath, types, elements);
+        return new TomlSchema(schemaPath, version, types, elements);
     }
 
-    private void validateTopLevel(TomlTable schema) {
+    private String validateTopLevel(TomlTable schema) {
         if (!schema.isTable("toml-schema")) {
             throw new SchemaException("Schema must contain a [toml-schema] table");
         }
@@ -62,12 +62,13 @@ final class SchemaLoader {
         if (metadata == null || !metadata.contains("version")) {
             throw new SchemaException("[toml-schema] must contain version");
         }
-        TomlSchemaVersion.validate(metadata.get("version"));
+        String version = TomlSchemaVersion.validate(metadata.get("version")).value();
         for (String key : metadata.keySet()) {
             if (!key.equals("version") && !key.equals("meta")) {
                 throw new SchemaException("Unsupported [toml-schema] key: " + key);
             }
         }
+        return version;
     }
 
     private Map<String, SchemaDefinition> parseDefinitions(String prefix, TomlTable table, boolean required) {

--- a/reference-implementations/java/src/main/java/org/tomlschema/TomlSchema.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/TomlSchema.java
@@ -12,11 +12,13 @@ import java.util.stream.Collectors;
 
 public final class TomlSchema {
     private final Path source;
+    private final String version;
     private final Map<String, SchemaDefinition> types;
     private final Map<String, SchemaDefinition> elements;
 
-    TomlSchema(Path source, Map<String, SchemaDefinition> types, Map<String, SchemaDefinition> elements) {
+    TomlSchema(Path source, String version, Map<String, SchemaDefinition> types, Map<String, SchemaDefinition> elements) {
         this.source = source;
+        this.version = version;
         this.types = Map.copyOf(types);
         this.elements = Map.copyOf(elements);
     }
@@ -42,6 +44,10 @@ public final class TomlSchema {
 
     Path source() {
         return source;
+    }
+
+    String version() {
+        return version;
     }
 
     Map<String, SchemaDefinition> types() {

--- a/reference-implementations/java/src/main/java/org/tomlschema/TomlSchemaCli.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/TomlSchemaCli.java
@@ -7,6 +7,7 @@ import org.tomlj.TomlTable;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -69,18 +70,54 @@ public final class TomlSchemaCli {
             document.errors().forEach(error -> err.println(error.toString()));
             return 1;
         }
-        TomlTable metadata = document.getTable("toml-schema");
-        if (metadata == null) {
-            err.println("Document does not contain [toml-schema].location");
+        Object metadataValue = document.get(List.of("toml-schema"));
+        if (!(metadataValue instanceof TomlTable metadata)) {
+            err.println("Document must contain a [toml-schema] table");
             return 2;
         }
-        String location = metadata.getString("location");
-        if (location == null || location.isBlank()) {
-            err.println("Document does not contain [toml-schema].location");
+        Object locationValue = metadata.get("location");
+        if (!(locationValue instanceof String location) || location.isBlank()) {
+            err.println("Document [toml-schema].location must be a non-empty string");
             return 2;
         }
-        Path schemaPath = tomlPath.toAbsolutePath().getParent().resolve(location).normalize();
-        return validate(TomlSchema.load(schemaPath), document, tomlPath, out, err);
+        Path schemaPath = resolveSchemaPath(tomlPath, location);
+        TomlSchema schema = TomlSchema.load(schemaPath);
+        if (metadata.contains("version")) {
+            TomlSchemaVersion.Version expected = TomlSchemaVersion.parseDocumentVersion(metadata.get("version"));
+            TomlSchemaVersion.Version actual = TomlSchemaVersion.validate(schema.version());
+            if (!expected.major().equals(actual.major())) {
+                err.printf(
+                        "Document expects TOML Schema major version %s, but resolved schema uses %s%n",
+                        expected.value(),
+                        actual.value());
+                return 2;
+            }
+            if (!expected.value().equals(actual.value())) {
+                err.printf(
+                        "Warning: document expects TOML Schema version %s, but resolved schema uses %s%n",
+                        expected.value(),
+                        actual.value());
+            }
+        }
+        return validate(schema, document, tomlPath, out, err);
+    }
+
+    private static Path resolveSchemaPath(Path tomlPath, String location) {
+        URI reference;
+        try {
+            reference = URI.create(location);
+        } catch (IllegalArgumentException e) {
+            throw new SchemaException("Invalid [toml-schema].location URI: " + location, e);
+        }
+        URI resolved = tomlPath.toAbsolutePath().toUri().resolve(reference);
+        if (!"file".equalsIgnoreCase(resolved.getScheme())) {
+            throw new SchemaException("Unsupported schema location URI scheme: " + resolved.getScheme());
+        }
+        try {
+            return Path.of(resolved).normalize();
+        } catch (IllegalArgumentException e) {
+            throw new SchemaException("Invalid file schema location: " + location, e);
+        }
     }
 
     private static int validate(Path schemaPath, Path tomlPath, PrintStream out, PrintStream err) throws IOException {

--- a/reference-implementations/java/src/main/java/org/tomlschema/TomlSchemaVersion.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/TomlSchemaVersion.java
@@ -17,21 +17,32 @@ final class TomlSchemaVersion {
     private TomlSchemaVersion() {
     }
 
-    static void validate(Object value) {
+    static Version validate(Object value) {
+        Version version = parse(value, "[toml-schema].version");
+        if (!SUPPORTED_MAJOR.equals(version.major())) {
+            throw new SchemaException("Unsupported TOML Schema major version: " + version.value());
+        }
+        if (!SUPPORTED_MINOR.equals(version.minor())) {
+            throw new SchemaException("Unsupported TOML Schema minor version: " + version.value());
+        }
+        return version;
+    }
+
+    static Version parseDocumentVersion(Object value) {
+        return parse(value, "Document [toml-schema].version");
+    }
+
+    private static Version parse(Object value, String property) {
         if (!(value instanceof String version)) {
-            throw new SchemaException("[toml-schema].version must be a SemVer string");
+            throw new SchemaException(property + " must be a SemVer string");
         }
         Matcher matcher = SEMVER.matcher(version);
         if (!matcher.matches()) {
-            throw new SchemaException("[toml-schema].version must use SemVer MAJOR.MINOR.PATCH syntax");
+            throw new SchemaException(property + " must use SemVer MAJOR.MINOR.PATCH syntax");
         }
-        String major = matcher.group(1);
-        String minor = matcher.group(2);
-        if (!SUPPORTED_MAJOR.equals(major)) {
-            throw new SchemaException("Unsupported TOML Schema major version: " + version);
-        }
-        if (!SUPPORTED_MINOR.equals(minor)) {
-            throw new SchemaException("Unsupported TOML Schema minor version: " + version);
-        }
+        return new Version(version, matcher.group(1), matcher.group(2));
+    }
+
+    record Version(String value, String major, String minor) {
     }
 }

--- a/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
+++ b/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
@@ -975,10 +975,69 @@ class TomlSchemaTest {
     }
 
     @Test
-    void cliLocatesSchemaFromDocumentMetadata() throws IOException {
+    void cliResolvesRelativeSchemaLocationFromDocumentDirectory() throws IOException {
+        Path schemaDirectory = Files.createDirectories(tempDir.resolve("schemas"));
+        Files.writeString(schemaDirectory.resolve("schema.tosd"), """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.title]
+                type = "string"
+                """, StandardCharsets.UTF_8);
+        Path documentDirectory = Files.createDirectories(tempDir.resolve("documents"));
+        Path document = documentDirectory.resolve("document.toml");
+        Files.writeString(document, """
+                title = "Example"
+
+                [toml-schema]
+                version = "1.0.0"
+                location = "../schemas/schema.tosd"
+                """, StandardCharsets.UTF_8);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+        int exitCode = TomlSchemaCli.run(
+                new String[]{"validate", document.toString()},
+                new PrintStream(out, true, StandardCharsets.UTF_8),
+                new PrintStream(err, true, StandardCharsets.UTF_8));
+
+        assertEquals(0, exitCode, err::toString);
+        assertTrue(out.toString(StandardCharsets.UTF_8).contains("is valid"));
+        assertEquals("", err.toString(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void cliAllowsDocumentSchemaVersionToBeOmitted() throws IOException {
         write("schema.tosd", """
                 [toml-schema]
                 version = "1.0.0"
+
+                [elements.title]
+                type = "string"
+                """);
+        Path document = write("document.toml", """
+                title = "Example"
+
+                [toml-schema]
+                location = "schema.tosd"
+                """);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+        int exitCode = TomlSchemaCli.run(
+                new String[]{"validate", document.toString()},
+                new PrintStream(out, true, StandardCharsets.UTF_8),
+                new PrintStream(err, true, StandardCharsets.UTF_8));
+
+        assertEquals(0, exitCode, err::toString);
+        assertEquals("", err.toString(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void cliWarnsOnNonMajorDocumentSchemaVersionMismatch() throws IOException {
+        write("schema.tosd", """
+                [toml-schema]
+                version = "1.0.1"
 
                 [elements.title]
                 type = "string"
@@ -999,7 +1058,123 @@ class TomlSchemaTest {
                 new PrintStream(err, true, StandardCharsets.UTF_8));
 
         assertEquals(0, exitCode, err::toString);
-        assertTrue(out.toString(StandardCharsets.UTF_8).contains("is valid"));
+        assertTrue(err.toString(StandardCharsets.UTF_8).contains(
+                "Warning: document expects TOML Schema version 1.0.0, but resolved schema uses 1.0.1"));
+    }
+
+    @Test
+    void cliRejectsMajorDocumentSchemaVersionMismatch() throws IOException {
+        write("schema.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.title]
+                type = "string"
+                """);
+        Path document = write("document.toml", """
+                title = "Example"
+
+                [toml-schema]
+                version = "2.0.0"
+                location = "schema.tosd"
+                """);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+        int exitCode = TomlSchemaCli.run(
+                new String[]{"validate", document.toString()},
+                new PrintStream(out, true, StandardCharsets.UTF_8),
+                new PrintStream(err, true, StandardCharsets.UTF_8));
+
+        assertEquals(2, exitCode);
+        assertTrue(err.toString(StandardCharsets.UTF_8).contains(
+                "Document expects TOML Schema major version 2.0.0, but resolved schema uses 1.0.0"));
+    }
+
+    @Test
+    void cliRejectsMalformedDocumentSchemaVersions() throws IOException {
+        write("schema.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.title]
+                type = "string"
+                """);
+        Path shorthandDocument = write("shorthand.toml", """
+                title = "Example"
+
+                [toml-schema]
+                version = "1.0"
+                location = "schema.tosd"
+                """);
+        Path nonStringDocument = write("non-string.toml", """
+                title = "Example"
+
+                [toml-schema]
+                version = 1
+                location = "schema.tosd"
+                """);
+
+        for (Path document : List.of(shorthandDocument, nonStringDocument)) {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+            int exitCode = TomlSchemaCli.run(
+                    new String[]{"validate", document.toString()},
+                    new PrintStream(out, true, StandardCharsets.UTF_8),
+                    new PrintStream(err, true, StandardCharsets.UTF_8));
+
+            assertEquals(2, exitCode);
+            assertTrue(err.toString(StandardCharsets.UTF_8).contains("Document [toml-schema].version must"));
+        }
+    }
+
+    @Test
+    void cliRejectsMalformedSchemaReferenceMetadata() throws IOException {
+        Path nonTableMetadata = write("non-table-metadata.toml", """
+                title = "Example"
+                toml-schema = "schema.tosd"
+                """);
+        Path nonStringLocation = write("non-string-location.toml", """
+                title = "Example"
+
+                [toml-schema]
+                location = 1
+                """);
+
+        for (Path document : List.of(nonTableMetadata, nonStringLocation)) {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+            int exitCode = TomlSchemaCli.run(
+                    new String[]{"validate", document.toString()},
+                    new PrintStream(out, true, StandardCharsets.UTF_8),
+                    new PrintStream(err, true, StandardCharsets.UTF_8));
+
+            assertEquals(2, exitCode);
+            assertTrue(err.toString(StandardCharsets.UTF_8).contains("Document"));
+        }
+    }
+
+    @Test
+    void cliRejectsUnsupportedSchemaLocationUriScheme() throws IOException {
+        Path document = write("document.toml", """
+                title = "Example"
+
+                [toml-schema]
+                location = "https://example.com/schema.tosd"
+                """);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+        int exitCode = TomlSchemaCli.run(
+                new String[]{"validate", document.toString()},
+                new PrintStream(out, true, StandardCharsets.UTF_8),
+                new PrintStream(err, true, StandardCharsets.UTF_8));
+
+        assertEquals(2, exitCode);
+        assertTrue(err.toString(StandardCharsets.UTF_8).contains(
+                "Unsupported schema location URI scheme: https"));
     }
 
     @Test


### PR DESCRIPTION
Data documents can reference a TOML Schema, but the specification did not define whether `version` was required, how mismatches behaved, or what base should resolve a relative `location`. This makes schema discovery dependent on implementation-specific assumptions.

## Summary

- Define `location` as required for document-driven discovery and resolve relative references from the referencing TOML document, never the process working directory.
- Define data-document `version` as an optional expected TOML Schema language version: major mismatches fail, while other unequal versions warn.
- Specify behavior for documents without a base URI and for unsupported absolute URI schemes.
- Align the Java CLI with those rules, including clean diagnostics for malformed metadata, and retain the resolved schema version for comparison.
- Update the quick reference documentation and add focused Java conformance coverage.

The Java reference implementation still supports local file schema locations only; absolute unsupported schemes are now rejected explicitly instead of being reinterpreted as local paths.

## Validation

- `mvn -f reference-implementations/java/pom.xml test`

Fixes: #69