### PR TITLE
Define scalar allowedvalues constraint semantics

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -311,6 +311,12 @@ List of considered simple types:
 
 `allowedvalues` provides a mechanism to set an enumeration of allowed values to be used in any given simple type.
 
+For a non-array simple type, when `allowedvalues` is combined with `pattern`, `min`, `max`, `minlength`, or `maxlength`, every entry in `allowedvalues` MUST satisfy every applicable constraint. A schema containing an entry that violates one of those constraints is malformed, and parsers MUST reject it at schema-load time.
+
+After a schema with `allowedvalues` has been loaded successfully, a document value is valid when it is a member of `allowedvalues`. Parsers do not need to re-evaluate the other constraints for that document value because every enumerated value has already been checked against them while loading the schema.
+
+The rules for applying `allowedvalues` to array items are defined separately under [Observations on Conditions to Arrays](#observations-on-conditions-to-arrays).
+
 Example:
 ```toml
 [types.colorType]

--- a/reference-implementations/go/schema.go
+++ b/reference-implementations/go/schema.go
@@ -372,6 +372,9 @@ func parseDefinition(name string, table map[string]any) (Definition, error) {
 	if err := validateRangeConstraints(name, typeName, arrayType, normalizeReference(itemReference), min, max); err != nil {
 		return Definition{}, err
 	}
+	if err := validateAllowedValuesConstraints(name, typeName, allowedValues, pattern, min, max, minLength, maxLength); err != nil {
+		return Definition{}, err
+	}
 	return Definition{
 		name: name, typeName: typeName, reference: reference, description: description,
 		arrayType: arrayType, itemReference: normalizeReference(itemReference), optional: optional,
@@ -477,6 +480,63 @@ func boundaryMatchesType(value any, typeName SchemaType) bool {
 	default:
 		return false
 	}
+}
+
+func validateAllowedValuesConstraints(
+	name string,
+	typeName SchemaType,
+	allowedValues []any,
+	pattern *regexp.Regexp,
+	min, max any,
+	minLength, maxLength *int,
+) error {
+	if len(allowedValues) == 0 || typeName == TypeArray {
+		return nil
+	}
+	for index, allowed := range allowedValues {
+		entry := fmt.Sprintf("%s allowedvalues[%d]", name, index)
+		if pattern != nil {
+			stringValue, ok := allowed.(string)
+			if !ok || !matchesPattern(pattern, stringValue) {
+				return fmt.Errorf("%s does not satisfy pattern", entry)
+			}
+		}
+		if (min != nil || max != nil) && isNaN(allowed) {
+			return fmt.Errorf("%s does not satisfy min or max", entry)
+		}
+		if min != nil {
+			comparison, err := compare(allowed, min)
+			if err != nil {
+				return fmt.Errorf("%s cannot be compared with min: %w", entry, err)
+			}
+			if comparison < 0 {
+				return fmt.Errorf("%s is less than min", entry)
+			}
+		}
+		if max != nil {
+			comparison, err := compare(allowed, max)
+			if err != nil {
+				return fmt.Errorf("%s cannot be compared with max: %w", entry, err)
+			}
+			if comparison > 0 {
+				return fmt.Errorf("%s is greater than max", entry)
+			}
+		}
+		if minLength != nil || maxLength != nil {
+			stringValue, ok := allowed.(string)
+			if !ok {
+				return fmt.Errorf("%s does not satisfy string length constraints", entry)
+			}
+			length := utf8.RuneCountInString(stringValue)
+			if minLength != nil && length < *minLength {
+				return fmt.Errorf("%s is shorter than minlength", entry)
+			}
+			if maxLength != nil && length > *maxLength {
+				return fmt.Errorf("%s is longer than maxlength", entry)
+			}
+		}
+	}
+	return nil
 }
 
 type validator struct {
@@ -678,6 +738,9 @@ func (v *validator) validateCommonConstraints(path string, value any, definition
 		return
 	}
 	v.validateAllowedValues(path, value, definition)
+	if len(definition.allowedValues) > 0 {
+		return
+	}
 	v.validateRange(path, value, definition)
 	if stringValue, ok := value.(string); ok {
 		v.validateLength(path, utf8.RuneCountInString(stringValue), definition)

--- a/reference-implementations/go/schema_test.go
+++ b/reference-implementations/go/schema_test.go
@@ -278,6 +278,74 @@ maxlength = 2
 	}
 }
 
+func TestEnforcesConstraintsOnScalarAllowedValuesAtSchemaLoadTime(t *testing.T) {
+	dir := t.TempDir()
+	malformedDefinitions := []string{
+		`
+type = "string"
+allowedvalues = [ "valid", "INVALID" ]
+pattern = "^[a-z]+$"
+`,
+		`
+type = "integer"
+allowedvalues = [ 1, 2 ]
+min = 2
+`,
+		`
+type = "integer"
+allowedvalues = [ 2, 3 ]
+max = 2
+`,
+		`
+type = "string"
+allowedvalues = [ "a", "ok" ]
+minlength = 2
+`,
+		`
+type = "string"
+allowedvalues = [ "ok", "long" ]
+maxlength = 2
+`,
+	}
+
+	for index, definition := range malformedDefinitions {
+		schemaPath := write(t, dir, fmt.Sprintf("invalid-allowedvalues-%d.tosd", index), `
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+`+definition)
+		if _, err := LoadSchema(schemaPath); err == nil {
+			t.Fatalf("expected malformed allowedvalues schema %d to be rejected", index)
+		}
+	}
+
+	schemaPath := write(t, dir, "valid-allowedvalues.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "string"
+allowedvalues = [ "ab", "cd" ]
+pattern = "^[a-z]+$"
+minlength = 2
+maxlength = 2
+`)
+	validDocument := write(t, dir, "valid-allowedvalues.toml", `value = "ab"`)
+	invalidDocument := write(t, dir, "invalid-allowedvalues.toml", `value = "ef"`)
+	schema, err := LoadSchema(schemaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result := schema.ValidateFile(validDocument); !result.Valid() {
+		t.Fatalf("expected valid allowed value, got %#v", result.Errors)
+	}
+	result := schema.ValidateFile(invalidDocument)
+	if len(result.Errors) != 1 || result.Errors[0].Message != "value is not in allowedvalues" {
+		t.Fatalf("expected only allowedvalues membership error, got %#v", result.Errors)
+	}
+}
+
 func TestPatternMatchesUnanchored(t *testing.T) {
 	dir := t.TempDir()
 	schemaPath := write(t, dir, "schema.tosd", `

--- a/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
@@ -175,6 +175,7 @@ final class SchemaLoader {
         Object min = getPropertyValue(table, "min");
         Object max = getPropertyValue(table, "max");
         validateRangeConstraints(name, type, arrayType, itemReference, min, max);
+        validateAllowedValuesConstraints(name, type, allowedValues, pattern, min, max, minLength, maxLength);
         return new SchemaDefinition(
                 name,
                 type,
@@ -359,6 +360,60 @@ final class SchemaLoader {
             case LOCAL_TIME -> value instanceof LocalTime;
             default -> false;
         };
+    }
+
+    private void validateAllowedValuesConstraints(
+            String name,
+            SchemaType type,
+            List<Object> allowedValues,
+            Pattern pattern,
+            Object min,
+            Object max,
+            Integer minLength,
+            Integer maxLength
+    ) {
+        if (allowedValues.isEmpty() || type == SchemaType.ARRAY) {
+            return;
+        }
+        for (int i = 0; i < allowedValues.size(); i++) {
+            Object allowed = allowedValues.get(i);
+            String entry = name + " allowedvalues[" + i + "]";
+            if (pattern != null && (!(allowed instanceof String stringValue) || !pattern.matcher(stringValue).find())) {
+                throw new SchemaException(entry + " does not satisfy pattern");
+            }
+            if ((min != null || max != null) && allowed instanceof Double doubleValue && doubleValue.isNaN()) {
+                throw new SchemaException(entry + " does not satisfy min or max");
+            }
+            if (min != null && compare(allowed, min, entry) < 0) {
+                throw new SchemaException(entry + " is less than min");
+            }
+            if (max != null && compare(allowed, max, entry) > 0) {
+                throw new SchemaException(entry + " is greater than max");
+            }
+            if (minLength != null || maxLength != null) {
+                if (!(allowed instanceof String stringValue)) {
+                    throw new SchemaException(entry + " does not satisfy string length constraints");
+                }
+                int length = stringValue.codePointCount(0, stringValue.length());
+                if (minLength != null && length < minLength) {
+                    throw new SchemaException(entry + " is shorter than minlength");
+                }
+                if (maxLength != null && length > maxLength) {
+                    throw new SchemaException(entry + " is longer than maxlength");
+                }
+            }
+        }
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private int compare(Object value, Object boundary, String entry) {
+        if (value instanceof Number valueNumber && boundary instanceof Number boundaryNumber) {
+            return Double.compare(valueNumber.doubleValue(), boundaryNumber.doubleValue());
+        }
+        if (value instanceof Comparable valueComparable && value.getClass().isInstance(boundary)) {
+            return valueComparable.compareTo(boundary);
+        }
+        throw new SchemaException(entry + " cannot be compared with its boundary");
     }
 
     private String normalizeReference(String reference) {

--- a/reference-implementations/java/src/main/java/org/tomlschema/TomlSchemaValidator.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/TomlSchemaValidator.java
@@ -209,6 +209,9 @@ final class TomlSchemaValidator {
             return;
         }
         validateAllowedValues(path, value, definition);
+        if (!definition.allowedValues().isEmpty()) {
+            return;
+        }
         validateRange(path, value, definition);
         if (value instanceof String stringValue) {
             validateLength(path, stringLength(stringValue), definition);

--- a/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
+++ b/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
@@ -972,6 +972,67 @@ class TomlSchemaTest {
     }
 
     @Test
+    void enforcesConstraintsOnScalarAllowedValuesAtSchemaLoadTime() throws IOException {
+        List<String> malformedDefinitions = List.of(
+                """
+                type = "string"
+                allowedvalues = [ "valid", "INVALID" ]
+                pattern = "^[a-z]+$"
+                """,
+                """
+                type = "integer"
+                allowedvalues = [ 1, 2 ]
+                min = 2
+                """,
+                """
+                type = "integer"
+                allowedvalues = [ 2, 3 ]
+                max = 2
+                """,
+                """
+                type = "string"
+                allowedvalues = [ "a", "ok" ]
+                minlength = 2
+                """,
+                """
+                type = "string"
+                allowedvalues = [ "ok", "long" ]
+                maxlength = 2
+                """
+        );
+
+        for (int i = 0; i < malformedDefinitions.size(); i++) {
+            Path schema = write("invalid-allowedvalues-" + i + ".tosd", """
+                    [toml-schema]
+                    version = "1.0.0"
+
+                    [elements.value]
+                    """ + malformedDefinitions.get(i));
+            assertThrows(SchemaException.class, () -> TomlSchema.load(schema));
+        }
+
+        Path schema = write("valid-allowedvalues.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.value]
+                type = "string"
+                allowedvalues = [ "ab", "cd" ]
+                pattern = "^[a-z]+$"
+                minlength = 2
+                maxlength = 2
+                """);
+        Path validDocument = write("valid-allowedvalues.toml", "value = \"ab\"");
+        Path invalidDocument = write("invalid-allowedvalues.toml", "value = \"ef\"");
+        TomlSchema loaded = assertDoesNotThrow(() -> TomlSchema.load(schema));
+
+        assertTrue(loaded.validate(validDocument).isValid());
+        ValidationResult invalid = loaded.validate(invalidDocument);
+        assertEquals(1, invalid.errors().size());
+        assertEquals("value is not in allowedvalues", invalid.errors().getFirst().message());
+    }
+
+    @Test
     void ignoresReservedTomlSchemaMetadataUnlessSchemaDefinesIt() throws IOException {
         Path schema = write("metadata-ignored.tosd", """
                 [toml-schema]

--- a/reference-implementations/rust/src/schema.rs
+++ b/reference-implementations/rust/src/schema.rs
@@ -429,6 +429,16 @@ fn parse_definition(name: &str, table: &Table) -> Result<Definition, String> {
         min.as_ref(),
         max.as_ref(),
     )?;
+    validate_allowed_values_constraints(
+        name,
+        type_name,
+        &allowed_values,
+        pattern.as_ref(),
+        min.as_ref(),
+        max.as_ref(),
+        min_length,
+        max_length,
+    )?;
     Ok(Definition {
         name: name.to_string(),
         type_name,
@@ -550,6 +560,65 @@ fn boundary_matches_type(value: &Value, type_name: SchemaType) -> bool {
         | SchemaType::LocalTime => value_matches_type(value, type_name),
         _ => false,
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn validate_allowed_values_constraints(
+    name: &str,
+    type_name: Option<SchemaType>,
+    allowed_values: &[Value],
+    pattern: Option<&Regex>,
+    min: Option<&Value>,
+    max: Option<&Value>,
+    min_length: Option<i64>,
+    max_length: Option<i64>,
+) -> Result<(), String> {
+    if allowed_values.is_empty() || type_name == Some(SchemaType::Array) {
+        return Ok(());
+    }
+    for (index, allowed) in allowed_values.iter().enumerate() {
+        let entry = format!("{name} allowedvalues[{index}]");
+        if let Some(pattern) = pattern {
+            let Some(string_value) = allowed.as_str() else {
+                return Err(format!("{entry} does not satisfy pattern"));
+            };
+            if !matches_pattern(pattern, string_value) {
+                return Err(format!("{entry} does not satisfy pattern"));
+            }
+        }
+        if (min.is_some() || max.is_some()) && is_nan(Some(allowed)) {
+            return Err(format!("{entry} does not satisfy min or max"));
+        }
+        if let Some(min) = min {
+            let comparison = compare(allowed, min)
+                .map_err(|error| format!("{entry} cannot be compared with min: {error}"))?;
+            if comparison == std::cmp::Ordering::Less {
+                return Err(format!("{entry} is less than min"));
+            }
+        }
+        if let Some(max) = max {
+            let comparison = compare(allowed, max)
+                .map_err(|error| format!("{entry} cannot be compared with max: {error}"))?;
+            if comparison == std::cmp::Ordering::Greater {
+                return Err(format!("{entry} is greater than max"));
+            }
+        }
+        if min_length.is_some() || max_length.is_some() {
+            let Some(string_value) = allowed.as_str() else {
+                return Err(format!(
+                    "{entry} does not satisfy string length constraints"
+                ));
+            };
+            let length = string_value.chars().count() as i64;
+            if min_length.is_some_and(|minimum| length < minimum) {
+                return Err(format!("{entry} is shorter than minlength"));
+            }
+            if max_length.is_some_and(|maximum| length > maximum) {
+                return Err(format!("{entry} is longer than maxlength"));
+            }
+        }
+    }
+    Ok(())
 }
 
 struct Validator<'schema> {
@@ -802,6 +871,9 @@ impl<'schema> Validator<'schema> {
             return;
         }
         self.validate_allowed_values(path, value, definition);
+        if !definition.allowed_values.is_empty() {
+            return;
+        }
         self.validate_range(path, value, definition);
         if let Value::String(string_value) = value {
             self.validate_length(path, string_value.chars().count(), definition);

--- a/reference-implementations/rust/tests/integration.rs
+++ b/reference-implementations/rust/tests/integration.rs
@@ -394,6 +394,80 @@ maxlength = 2
 }
 
 #[test]
+fn enforces_constraints_on_scalar_allowed_values_at_schema_load_time() {
+    let directory = tempfile_dir("scalar-allowedvalues");
+    let malformed_definitions = [
+        r#"
+type = "string"
+allowedvalues = [ "valid", "INVALID" ]
+pattern = "^[a-z]+$"
+"#,
+        r#"
+type = "integer"
+allowedvalues = [ 1, 2 ]
+min = 2
+"#,
+        r#"
+type = "integer"
+allowedvalues = [ 2, 3 ]
+max = 2
+"#,
+        r#"
+type = "string"
+allowedvalues = [ "a", "ok" ]
+minlength = 2
+"#,
+        r#"
+type = "string"
+allowedvalues = [ "ok", "long" ]
+maxlength = 2
+"#,
+    ];
+
+    for (index, definition) in malformed_definitions.iter().enumerate() {
+        let content = format!(
+            r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+{definition}
+"#
+        );
+        let schema_path = write_file(
+            &directory,
+            &format!("invalid-allowedvalues-{index}.tosd"),
+            &content,
+        );
+        Schema::load(&schema_path).expect_err("expected malformed allowedvalues schema");
+    }
+
+    let schema_path = write_file(
+        &directory,
+        "valid-allowedvalues.tosd",
+        r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "string"
+allowedvalues = [ "ab", "cd" ]
+pattern = "^[a-z]+$"
+minlength = 2
+maxlength = 2
+"#,
+    );
+    let valid_document = write_file(&directory, "valid-allowedvalues.toml", r#"value = "ab""#);
+    let invalid_document = write_file(&directory, "invalid-allowedvalues.toml", r#"value = "ef""#);
+    let schema = Schema::load(&schema_path).expect("load conforming allowedvalues schema");
+
+    assert!(schema.validate_file(valid_document).valid());
+    let result = schema.validate_file(invalid_document);
+    assert_eq!(result.errors.len(), 1);
+    assert_eq!(result.errors[0].message, "value is not in allowedvalues");
+}
+
+#[test]
 fn pattern_matches_unanchored() {
     let directory = tempfile_dir("pattern-unanchored");
     let schema_path = write_file(


### PR DESCRIPTION
Scalar `allowedvalues` definitions were ambiguous when combined with `pattern`, range, or length constraints. This change makes malformed enumerations fail during schema loading and gives document validation a single, predictable membership rule.

The specification now requires every non-array enumerated value to satisfy its applicable sibling constraints. Java, Go, and Rust enforce that rule consistently for `pattern`, `min`, `max`, `minlength`, and `maxlength`, then validate loaded schemas by enum membership. Matching conformance coverage includes each malformed constraint combination plus valid and non-member document values.

**Validation**
- `mvn -q -f reference-implementations/java/pom.xml test`
- `go -C reference-implementations/go test ./...`
- `cargo test --quiet --manifest-path reference-implementations/rust/Cargo.toml`

Fixes: #62