### PR TITLE
Define closed root element semantics

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -196,6 +196,12 @@ The `[elements]` table is the root schema for the TOML document being validated.
 
 Each direct child of `[elements]` defines one top-level TOML key. Nested children define the structure below that key, such as fields inside a table or item definitions inside arrays and collections.
 
+The root is closed: every top-level application-data key MUST be defined by a direct child of `[elements]`. Validators MUST reject any other top-level application-data key. This rule applies even when `[elements]` has no children, so an empty `[elements]` table accepts no application data.
+
+The reserved root `[toml-schema]` metadata table is the only exception. When `[elements.toml-schema]` is omitted, validators ignore that table during application-data validation as described in [TOML Reference of a TOML Schema](#toml-reference-of-a-toml-schema). Therefore, a document validated by an empty `[elements]` table may contain only the reserved `[toml-schema]` table and no application data.
+
+This root behavior differs from a nested property declared as `type = "table"` with no child definitions. Such a nested table is intentionally open-ended as described in [Tables](#tables); an empty `[elements]` table is not an implicit allow-anything schema.
+
 For example, this schema:
 
 ```toml

--- a/reference-implementations/go/schema_test.go
+++ b/reference-implementations/go/schema_test.go
@@ -31,6 +31,67 @@ func TestLoadsExamplesMigratedFromReferenceSpecialization(t *testing.T) {
 	}
 }
 
+func TestEnforcesClosedRootElementSemantics(t *testing.T) {
+	dir := t.TempDir()
+	schemaPath := write(t, dir, "closed-root.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[types]
+
+[elements]
+`)
+	emptyDocument := write(t, dir, "empty.toml", "")
+	metadataOnlyDocument := write(t, dir, "metadata-only.toml", `
+[toml-schema]
+location = "closed-root.tosd"
+`)
+	applicationDocument := write(t, dir, "application.toml", "extra = true")
+	definedRootSchema := write(t, dir, "defined-root.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[elements.allowed]
+type = "string"
+`)
+	documentWithExtraKey := write(t, dir, "extra-key.toml", `
+allowed = "value"
+extra = true
+`)
+	schema, err := LoadSchema(schemaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, document := range []string{emptyDocument, metadataOnlyDocument} {
+		if result := schema.ValidateFile(document); !result.Valid() {
+			t.Fatalf("expected %s to be valid, got %#v", document, result.Errors)
+		}
+	}
+
+	result := schema.ValidateFile(applicationDocument)
+	if result.Valid() || !hasPath(result, "$.extra") {
+		t.Fatalf("expected an unexpected-key error at $.extra, got %#v", result.Errors)
+	}
+
+	definedSchema, err := LoadSchema(definedRootSchema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result = definedSchema.ValidateFile(documentWithExtraKey)
+	if result.Valid() || !hasPath(result, "$.extra") {
+		t.Fatalf("expected an unexpected-key error beside a declared root key, got %#v", result.Errors)
+	}
+
+	schemaSchema, err := LoadSchema(fixture("toml-schema.tosd"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result := schemaSchema.ValidateFile(schemaPath); !result.Valid() {
+		t.Fatalf("expected self-schema to accept empty [elements], got %#v", result.Errors)
+	}
+}
+
 func TestAcceptsStringDescriptionsAndRejectsOtherValues(t *testing.T) {
 	dir := t.TempDir()
 	describedSchema := write(t, dir, "described.tosd", `

--- a/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
+++ b/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
@@ -70,9 +70,61 @@ class TomlSchemaTest {
     @Test
     void selfSchemaValidatesSchemaDocuments() throws IOException {
         TomlSchema schemaSchema = TomlSchema.load(fixture("toml-schema.tosd"));
+        Path emptyElementsSchema = write("empty-elements.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [types]
+
+                [elements]
+                """);
 
         assertTrue(schemaSchema.validate(fixture("config.tosd")).isValid());
         assertTrue(schemaSchema.validate(fixture("toml-schema.tosd")).isValid());
+        assertTrue(schemaSchema.validate(emptyElementsSchema).isValid());
+    }
+
+    @Test
+    void enforcesClosedRootElementSemantics() throws IOException {
+        Path schemaPath = write("closed-root.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [types]
+
+                [elements]
+                """);
+        Path emptyDocument = write("empty.toml", "");
+        Path metadataOnlyDocument = write("metadata-only.toml", """
+                [toml-schema]
+                location = "closed-root.tosd"
+                """);
+        Path applicationDocument = write("application.toml", "extra = true");
+        Path definedRootSchema = write("defined-root.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.allowed]
+                type = "string"
+                """);
+        Path documentWithExtraKey = write("extra-key.toml", """
+                allowed = "value"
+                extra = true
+                """);
+        TomlSchema schema = TomlSchema.load(schemaPath);
+
+        assertTrue(schema.validate(emptyDocument).isValid());
+        assertTrue(schema.validate(metadataOnlyDocument).isValid());
+
+        ValidationResult emptyRootResult = schema.validate(applicationDocument);
+        assertFalse(emptyRootResult.isValid());
+        assertTrue(emptyRootResult.errors().stream()
+                .anyMatch(error -> error.path().equals("$.extra") && error.message().equals("unexpected key")));
+
+        ValidationResult definedRootResult = TomlSchema.load(definedRootSchema).validate(documentWithExtraKey);
+        assertFalse(definedRootResult.isValid());
+        assertTrue(definedRootResult.errors().stream()
+                .anyMatch(error -> error.path().equals("$.extra") && error.message().equals("unexpected key")));
     }
 
     @Test

--- a/reference-implementations/rust/tests/integration.rs
+++ b/reference-implementations/rust/tests/integration.rs
@@ -68,6 +68,86 @@ fn loads_examples_migrated_from_reference_specialization() {
 }
 
 #[test]
+fn enforces_closed_root_element_semantics() {
+    let directory = tempfile_dir("closed-root");
+    let schema_path = write_file(
+        &directory,
+        "closed-root.tosd",
+        r#"
+[toml-schema]
+version = "1.0.0"
+
+[types]
+
+[elements]
+"#,
+    );
+    let empty_document = write_file(&directory, "empty.toml", "");
+    let metadata_only_document = write_file(
+        &directory,
+        "metadata-only.toml",
+        r#"
+[toml-schema]
+location = "closed-root.tosd"
+"#,
+    );
+    let application_document = write_file(&directory, "application.toml", "extra = true");
+    let defined_root_schema = write_file(
+        &directory,
+        "defined-root.tosd",
+        r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.allowed]
+type = "string"
+"#,
+    );
+    let document_with_extra_key = write_file(
+        &directory,
+        "extra-key.toml",
+        r#"
+allowed = "value"
+extra = true
+"#,
+    );
+    let schema = Schema::load(&schema_path).expect("load closed-root schema");
+
+    for document in [&empty_document, &metadata_only_document] {
+        let result = schema.validate_file(document);
+        assert!(
+            result.valid(),
+            "expected {} to be valid, got {:#?}",
+            document.display(),
+            result.errors
+        );
+    }
+
+    let result = schema.validate_file(&application_document);
+    assert!(
+        !result.valid() && has_path(&result, "$.extra"),
+        "expected an unexpected-key error at $.extra, got {:#?}",
+        result.errors
+    );
+
+    let defined_schema = Schema::load(&defined_root_schema).expect("load defined-root schema");
+    let result = defined_schema.validate_file(&document_with_extra_key);
+    assert!(
+        !result.valid() && has_path(&result, "$.extra"),
+        "expected an unexpected-key error beside a declared root key, got {:#?}",
+        result.errors
+    );
+
+    let schema_schema = Schema::load(fixture("toml-schema.tosd")).expect("load toml-schema.tosd");
+    let result = schema_schema.validate_file(&schema_path);
+    assert!(
+        result.valid(),
+        "expected self-schema to accept empty [elements], got {:#?}",
+        result.errors
+    );
+}
+
+#[test]
 fn accepts_string_descriptions_and_rejects_other_values() {
     let directory = tempfile_dir("descriptions");
     let described_schema = write_file(

--- a/toml-schema.abnf
+++ b/toml-schema.abnf
@@ -16,7 +16,7 @@ toml-schema-document = toml-schema-table [ types-table ] elements-table
 
 toml-schema-table = toml-table-header-toml-schema version [ metadata-table ]
 types-table       = toml-table-header-types *schema-definition
-elements-table    = toml-table-header-elements 1*schema-definition
+elements-table    = toml-table-header-elements *schema-definition
 metadata-table    = toml-table-header-toml-schema-meta *toml-keyval
 
 schema-definition = schema-definition-table *definition-property *schema-definition

--- a/toml-schema.tosd
+++ b/toml-schema.tosd
@@ -32,4 +32,4 @@ version = "1.0.0"
     [elements.elements]
     type = "collection"
     itemtype = "types.schemaDef"
-    minlength = 1
+    minlength = 0


### PR DESCRIPTION
An empty `[elements]` table was ambiguous: nested empty table definitions are open-ended, while reference validators already treated the document root as closed. This makes the root behavior explicit and consistent across the specification surfaces.

## Summary

- define `[elements]` as the complete allowed set of top-level application-data keys
- specify that empty `[elements]` accepts no application data, while preserving the reserved `[toml-schema]` metadata exception
- update the ABNF and self-schema to permit zero element definitions
- add equivalent Java, Go, and Rust conformance coverage for empty roots, undeclared root keys, and metadata-only documents

## Validation

- Java Maven test suite
- Go test suite
- Rust locked test suite

Fixes: #63