### PR TITLE
Retire arraytype in favor of itemtype

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,10 +31,10 @@ This repository contains the TOML Schema specification/proposal plus reference i
 - Use full SemVer strings for `[toml-schema].version`; the current TOML Schema version is `1.0.0`, and shorthand values like `"1"` or `"1.0"` are invalid.
 - Custom metadata belongs under `[toml-schema.meta]`; do not add arbitrary keys or subtables directly under `[toml-schema]`.
 - Reusable definitions live under `[types.<name>]` and are referenced from `[elements]` or nested type definitions rather than duplicating structures.
-- Use `type` for built-in and named type references, `collection` for dynamic-key tables, and `itemtype` for array or collection members.
+- Use `type` for built-in and named type references, `collection` for dynamic-key tables, and `itemtype` for homogeneous array or collection members.
 - Use `itemtype = "types.<name>"` on `type = "array"` definitions when array items need structural validation, including TOML arrays of tables (`[[name]]`) and arrays of inline tables.
 - Use `oneof` for exactly-one alternative type validation and `anyof` for at-least-one validation; both select the current node's type. For array or collection members, reference a reusable alternative definition through `itemtype`.
-- `min`/`max` are inclusive and only valid for numeric/date-time types, or arrays with comparable `arraytype`; NaN is not a valid boundary.
+- `min`/`max` are inclusive and only valid for numeric/date-time types, or arrays whose `itemtype` resolves to one comparable kind; NaN is not a valid boundary.
 - String `minlength`/`maxlength` count Unicode scalar values after TOML parsing, not UTF-8 bytes, UTF-16 code units, or grapheme clusters.
 - Use quoted TOML key/table paths only when TOML syntax needs quoting, e.g. literal dotted or empty keys. Schema-key-colliding child paths like `[elements.plugin.pattern]` do not require quotes.
 - Root `[toml-schema]` in TOML documents is reserved metadata and ignored during application validation unless the schema explicitly defines `[elements.toml-schema]`.

--- a/.github/extensions/tosd-editor/client.js
+++ b/.github/extensions/tosd-editor/client.js
@@ -35,7 +35,6 @@ const NUMERIC_TEMPORAL = [
     "local-date",
     "local-time",
 ];
-const ARRAY_TYPES = BUILTIN_TYPES.filter((t) => t !== "collection");
 
 const state = {
     path: null,
@@ -48,6 +47,24 @@ const state = {
     view: "elements",
     zoom: 1,
 };
+
+function resolvedKinds(ref, seen = new Set()) {
+    if (!ref) return new Set();
+    const name = ref.startsWith("types.") ? ref.slice(6) : ref;
+    if (BUILTIN_TYPES.includes(name)) return new Set([name]);
+    if (seen.has(name)) return new Set();
+    const definition = (state.model?.types || []).find((candidate) => candidate.name === name);
+    if (!definition) return new Set();
+    const nextSeen = new Set(seen).add(name);
+    const props = definition.props || {};
+    if (props.type) return resolvedKinds(props.type, nextSeen);
+    const alternatives = props.oneof?.length ? props.oneof : props.anyof;
+    const kinds = new Set();
+    for (const alternative of alternatives || []) {
+        for (const kind of resolvedKinds(alternative, nextSeen)) kinds.add(kind);
+    }
+    return kinds;
+}
 
 const $ = (sel, root = document) => root.querySelector(sel);
 function el(tag, attrs = {}, ...kids) {
@@ -539,14 +556,10 @@ function renderEditor() {
 
     // Array-specific
     if (t === "array") {
-        box.append(
-            selectField("arraytype", p.arraytype || "", ["", ...ARRAY_TYPES], (v) => setProp(p, "arraytype", v),
-                "Built-in type of each array item."),
-        );
-        box.append(refField("itemtype", "Item type (reference)", p.itemtype || "", (v) => setProp(p, "itemtype", v),
-            "Validate each item against a reusable type (required for arrays of tables)."));
+        box.append(refField("itemtype", "Item type", p.itemtype || "", (v) => setProp(p, "itemtype", v),
+            "Validate every item against a built-in or reusable type."));
         box.append(listField("items", "Positional items (tuple)", p.items || [], (arr) => setListProp(p, "items", arr),
-            true, "Ordered type refs; fixed arity. Mutually exclusive with arraytype/itemtype."));
+            true, "Ordered type refs; fixed arity. Mutually exclusive with itemtype."));
     }
 
     if (t === "collection") {
@@ -577,7 +590,9 @@ function renderEditor() {
     }
 
     // min / max for numeric/temporal (or arrays thereof)
-    const showRange = NUMERIC_TEMPORAL.includes(t) || (t === "array" && NUMERIC_TEMPORAL.includes(p.arraytype));
+    const itemKinds = t === "array" ? resolvedKinds(p.itemtype) : new Set();
+    const showRange = NUMERIC_TEMPORAL.includes(t)
+        || (itemKinds.size === 1 && NUMERIC_TEMPORAL.includes([...itemKinds][0]));
     if (showRange) {
         const row = el("div", { class: "row-2" });
         row.append(textField("min", "min", p.min || "", (v) => setProp(p, "min", v), true));
@@ -622,7 +637,7 @@ function renderEditor() {
 function advancedAll(p) {
     const wrap = el("div");
     wrap.append(el("div", { class: "section-title", text: "All properties" }));
-    const allProps = ["type", "arraytype", "itemtype", "pattern", "keypattern", "min", "max", "default"];
+    const allProps = ["type", "itemtype", "pattern", "keypattern", "min", "max", "default"];
     for (const key of allProps) {
         wrap.append(textField(key, key, p[key] != null ? String(p[key]) : "", (v) => setProp(p, key, v), true));
     }

--- a/.github/extensions/tosd-editor/extension.mjs
+++ b/.github/extensions/tosd-editor/extension.mjs
@@ -95,7 +95,7 @@ function buildGeneratePrompt(desc) {
         '- Include a [toml-schema] table with version = "1.0.0".',
         "- Describe the document's top-level structure under [elements]; use nested tables like [elements.<name>.<child>] for sub-tables.",
         '- Put reusable definitions under [types.<name>] and reference them with type = "types.<name>". Use itemtype = "types.<name>" for array and collection members.',
-        "- Use only TOSD property keys: type (string, integer, float, boolean, datetime, date, time, array, table, collection), optional, default, min, max, minlength, maxlength, pattern, allowedvalues, arraytype, itemtype, items, oneof, anyof.",
+        "- Use only TOSD property keys: type (string, integer, float, boolean, offset-date-time, local-date-time, local-date, local-time, array, table, collection), optional, default, min, max, minlength, maxlength, pattern, allowedvalues, itemtype, items, oneof, anyof.",
         "- Mark fields that may be omitted with optional = true; everything is required by default.",
     ].join("\n");
 }

--- a/.github/extensions/tosd-editor/infer.mjs
+++ b/.github/extensions/tosd-editor/infer.mjs
@@ -50,17 +50,17 @@ function inferArrayProps(name, arr, ctx) {
     const allTables = arr.every(isTableLike);
     if (allTables) {
         const typeName = synthTableType(name, arr.map(tableObject), ctx);
-        return { type: "array", arraytype: "table", itemtype: `types.${typeName}` };
+        return { type: "array", itemtype: `types.${typeName}` };
     }
 
     const anyArray = arr.some((v) => Array.isArray(v));
-    if (anyArray) return { type: "array", arraytype: "array" };
+    if (anyArray) return { type: "array", itemtype: "array" };
 
     const kinds = new Set(arr.map((v) => (isTableLike(v) ? "table" : Array.isArray(v) ? "array" : scalarType(v))));
     if (kinds.size === 1) {
-        return { type: "array", arraytype: [...kinds][0] };
+        return { type: "array", itemtype: [...kinds][0] };
     }
-    // Mixed scalar types: leave arraytype unset (items default to `any`).
+    // Mixed scalar types: leave itemtype unset (items default to `any`).
     return { type: "array" };
 }
 

--- a/.github/extensions/tosd-editor/model.mjs
+++ b/.github/extensions/tosd-editor/model.mjs
@@ -11,7 +11,7 @@
 // node = { name, props: { <prop>: <editorValue> }, children: [ node, ... ] }
 //
 // Editor value encoding per property:
-//   type/arraytype/itemtype/pattern/keypattern : plain string
+//   type/itemtype/pattern/keypattern : plain string
 //   optional                               : boolean
 //   minlength/maxlength                    : number
 //   items/oneof/anyof                      : string[]  (type references)
@@ -28,7 +28,6 @@ import {
 
 export const PROP_ORDER = [
     "type",
-    "arraytype",
     "itemtype",
     "items",
     "oneof",
@@ -44,7 +43,7 @@ export const PROP_ORDER = [
     "default",
 ];
 
-const STRING_PROPS = new Set(["type", "arraytype", "itemtype", "pattern", "keypattern"]);
+const STRING_PROPS = new Set(["type", "itemtype", "pattern", "keypattern"]);
 const INT_PROPS = new Set(["minlength", "maxlength"]);
 const BOOL_PROPS = new Set(["optional"]);
 const REFLIST_PROPS = new Set(["items", "oneof", "anyof"]);
@@ -106,6 +105,9 @@ function tableToNode(name, table) {
             node.children.push(tableToNode(key, value));
         } else if (ALL_PROPS.has(key)) {
             node.props[key] = decodeProp(key, value);
+        } else if (key === "arraytype") {
+            // Preserve removed syntax long enough for validation to report it.
+            node.props[key] = String(value);
         } else {
             // A target document key that collides with nothing schema-specific
             // but holds a scalar - treat it as a child definition placeholder so
@@ -259,6 +261,7 @@ const NUMERIC_OR_TEMPORAL = new Set([
 export function validateModel(model) {
     const issues = [];
     const typeNames = new Set((model.types || []).map((t) => t.name));
+    const typesByName = new Map((model.types || []).map((t) => [t.name, t]));
 
     const refExists = (ref) => {
         if (!ref) return true;
@@ -267,9 +270,31 @@ export function validateModel(model) {
         return typeNames.has(name);
     };
 
+    const resolvedKinds = (ref, seen = new Set()) => {
+        if (!ref) return new Set();
+        const name = ref.startsWith("types.") ? ref.slice(6) : ref;
+        if (BUILTIN_TYPES.includes(name)) return new Set([name]);
+        if (seen.has(name)) return new Set();
+        const definition = typesByName.get(name);
+        if (!definition) return new Set();
+        const nextSeen = new Set(seen).add(name);
+        const props = definition.props || {};
+        if (props.type) return resolvedKinds(props.type, nextSeen);
+        const alternatives = props.oneof?.length ? props.oneof : props.anyof;
+        const kinds = new Set();
+        for (const alternative of alternatives || []) {
+            for (const kind of resolvedKinds(alternative, nextSeen)) kinds.add(kind);
+        }
+        return kinds;
+    };
+
     const walk = (node, pathLabel) => {
         const p = node.props || {};
         const label = pathLabel;
+
+        if (p.arraytype != null) {
+            issues.push({ level: "error", path: label, message: "`arraytype` is not supported; use `itemtype`." });
+        }
 
         const exclusivity = ["type", "oneof", "anyof"].filter((k) => p[k] != null && p[k] !== "" && !(Array.isArray(p[k]) && p[k].length === 0));
         if (exclusivity.length > 1) {
@@ -279,8 +304,8 @@ export function validateModel(model) {
             issues.push({ level: "warning", path: label, message: "No type, oneof, anyof, or children - defaults to an open table." });
         }
 
-        if (p.items && (p.arraytype || p.itemtype)) {
-            issues.push({ level: "error", path: label, message: "`items` is mutually exclusive with `arraytype` and `itemtype`." });
+        if (p.items && p.itemtype) {
+            issues.push({ level: "error", path: label, message: "`items` is mutually exclusive with `itemtype`." });
         }
         if (p.itemtype && !["array", "collection"].includes(p.type)) {
             issues.push({ level: "error", path: label, message: "`itemtype` requires `type = \"array\"` or `type = \"collection\"`." });
@@ -296,8 +321,9 @@ export function validateModel(model) {
         const hasMax = p.max != null && p.max !== "";
         if (hasMin || hasMax) {
             const t = p.type;
-            const at = p.arraytype;
-            const ok = NUMERIC_OR_TEMPORAL.has(t) || (t === "array" && NUMERIC_OR_TEMPORAL.has(at));
+            const itemKinds = t === "array" ? resolvedKinds(p.itemtype) : new Set();
+            const comparableItems = itemKinds.size === 1 && NUMERIC_OR_TEMPORAL.has([...itemKinds][0]);
+            const ok = NUMERIC_OR_TEMPORAL.has(t) || comparableItems;
             if (t === "any") {
                 issues.push({ level: "error", path: label, message: "`min`/`max` cannot be applied to type `any`." });
             } else if (!ok) {

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ type = "table"
 
     [elements.database.ports]
     type = "array"
-    arraytype = "integer"
+    itemtype = "integer"
 ```
 
 ## Reference implementations

--- a/SPEC.md
+++ b/SPEC.md
@@ -108,10 +108,10 @@ type="table"
     type = "boolean"
     [elements.database.ports]
     type = "array"
-    arraytype = "integer"
+    itemtype = "integer"
     [elements.database.data]
     type = "array"
-    arraytype = "array"
+    itemtype = "array"
     [elements.database.temp_targets]
     type = "table"
 
@@ -245,7 +245,6 @@ Built-in type names are reserved and MUST NOT be used as `[types]` definition na
 [types.<typename>]
 type = "<type-reference>"
 description = "<human-readable description>"
-arraytype = "<simple-type> | array | table"
 itemtype = "<type-reference>"
 items = [ "<type-reference>", ... ]
 oneof = [ "<type-reference>", ... ]
@@ -331,9 +330,14 @@ These properties define inclusive value ranges. They may only be used for:
  - `float`
  - `integer`
  - date and/or time types: `offset-date-time`, `local-date-time`, `local-date`, and `local-time`
- - `array`, when `arraytype` is one of `integer`, `float`, or the temporal types above
+ - `array`, when `itemtype` resolves to `integer`, `float`, or one of the temporal types above
 
-For arrays, `min` and `max` apply to each array item. They cannot be combined with `itemtype`; put range constraints in the referenced item type instead.
+For arrays, `min` and `max` apply to each item. `itemtype` MUST resolve to one
+comparable built-in kind: `integer`, `float`, `offset-date-time`,
+`local-date-time`, `local-date`, or `local-time`. All alternatives of a
+referenced `oneof` or `anyof` definition MUST resolve to that same kind.
+Parsers MUST reject array range constraints when the item schema can resolve to
+different kinds or to a non-comparable kind.
 
 A `min` or `max` boundary must be a TOML value that is comparable with the schema type: `integer` or `float` boundaries for `integer` and `float` values, and matching temporal boundaries for temporal values.
 
@@ -380,8 +384,7 @@ If a property of type `table` has no defined property and/or structure, the pars
 
 Arrays can be defined by mixing the following properties:
 
- - `arraytype`: the built-in type of each value in the array (e.g. string, array, or table).
- - `itemtype`: a type reference used to validate each item in the array.
+ - `itemtype`: a type reference used to validate every item in a homogeneous array.
  - `items`: ordered type references for tuple-style positional validation with fixed arity.
  - `minlength`: the minimum length of the array (e.g. no less than 2 elements).
  - `maxlength`: the maximum length of the array (e.g. no more than 2 elements).
@@ -389,12 +392,16 @@ Arrays can be defined by mixing the following properties:
  - `max`: the maximum value allowed for each comparable array item (e.g. 8080).
  - `allowedvalues`: enumeration of possible values.
 
+`arraytype` is not a TOML Schema property. Parsers MUST reject schema
+definitions that declare it. Use `itemtype` for both built-in and named member
+types.
+
 Example for schema definition:
 
 ```toml
 [elements.colors]
 type="array"
-arraytype="string"
+itemtype="string"
 ```
 
 Example of TOML file:
@@ -405,7 +412,11 @@ colors=[ "red", "yellow", "green" ]
 
 ##### Observations on Conditions to Arrays
 
-The `min` and `max` conditions are used to set a valid range of values, and it may be applied only to properties where `arraytype` is one of the following: `integer`, `float`, and the four available `date` and/or `time` types. Both properties are **inclusive**.
+The `min` and `max` conditions set an inclusive range for every array item. They
+may be used only when `itemtype` resolves to one comparable built-in kind:
+`integer`, `float`, or one of the four date/time types. When `itemtype`
+references a named definition, aliases and alternatives are resolved before
+this rule is checked.
 
 Dates and Times are naturally sorted by past, present, future, meaning that the first element is in the past, and the furthest element is in the future.
 
@@ -413,15 +424,22 @@ Dates and Times are naturally sorted by past, present, future, meaning that the 
 
 If `allowedvalues` does not match the conditions of `minlength`, `maxlength`, `min` and `max`, the parser must throw an error indicating that the TOML Schema is malformed.
 
-If `arraytype` is not defined, then the type of array elements is `any`, and any data type can be used and mixed together.
+If neither `itemtype` nor `items` is defined, array items default to `any`, so
+items of different TOML types may be mixed.
 
-If `type` is `array` and `arraytype` is `array`, every item MUST be an array. The
-contents of those nested arrays are unconstrained; only omitting `arraytype`
+If `type = "array"` and `itemtype = "array"`, every item MUST be an array. The
+contents of those nested arrays are unconstrained; only omitting `itemtype`
 permits non-array and array items to be mixed in the outer array.
 
 ##### Array Item Schemas and Arrays of Tables
 
-Use `itemtype` when each array item must be validated against a reusable schema definition. This is required for TOML arrays of tables and arrays of inline tables, because both parse as arrays whose items are table values. The same keyword selects the type of each dynamic value in a `collection`.
+`itemtype` accepts the same built-in or named references as `type`. Use a
+built-in reference such as `itemtype = "string"` for a homogeneous scalar
+array, or a reusable schema definition when members require constraints or
+structure. A reusable table definition is required for TOML arrays of tables
+and arrays of inline tables because both parse as arrays whose items are table
+values. The same keyword selects the type of each dynamic value in a
+`collection`.
 
 Example with TOML arrays of tables:
 
@@ -449,7 +467,6 @@ type = "table"
 
 [elements.products]
 type = "array"
-arraytype = "table"
 itemtype = "types.productType"
 ```
 
@@ -476,7 +493,6 @@ type = "table"
 
 [elements.points]
 type = "array"
-arraytype = "table"
 itemtype = "types.pointType"
 ```
 
@@ -496,7 +512,7 @@ Semantics:
 
  - `items` is ordered, and each index validates against the corresponding referenced type.
  - When `items` is present, the array must have exactly the same number of items.
- - `items` is mutually exclusive with `arraytype` and `itemtype`.
+ - `items` is mutually exclusive with `itemtype`.
  - `items` is also mutually exclusive with `minlength` and `maxlength`.
 
 #### Collection of Elements for Dynamic Keys
@@ -581,7 +597,7 @@ A `collection` may be represented as subtables of a common table in a TOML docum
 
 A type reference applies a built-in type or inherits the rules of a named reusable type. Both `[types]` definitions and `[elements]` definitions may use type references. The `type` property selects the current node's type; built-in and named references use the same syntax.
 
-When `type` selects a named reusable definition, the reference inherits that definition's validation rules as-is. The referencing definition MAY also declare `optional` and `description`, but it MUST NOT declare any other sibling property or child definition. In particular, validation constraints such as `pattern`, `keypattern`, `min`, `max`, `minlength`, `maxlength`, `allowedvalues`, `arraytype`, `itemtype`, and `items` cannot be added or overridden at the reference site. Parsers MUST reject such schemas at schema-load time.
+When `type` selects a named reusable definition, the reference inherits that definition's validation rules as-is. The referencing definition MAY also declare `optional` and `description`, but it MUST NOT declare any other sibling property or child definition. In particular, validation constraints such as `pattern`, `keypattern`, `min`, `max`, `minlength`, `maxlength`, `allowedvalues`, `itemtype`, and `items` cannot be added or overridden at the reference site. Parsers MUST reject such schemas at schema-load time.
 
 To specialize validation rules, declare another named reusable definition rather than adding constraints to a reference:
 
@@ -665,7 +681,7 @@ anyof = [ "types.stringId", "types.integerId" ]
 oneof = [ "string", "integer" ]
 ```
 
-Use a named reusable definition whenever an alternative needs constraints such as `pattern`, `min`, `allowedvalues`, `arraytype`, or child fields.
+Use a named reusable definition whenever an alternative needs constraints such as `pattern`, `min`, `allowedvalues`, `itemtype`, or child fields.
 
 ```toml
 [types.dependencyVersion]
@@ -706,7 +722,6 @@ description = "A game object."
 [elements.game]
 type = "array"
 description = "A list of games."
-arraytype = "table"
 itemtype = "types.game"
 ```
 

--- a/config.tosd
+++ b/config.tosd
@@ -13,7 +13,7 @@ version = "1.0.0"
 
         [types.databaseType.ports]
         type = "array"
-        arraytype = "integer"
+        itemtype = "integer"
 
         [types.databaseType.connection_max]
         type = "integer"
@@ -135,15 +135,14 @@ version = "1.0.0"
 
         [elements.clients.data]
         type = "array"
-        arraytype = "array"
+        itemtype = "array"
 
         [elements.clients.hosts]
         type = "array"
-        arraytype = "string"
+        itemtype = "string"
 
         [elements.clients.points]
         type = "array"
-        arraytype = "table"
         itemtype = "types.pointType"
 
     [elements.libraries]
@@ -152,6 +151,5 @@ version = "1.0.0"
 
     [elements.products]
     type = "array"
-    arraytype = "table"
     itemtype = "types.productType"
     minlength = 1

--- a/docs/index.html
+++ b/docs/index.html
@@ -70,7 +70,7 @@ type = "boolean"
 
 [elements.database.ports]
 type = "array"
-arraytype = "integer"</code></pre>
+itemtype = "integer"</code></pre>
         </aside>
       </section>
 
@@ -140,7 +140,7 @@ type = "boolean"</code></pre>
             </div>
             <pre><code>[elements.database.ports]
 type = "array"
-arraytype = "integer"
+itemtype = "integer"
 minlength = 1</code></pre>
           </article>
           <article class="tour-step">
@@ -199,7 +199,7 @@ max = 10</code></pre>
           <div class="spec-item"><strong>Type references</strong><span><code>type</code>, <code>itemtype</code>, <code>items</code>, <code>oneof</code>, and <code>anyof</code> can reference built-in type names or reusable <code>[types]</code>.</span></div>
           <div class="spec-item"><strong>Dynamic keys</strong><span><code>collection</code> validates user-provided table keys.</span></div>
           <div class="spec-item"><strong>Union shapes</strong><span><code>oneof</code> and <code>anyof</code> model alternative valid forms.</span></div>
-          <div class="spec-item"><strong>Containers and tuples</strong><span><code>itemtype</code> validates array and collection members; <code>arraytype</code> and <code>items</code> cover homogeneous and positional arrays.</span></div>
+          <div class="spec-item"><strong>Containers and tuples</strong><span><code>itemtype</code> validates homogeneous array and collection members; <code>items</code> defines positional arrays.</span></div>
           <div class="spec-item"><strong>Media type</strong><span>TOML Schema files use <code>.tosd</code> and <code>application/tosd</code>.</span></div>
         </div>
         <div class="actions">

--- a/examples/gitlab-runner.tosd
+++ b/examples/gitlab-runner.tosd
@@ -15,11 +15,11 @@ oneof = [ "types.durationValue", "integer" ]
 
 [types.stringArray]
 type = "array"
-arraytype = "string"
+itemtype = "string"
 
 [types.integerArray]
 type = "array"
-arraytype = "integer"
+itemtype = "integer"
 
 [types.stringMap]
 type = "collection"
@@ -126,7 +126,6 @@ type = "table"
 
     [types.refereeMetrics.metric_queries]
     type = "array"
-    arraytype = "table"
     itemtype = "types.anyMap"
     optional = true
 
@@ -168,22 +167,21 @@ type = "table"
 
     [types.dockerService.entrypoint]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
     [types.dockerService.command]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
     [types.dockerService.environment]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
 [types.dockerServices]
 type = "array"
-arraytype = "table"
 itemtype = "types.dockerService"
 
 [types.docker]
@@ -641,7 +639,6 @@ type = "table"
 
 [types.machineAutoscalings]
 type = "array"
-arraytype = "table"
 itemtype = "types.machineAutoscaling"
 
 [types.runnerMachine]
@@ -802,7 +799,6 @@ type = "table"
 
 [types.autoscalerPolicies]
 type = "array"
-arraytype = "table"
 itemtype = "types.autoscalerPolicy"
 
 [types.vmIsolation]
@@ -1244,7 +1240,6 @@ itemtype = "any"
 
 [types.runners]
 type = "array"
-arraytype = "table"
 itemtype = "types.runner"
 
 [elements]

--- a/examples/hugo.tosd
+++ b/examples/hugo.tosd
@@ -5,11 +5,11 @@ version = "1.0.0"
 
 [types.stringArray]
 type = "array"
-arraytype = "string"
+itemtype = "string"
 
 [types.anyArray]
 type = "array"
-arraytype = "any"
+itemtype = "any"
 
 [types.numberValue]
 oneof = [ "integer", "float" ]
@@ -55,7 +55,6 @@ type = "table"
 
 [types.cacheBusters]
 type = "array"
-arraytype = "table"
 itemtype = "types.cacheBuster"
 
 [types.build]
@@ -105,22 +104,22 @@ type = "table"
 
     [types.frontmatter.date]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
     [types.frontmatter.expiryDate]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
     [types.frontmatter.lastmod]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
     [types.frontmatter.publishDate]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
 [types.imagingExif]
@@ -147,12 +146,12 @@ type = "table"
 
     [types.imagingMeta.fields]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
     [types.imagingMeta.sources]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
 [types.imagingWebp]
@@ -256,7 +255,6 @@ type = "table"
 
 [types.menu]
 type = "array"
-arraytype = "table"
 itemtype = "types.menuEntry"
 
 [types.menus]
@@ -347,7 +345,7 @@ type = "table"
 
     [types.mediaType.suffixes]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
 [types.goldmarkExtensionToggle]
@@ -675,7 +673,6 @@ itemtype = "any"
 
     [types.moduleImport.mounts]
     type = "array"
-    arraytype = "table"
     itemtype = "types.moduleMount"
     optional = true
 
@@ -701,12 +698,12 @@ itemtype = "any"
 
     [types.moduleMount.includeFiles]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
     [types.moduleMount.excludeFiles]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
 [types.module]
@@ -714,13 +711,11 @@ type = "table"
 
     [types.module.imports]
     type = "array"
-    arraytype = "table"
     itemtype = "types.moduleImport"
     optional = true
 
     [types.module.mounts]
     type = "array"
-    arraytype = "table"
     itemtype = "types.moduleMount"
     optional = true
 
@@ -851,12 +846,12 @@ type = "table"
 
     [types.securityAllowDeny.allow]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
     [types.securityAllowDeny.deny]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
 [types.securityHttp]
@@ -864,27 +859,27 @@ type = "table"
 
     [types.securityHttp.allow]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
     [types.securityHttp.deny]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
     [types.securityHttp.mediaTypes]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
     [types.securityHttp.methods]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
     [types.securityHttp.urls]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
 [types.security]
@@ -1127,12 +1122,12 @@ optional = true
 
 [elements.disableKinds]
 type = "array"
-arraytype = "string"
+itemtype = "string"
 optional = true
 
 [elements.disableLanguages]
 type = "array"
-arraytype = "string"
+itemtype = "string"
 optional = true
 
 [elements.disableLiveReload]
@@ -1185,12 +1180,12 @@ optional = true
 
 [elements.ignoreFiles]
 type = "array"
-arraytype = "string"
+itemtype = "string"
 optional = true
 
 [elements.ignoreLogs]
 type = "array"
-arraytype = "string"
+itemtype = "string"
 optional = true
 
 [elements.ignoreVendorPaths]
@@ -1332,7 +1327,7 @@ optional = true
 
 [elements.renderSegments]
 type = "array"
-arraytype = "string"
+itemtype = "string"
 optional = true
 
 [elements.resourceDir]

--- a/examples/netlify.tosd
+++ b/examples/netlify.tosd
@@ -5,7 +5,7 @@ version = "1.0.0"
 
 [types.stringArray]
 type = "array"
-arraytype = "string"
+itemtype = "string"
 
 [types.stringMap]
 type = "collection"
@@ -24,7 +24,7 @@ allowedvalues = [ "GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS" ]
 
 [types.httpMethodArray]
 type = "array"
-arraytype = "string"
+itemtype = "string"
 allowedvalues = [ "GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS" ]
 
 [types.httpMethodOrArray]
@@ -127,7 +127,6 @@ type = "table"
 
 [types.plugins]
 type = "array"
-arraytype = "table"
 itemtype = "types.plugin"
 
 [types.integration]
@@ -142,7 +141,6 @@ type = "table"
 
 [types.integrations]
 type = "array"
-arraytype = "table"
 itemtype = "types.integration"
 
 [types.context]
@@ -232,7 +230,6 @@ type = "table"
 
 [types.redirects]
 type = "array"
-arraytype = "table"
 itemtype = "types.redirect"
 
 [types.header]
@@ -246,7 +243,6 @@ type = "table"
 
 [types.headers]
 type = "array"
-arraytype = "table"
 itemtype = "types.header"
 
 [types.functionConfig]
@@ -259,17 +255,17 @@ type = "table"
 
     [types.functionConfig.external_node_modules]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
     [types.functionConfig.included_files]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
     [types.functionConfig.excluded_files]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
 [types.functions]
@@ -287,17 +283,17 @@ itemtype = "types.functionConfig"
 
     [types.functions.external_node_modules]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
     [types.functions.included_files]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
     [types.functions.excluded_files]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
 [types.edgeHeaderCondition]
@@ -344,7 +340,6 @@ type = "table"
 
 [types.edgeFunctions]
 type = "array"
-arraytype = "table"
 itemtype = "types.edgeFunction"
 
 [types.devHttps]
@@ -409,7 +404,7 @@ type = "table"
 
     [types.dev.envFiles]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
     [types.dev.https]
@@ -421,12 +416,12 @@ type = "table"
 
     [types.template."incoming-hooks"]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
     [types.template."required-extensions"]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
     [types.template.environment]
@@ -438,7 +433,7 @@ type = "table"
 
     [types.images.remote_images]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
 [elements]

--- a/examples/pyproject.tosd
+++ b/examples/pyproject.tosd
@@ -7,11 +7,11 @@ version = "1.0.0"
 
 [types.stringArray]
 type = "array"
-arraytype = "string"
+itemtype = "string"
 
 [types.dependencyArray]
 type = "array"
-arraytype = "string"
+itemtype = "string"
 
 [types.stringMap]
 type = "collection"
@@ -78,7 +78,6 @@ type = "table"
 
 [types.people]
 type = "array"
-arraytype = "table"
 itemtype = "types.person"
 
 [types.projectName]
@@ -95,17 +94,15 @@ pattern = '^$|^([A-Za-z_][A-Za-z0-9_]*)(\.[A-Za-z_][A-Za-z0-9_]*)*(\s*;\s*privat
 
 [types.importNames]
 type = "array"
-arraytype = "any"
 itemtype = "types.pythonImportNameOrEmpty"
 
 [types.importNamespaces]
 type = "array"
-arraytype = "any"
 itemtype = "types.pythonImportName"
 
 [types.dynamicMetadata]
 type = "array"
-arraytype = "string"
+itemtype = "string"
 allowedvalues = [
     "version",
     "description",
@@ -228,7 +225,6 @@ oneof = [ "string", "types.dependencyGroupInclude" ]
 
 [types.dependencyGroup]
 type = "array"
-arraytype = "any"
 itemtype = "types.dependencyGroupItem"
 
 [types.dependencyGroups]

--- a/examples/wrangler.tosd
+++ b/examples/wrangler.tosd
@@ -8,11 +8,10 @@ oneof = [ "integer", "float" ]
 
 [types.stringArray]
 type = "array"
-arraytype = "string"
+itemtype = "string"
 
 [types.numberArray]
 type = "array"
-arraytype = "any"
 itemtype = "types.numberValue"
 
 [types.stringMap]
@@ -63,7 +62,6 @@ oneof = [ "string", "types.routeTable" ]
 
 [types.routes]
 type = "array"
-arraytype = "any"
 itemtype = "types.route"
 
 [types.triggers]
@@ -71,7 +69,7 @@ type = "table"
 
     [types.triggers.crons]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
 [types.observability]
@@ -164,7 +162,7 @@ type = "table"
 
     [types.moduleRule.globs]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
 
     [types.moduleRule.fallthrough]
     type = "boolean"
@@ -172,7 +170,6 @@ type = "table"
 
 [types.rules]
 type = "array"
-arraytype = "table"
 itemtype = "types.moduleRule"
 
 [types.pythonModules]
@@ -180,7 +177,7 @@ type = "table"
 
     [types.pythonModules.excludes]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
 [types.dev]
@@ -238,7 +235,6 @@ type = "table"
 
 [types.kvNamespaces]
 type = "array"
-arraytype = "table"
 itemtype = "types.kvNamespace"
 
 [types.d1Database]
@@ -265,7 +261,6 @@ type = "table"
 
 [types.d1Databases]
 type = "array"
-arraytype = "table"
 itemtype = "types.d1Database"
 
 [types.r2Bucket]
@@ -288,7 +283,6 @@ type = "table"
 
 [types.r2Buckets]
 type = "array"
-arraytype = "table"
 itemtype = "types.r2Bucket"
 
 [types.simpleBinding]
@@ -371,7 +365,7 @@ type = "table"
 
     [types.dispatchOutbound.parameters]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
 [types.dispatchNamespace]
@@ -403,7 +397,6 @@ type = "table"
 
     [types.durableObjects.bindings]
     type = "array"
-    arraytype = "table"
     itemtype = "types.durableObjectBinding"
     optional = true
 
@@ -424,33 +417,31 @@ type = "table"
 
     [types.migration.deleted_classes]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
     [types.migration.new_classes]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
     [types.migration.new_sqlite_classes]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
     [types.migration.renamed_classes]
     type = "array"
-    arraytype = "table"
     itemtype = "types.renameClass"
     optional = true
 
     [types.migration.transferred_classes]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
 [types.migrations]
 type = "array"
-arraytype = "table"
 itemtype = "types.migration"
 
 [types.emailBinding]
@@ -461,7 +452,7 @@ type = "table"
 
     [types.emailBinding.allowed_destination_addresses]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
     [types.emailBinding.destination_address]
@@ -513,13 +504,11 @@ type = "table"
 
     [types.queues.consumers]
     type = "array"
-    arraytype = "table"
     itemtype = "types.queueConsumer"
     optional = true
 
     [types.queues.producers]
     type = "array"
-    arraytype = "table"
     itemtype = "types.queueProducer"
     optional = true
 
@@ -528,7 +517,7 @@ type = "table"
 
     [types.secrets.required]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
 [types.secretsStoreSecret]
@@ -550,12 +539,12 @@ type = "table"
 
     [types.site.exclude]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
     [types.site.include]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
 [types.instanceType]
@@ -612,7 +601,7 @@ type = "table"
 
     [types.containerConstraints.regions]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
 [types.container]
@@ -626,7 +615,6 @@ type = "table"
 
     [types.container.authorized_keys]
     type = "array"
-    arraytype = "table"
     itemtype = "types.authorizedKey"
     optional = true
 
@@ -672,67 +660,54 @@ type = "table"
 
 [types.containers]
 type = "array"
-arraytype = "table"
 itemtype = "types.container"
 
 [types.arrayOfSimpleBindings]
 type = "array"
-arraytype = "table"
 itemtype = "types.simpleBinding"
 
 [types.arrayOfIdBindings]
 type = "array"
-arraytype = "table"
 itemtype = "types.idBinding"
 
 [types.arrayOfNameBindings]
 type = "array"
-arraytype = "table"
 itemtype = "types.nameBinding"
 
 [types.arrayOfNamespaceBindings]
 type = "array"
-arraytype = "table"
 itemtype = "types.namespaceBinding"
 
 [types.arrayOfIndexBindings]
 type = "array"
-arraytype = "table"
 itemtype = "types.indexBinding"
 
 [types.arrayOfDatasetBindings]
 type = "array"
-arraytype = "table"
 itemtype = "types.datasetBinding"
 
 [types.arrayOfServiceBindings]
 type = "array"
-arraytype = "table"
 itemtype = "types.serviceBinding"
 
 [types.arrayOfCertificateBindings]
 type = "array"
-arraytype = "table"
 itemtype = "types.certificateBinding"
 
 [types.arrayOfWorkflowBindings]
 type = "array"
-arraytype = "table"
 itemtype = "types.workflowBinding"
 
 [types.arrayOfDispatchNamespaces]
 type = "array"
-arraytype = "table"
 itemtype = "types.dispatchNamespace"
 
 [types.arrayOfEmailBindings]
 type = "array"
-arraytype = "table"
 itemtype = "types.emailBinding"
 
 [types.arrayOfSecretsStoreSecrets]
 type = "array"
-arraytype = "table"
 itemtype = "types.secretsStoreSecret"
 
 [types.workerSettings]
@@ -749,7 +724,6 @@ itemtype = "any"
 
     [types.workerSettings.ai_search]
     type = "array"
-    arraytype = "table"
     itemtype = "types.aiSearchInstance"
     optional = true
 
@@ -787,7 +761,7 @@ itemtype = "any"
 
     [types.workerSettings.compatibility_flags]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
     [types.workerSettings.containers]
@@ -975,7 +949,6 @@ optional = true
 
 [elements.ai_search]
 type = "array"
-arraytype = "table"
 itemtype = "types.aiSearchInstance"
 optional = true
 
@@ -1009,7 +982,7 @@ optional = true
 
 [elements.compatibility_flags]
 type = "array"
-arraytype = "string"
+itemtype = "string"
 optional = true
 
 [elements.containers]

--- a/reference-implementations/go/extract.go
+++ b/reference-implementations/go/extract.go
@@ -47,7 +47,7 @@ func appendDefinition(schema *strings.Builder, path []string, value any) {
 	typeName := schemaType(value)
 	fmt.Fprintf(schema, "type = %q\n", typeName)
 	if typeName == string(TypeArray) {
-		fmt.Fprintf(schema, "arraytype = %q\n", inferArrayType(value.([]any)))
+		fmt.Fprintf(schema, "itemtype = %q\n", inferItemType(value.([]any)))
 	}
 	if table, ok := value.(map[string]any); ok {
 		for _, childKey := range sortedKeys(table) {
@@ -84,7 +84,7 @@ func schemaType(value any) string {
 	}
 }
 
-func inferArrayType(array []any) string {
+func inferItemType(array []any) string {
 	if len(array) == 0 {
 		return string(TypeAny)
 	}

--- a/reference-implementations/go/schema.go
+++ b/reference-implementations/go/schema.go
@@ -31,7 +31,7 @@ const (
 )
 
 var definitionKeys = map[string]bool{
-	"type": true, "description": true, "arraytype": true, "itemtype": true, "items": true,
+	"type": true, "description": true, "itemtype": true, "items": true,
 	"allowedvalues": true, "pattern": true, "keypattern": true, "optional": true, "default": true, "min": true,
 	"max": true, "minlength": true, "maxlength": true,
 	"oneof": true, "anyof": true,
@@ -85,7 +85,6 @@ type Definition struct {
 	typeName      SchemaType
 	reference     string
 	description   string
-	arrayType     SchemaType
 	itemReference string
 	items         []string
 	optional      bool
@@ -151,7 +150,11 @@ func LoadSchema(path string) (*Schema, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Schema{source: path, types: types, elements: elements}, nil
+	schema := &Schema{source: path, types: types, elements: elements}
+	if err := schema.validateArrayRanges(); err != nil {
+		return nil, err
+	}
+	return schema, nil
 }
 
 func LoadDocument(path string) (map[string]any, error) {
@@ -259,10 +262,6 @@ func parseDefinition(name string, table map[string]any) (Definition, error) {
 	if err != nil {
 		return Definition{}, err
 	}
-	arrayType, err := getSchemaType(table, "arraytype")
-	if err != nil {
-		return Definition{}, err
-	}
 	itemReference, err := getString(table, "itemtype")
 	if err != nil {
 		return Definition{}, err
@@ -338,9 +337,6 @@ func parseDefinition(name string, table map[string]any) (Definition, error) {
 		}
 		typeName = TypeTable
 	}
-	if typeName != TypeArray && arrayType != "" {
-		return Definition{}, fmt.Errorf("%s can only define arraytype when type is array", name)
-	}
 	if typeName != TypeArray && typeName != TypeCollection && itemReference != "" {
 		return Definition{}, fmt.Errorf("%s can only define itemtype when type is array or collection", name)
 	}
@@ -348,9 +344,6 @@ func parseDefinition(name string, table map[string]any) (Definition, error) {
 		return Definition{}, fmt.Errorf("%s can only define items when type is array", name)
 	}
 	if len(items) > 0 {
-		if arrayType != "" {
-			return Definition{}, fmt.Errorf("%s cannot define both items and arraytype", name)
-		}
 		if itemReference != "" {
 			return Definition{}, fmt.Errorf("%s cannot define both items and itemtype", name)
 		}
@@ -369,7 +362,7 @@ func parseDefinition(name string, table map[string]any) (Definition, error) {
 	if typeName == TypeCollection && itemReference == "" {
 		return Definition{}, fmt.Errorf("%s must define itemtype when type is collection", name)
 	}
-	if err := validateRangeConstraints(name, typeName, arrayType, normalizeReference(itemReference), min, max); err != nil {
+	if err := validateRangeConstraints(name, typeName, min, max); err != nil {
 		return Definition{}, err
 	}
 	if err := validateAllowedValuesConstraints(name, typeName, allowedValues, pattern, min, max, minLength, maxLength); err != nil {
@@ -377,7 +370,7 @@ func parseDefinition(name string, table map[string]any) (Definition, error) {
 	}
 	return Definition{
 		name: name, typeName: typeName, reference: reference, description: description,
-		arrayType: arrayType, itemReference: normalizeReference(itemReference), optional: optional,
+		itemReference: normalizeReference(itemReference), optional: optional,
 		items:         normalizeReferences(items),
 		allowedValues: allowedValues, pattern: pattern, keyPattern: keyPattern, min: min, max: max,
 		minLength: minLength, maxLength: maxLength, oneOf: normalizeReferences(oneOf), anyOf: normalizeReferences(anyOf),
@@ -385,7 +378,7 @@ func parseDefinition(name string, table map[string]any) (Definition, error) {
 	}, nil
 }
 
-func validateRangeConstraints(name string, typeName, arrayType SchemaType, itemReference string, min, max any) error {
+func validateRangeConstraints(name string, typeName SchemaType, min, max any) error {
 	if min == nil && max == nil {
 		return nil
 	}
@@ -405,22 +398,6 @@ func validateRangeConstraints(name string, typeName, arrayType SchemaType, itemR
 		return fmt.Errorf("%s cannot define min or max when type is any", name)
 	}
 	if typeName == TypeArray {
-		if itemReference != "" {
-			return fmt.Errorf("%s cannot define min or max together with itemtype", name)
-		}
-		itemType := arrayType
-		if itemType == "" {
-			itemType = TypeAny
-		}
-		if !isRangeComparable(itemType) {
-			return fmt.Errorf("%s can only define min or max for arrays with integer, float, or temporal arraytype", name)
-		}
-		if err := validateBoundaryMatchesType(name, "min", min, itemType); err != nil {
-			return err
-		}
-		if err := validateBoundaryMatchesType(name, "max", max, itemType); err != nil {
-			return err
-		}
 		return nil
 	}
 	if typeName != "" && !isRangeComparable(typeName) {
@@ -435,6 +412,82 @@ func validateRangeConstraints(name string, typeName, arrayType SchemaType, itemR
 		}
 	}
 	return nil
+}
+
+func (s *Schema) validateArrayRanges() error {
+	var validateDefinition func(Definition) error
+	validateDefinition = func(definition Definition) error {
+		if definition.typeName == TypeArray && (definition.min != nil || definition.max != nil) {
+			itemType, ok, err := s.resolveItemKind(definition.itemReference, map[string]bool{})
+			if err != nil {
+				return fmt.Errorf("%s has invalid itemtype: %w", definition.name, err)
+			}
+			if !ok || !isRangeComparable(itemType) {
+				return fmt.Errorf("%s can only define min or max when itemtype resolves to one comparable built-in type", definition.name)
+			}
+			if err := validateBoundaryMatchesType(definition.name, "min", definition.min, itemType); err != nil {
+				return err
+			}
+			if err := validateBoundaryMatchesType(definition.name, "max", definition.max, itemType); err != nil {
+				return err
+			}
+		}
+		for _, child := range definition.children {
+			if err := validateDefinition(child); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for _, definitions := range []map[string]Definition{s.types, s.elements} {
+		for _, definition := range definitions {
+			if err := validateDefinition(definition); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (s *Schema) resolveItemKind(reference string, seen map[string]bool) (SchemaType, bool, error) {
+	normalized := normalizeReference(reference)
+	if normalized == "" {
+		return "", false, nil
+	}
+	if builtInType, ok := parseSchemaType(normalized); ok {
+		return builtInType, true, nil
+	}
+	if seen[normalized] {
+		return "", false, fmt.Errorf("cyclic type reference: %s", normalized)
+	}
+	definition, ok := s.types[normalized]
+	if !ok {
+		return "", false, fmt.Errorf("unknown type reference: %s", reference)
+	}
+	seen[normalized] = true
+	defer delete(seen, normalized)
+	if definition.reference != "" {
+		return s.resolveItemKind(definition.reference, seen)
+	}
+	alternatives := definition.oneOf
+	if len(alternatives) == 0 {
+		alternatives = definition.anyOf
+	}
+	if len(alternatives) == 0 {
+		return definition.typeName, definition.typeName != "", nil
+	}
+	var resolvedType SchemaType
+	for _, alternative := range alternatives {
+		alternativeType, resolved, err := s.resolveItemKind(alternative, seen)
+		if err != nil {
+			return "", false, err
+		}
+		if !resolved || (resolvedType != "" && alternativeType != resolvedType) {
+			return "", false, nil
+		}
+		resolvedType = alternativeType
+	}
+	return resolvedType, resolvedType != "", nil
 }
 
 func validateRangeBoundary(name, key string, value any) error {
@@ -672,37 +725,29 @@ func (v *validator) validateArray(path string, array []any, definition Definitio
 		v.validateTupleArray(path, array, definition)
 		return
 	}
-	arrayType := definition.arrayType
-	if arrayType == "" {
-		arrayType = TypeAny
-	}
-	var itemDefinition *Definition
-	if definition.itemReference != "" {
-		resolved, err := v.resolveReference(definition.itemReference, map[string]bool{})
-		if err != nil {
-			v.add(path, err.Error())
+	if definition.itemReference == "" {
+		if len(definition.allowedValues) == 0 {
 			return
 		}
-		itemDefinition = &resolved
-	}
-	if arrayType == TypeAny && itemDefinition == nil {
+		for i, item := range array {
+			v.validateAllowedValues(fmt.Sprintf("%s[%d]", path, i), item, definition)
+		}
 		return
 	}
+	itemDefinition, err := v.resolveReference(definition.itemReference, map[string]bool{})
+	if err != nil {
+		v.add(path, err.Error())
+		return
+	}
+	rangeType, hasRangeType, _ := v.schema.resolveItemKind(definition.itemReference, map[string]bool{})
 	for i, item := range array {
 		itemPath := fmt.Sprintf("%s[%d]", path, i)
-		matchesArrayType := true
-		if arrayType != TypeAny {
-			v.validateType(itemPath, item, arrayType)
-			matchesArrayType = isType(item, arrayType)
-		}
-		if !matchesArrayType {
-			continue
-		}
-		if itemDefinition == nil {
+		v.validateValue(itemPath, item, itemDefinition)
+		if len(definition.allowedValues) > 0 {
 			v.validateAllowedValues(itemPath, item, definition)
+		}
+		if hasRangeType && isType(item, rangeType) {
 			v.validateRange(itemPath, item, definition)
-		} else {
-			v.validateValue(itemPath, item, *itemDefinition)
 		}
 	}
 }
@@ -800,7 +845,6 @@ func (v *validator) resolve(definition Definition, seenReferences map[string]boo
 	}
 	return Definition{
 		name: definition.name, typeName: referenced.typeName, description: definition.description,
-		arrayType:     referenced.arrayType,
 		itemReference: referenced.itemReference,
 		items:         referenced.items,
 		optional:      definition.optional || referenced.optional,
@@ -857,17 +901,6 @@ func SchemaFromDocument(documentPath string) (*Schema, map[string]any, error) {
 		return nil, nil, err
 	}
 	return schema, document, nil
-}
-
-func getSchemaType(table map[string]any, key string) (SchemaType, error) {
-	value, err := getString(table, key)
-	if err != nil || value == "" {
-		return "", err
-	}
-	if schemaType, ok := parseSchemaType(value); ok {
-		return schemaType, nil
-	}
-	return "", fmt.Errorf("unsupported schema type: %s", value)
 }
 
 func propertyValue(table map[string]any, key string) any {

--- a/reference-implementations/go/schema_test.go
+++ b/reference-implementations/go/schema_test.go
@@ -239,6 +239,97 @@ min = 2026-01-01T00:00:00Z
 	}
 }
 
+func TestValidatesArrayRangesThroughItemtype(t *testing.T) {
+	dir := t.TempDir()
+	schemaPath := write(t, dir, "array-ranges.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[types.boundedInteger]
+type = "integer"
+min = 10
+max = 20
+
+[types.smallInteger]
+type = "integer"
+max = 5
+
+[types.largeInteger]
+type = "integer"
+min = 6
+
+[types.integerAlternative]
+oneof = [ "types.smallInteger", "types.largeInteger" ]
+
+[elements.direct]
+type = "array"
+itemtype = "integer"
+min = 2
+max = 4
+
+[elements.named]
+type = "array"
+itemtype = "types.boundedInteger"
+min = 5
+max = 25
+
+[elements.alternatives]
+type = "array"
+itemtype = "types.integerAlternative"
+min = 1
+max = 10
+`)
+	validPath := write(t, dir, "valid-array-ranges.toml", `
+direct = [2, 3, 4]
+named = [10, 20]
+alternatives = [2, 8]
+`)
+	invalidPath := write(t, dir, "invalid-array-ranges.toml", `
+direct = [1, 5]
+named = [7, 21]
+alternatives = [0, 11]
+`)
+
+	schema, err := LoadSchema(schemaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result := schema.ValidateFile(validPath); !result.Valid() {
+		t.Fatalf("expected comparable itemtype ranges to validate, got %#v", result.Errors)
+	}
+	result := schema.ValidateFile(invalidPath)
+	for _, path := range []string{
+		"$.direct[0]", "$.direct[1]",
+		"$.named[0]", "$.named[1]",
+		"$.alternatives[0]", "$.alternatives[1]",
+	} {
+		if !hasPath(result, path) {
+			t.Fatalf("expected range error at %s, got %#v", path, result.Errors)
+		}
+	}
+}
+
+func TestRejectsArrayRangesForMixedItemtypeAlternatives(t *testing.T) {
+	dir := t.TempDir()
+	schemaPath := write(t, dir, "mixed-array-range.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[types.mixed]
+oneof = [ "integer", "string" ]
+
+[elements.values]
+type = "array"
+itemtype = "types.mixed"
+min = 1
+`)
+
+	if _, err := LoadSchema(schemaPath); err == nil ||
+		!strings.Contains(err.Error(), "one comparable built-in type") {
+		t.Fatalf("expected mixed itemtype alternatives to reject array min, got %v", err)
+	}
+}
+
 func TestRejectsMalformedLengthSchemas(t *testing.T) {
 	dir := t.TempDir()
 	cases := map[string]string{
@@ -418,7 +509,6 @@ anyof = [ "types.stringId", "types.intId" ]
 
 [elements.entries]
 type = "array"
-arraytype = "table"
 itemtype = "types.namedOrNumbered"
 `)
 	documentPath := write(t, dir, "document.toml", `
@@ -440,7 +530,7 @@ entries = [
 	}
 }
 
-func TestRequiresArrayItemsWhenArrayTypeIsArray(t *testing.T) {
+func TestValidatesNestedArraysThroughItemtype(t *testing.T) {
 	dir := t.TempDir()
 	schemaPath := write(t, dir, "nested-arrays.tosd", `
 [toml-schema]
@@ -448,7 +538,7 @@ version = "1.0.0"
 
 [elements.nested]
 type = "array"
-arraytype = "array"
+itemtype = "array"
 
 [elements.mixed]
 type = "array"
@@ -474,7 +564,7 @@ mixed = [1, "two", [true]]
 
 	invalidResult := schema.ValidateFile(invalidPath)
 	if invalidResult.Valid() {
-		t.Fatal("expected arraytype array to reject a non-array item")
+		t.Fatal("expected array itemtype to reject a non-array item")
 	}
 	if !hasPath(invalidResult, "$.nested[1]") {
 		t.Fatalf("expected nested item type error, got %#v", invalidResult.Errors)
@@ -520,6 +610,59 @@ flex = "abc"
 
 	if !result.Valid() {
 		t.Fatalf("expected valid document, got %#v", result.Errors)
+	}
+}
+
+func TestValidatesAllowedValuesForArrayWithoutItemtype(t *testing.T) {
+	dir := t.TempDir()
+	schemaPath := write(t, dir, "array-allowedvalues.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[elements.colors]
+type = "array"
+allowedvalues = [ "red", "blue" ]
+
+[elements.unrestricted]
+type = "array"
+allowedvalues = []
+`)
+	validPath := write(t, dir, "valid-array-allowedvalues.toml", `
+colors = [ "red", "blue" ]
+unrestricted = [ 1, 2 ]
+`)
+	invalidPath := write(t, dir, "invalid-array-allowedvalues.toml", `
+colors = [ "red", "green" ]
+unrestricted = [ 1, 2 ]
+`)
+
+	schema, err := LoadSchema(schemaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result := schema.ValidateFile(validPath); !result.Valid() {
+		t.Fatalf("expected array items in allowedvalues to validate, got %#v", result.Errors)
+	}
+	result := schema.ValidateFile(invalidPath)
+	if result.Valid() || !hasPath(result, "$.colors[1]") {
+		t.Fatalf("expected disallowed array item error, got %#v", result.Errors)
+	}
+}
+
+func TestRejectsRemovedArraytypeProperty(t *testing.T) {
+	dir := t.TempDir()
+	schemaPath := write(t, dir, "arraytype.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[elements.values]
+type = "array"
+arraytype = "string"
+`)
+
+	if _, err := LoadSchema(schemaPath); err == nil ||
+		!strings.Contains(err.Error(), "unsupported property: arraytype") {
+		t.Fatalf("expected arraytype to be rejected as unsupported, got %v", err)
 	}
 }
 
@@ -662,7 +805,6 @@ optional = true
 
 func TestRejectsConstraintsAndChildrenOnNamedTypeReference(t *testing.T) {
 	invalidSiblings := []string{
-		`arraytype = "string"`,
 		`itemtype = "string"`,
 		`items = [ "string" ]`,
 		`allowedvalues = [ "name" ]`,
@@ -797,7 +939,7 @@ version = "1.0.0"
 
 [elements.values]
 type = "array"
-arraytype = "string"
+itemtype = "string"
 %s = 1
 `, alias))
 		if _, err := LoadSchema(schemaPath); err == nil {
@@ -897,7 +1039,7 @@ version = "1.0.0"
 [elements.value]
 type = "array"
 items = [ "types.coordinate", "types.label" ]
-arraytype = "string"
+itemtype = "string"
 `,
 		`
 [toml-schema]
@@ -1020,7 +1162,7 @@ location = "ignored.tosd"
 		"[elements.owner]",
 		"[elements.owner.name]",
 		`[elements.site."google.com"]`,
-		`arraytype = "integer"`,
+		`itemtype = "integer"`,
 	} {
 		if !strings.Contains(schemaText, expected) {
 			t.Fatalf("expected extracted schema to contain %q:\n%s", expected, schemaText)
@@ -1028,6 +1170,9 @@ location = "ignored.tosd"
 	}
 	if strings.Contains(schemaText, "[elements.toml-schema]") {
 		t.Fatalf("extracted schema should not include reserved metadata:\n%s", schemaText)
+	}
+	if strings.Contains(schemaText, "arraytype") {
+		t.Fatalf("extracted schema should not contain removed arraytype:\n%s", schemaText)
 	}
 
 	schema, err := LoadSchema(extractedSchema)

--- a/reference-implementations/java/src/main/java/org/tomlschema/SchemaDefinition.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/SchemaDefinition.java
@@ -9,7 +9,6 @@ record SchemaDefinition(
         SchemaType type,
         String reference,
         String description,
-        SchemaType arrayType,
         String itemReference,
         List<String> items,
         boolean optional,

--- a/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
@@ -13,6 +13,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,7 +25,7 @@ import java.util.stream.Collectors;
 final class SchemaLoader {
     static final Set<String> TOP_LEVEL_KEYS = Set.of("toml-schema", "types", "elements");
     static final Set<String> DEFINITION_KEYS = Set.of(
-            "type", "description", "arraytype", "itemtype", "items", "allowedvalues", "pattern",
+            "type", "description", "itemtype", "items", "allowedvalues", "pattern",
             "keypattern", "optional", "default", "min", "max", "minlength", "maxlength",
             "oneof", "anyof"
     );
@@ -43,6 +44,8 @@ final class SchemaLoader {
         String version = validateTopLevel(parsed);
         Map<String, SchemaDefinition> types = parseDefinitions("types", parsed.getTable("types"), false);
         Map<String, SchemaDefinition> elements = parseDefinitions("elements", parsed.getTable("elements"), true);
+        validateArrayRangeConstraints(types, types);
+        validateArrayRangeConstraints(types, elements);
         return new TomlSchema(schemaPath, version, types, elements);
     }
 
@@ -92,6 +95,9 @@ final class SchemaLoader {
     }
 
     private SchemaDefinition parseDefinition(String name, TomlTable table) {
+        if (getPropertyValue(table, "arraytype") != null) {
+            throw new SchemaException(name + " contains unsupported property: arraytype");
+        }
         String typeSelector = getString(table, "type");
         SchemaType type = typeSelector == null
                 ? null
@@ -107,7 +113,6 @@ final class SchemaLoader {
             }
         }
         String description = getString(table, "description");
-        SchemaType arrayType = getSchemaType(table, "arraytype");
         String itemReference = normalizeReference(getString(table, "itemtype"));
         List<String> items = getStringArrayValues(table, "items").stream().map(this::normalizeReference).toList();
         Boolean optional = getBoolean(table, "optional");
@@ -143,9 +148,6 @@ final class SchemaLoader {
             }
             type = SchemaType.TABLE;
         }
-        if (type != SchemaType.ARRAY && arrayType != null) {
-            throw new SchemaException(name + " can only define arraytype when type is array");
-        }
         if (type != SchemaType.ARRAY && type != SchemaType.COLLECTION && itemReference != null) {
             throw new SchemaException(name + " can only define itemtype when type is array or collection");
         }
@@ -153,9 +155,6 @@ final class SchemaLoader {
             throw new SchemaException(name + " can only define items when type is array");
         }
         if (!items.isEmpty()) {
-            if (arrayType != null) {
-                throw new SchemaException(name + " cannot define both items and arraytype");
-            }
             if (itemReference != null) {
                 throw new SchemaException(name + " cannot define both items and itemtype");
             }
@@ -174,14 +173,13 @@ final class SchemaLoader {
         }
         Object min = getPropertyValue(table, "min");
         Object max = getPropertyValue(table, "max");
-        validateRangeConstraints(name, type, arrayType, itemReference, min, max);
+        validateRangeConstraints(name, type, itemReference, min, max);
         validateAllowedValuesConstraints(name, type, allowedValues, pattern, min, max, minLength, maxLength);
         return new SchemaDefinition(
                 name,
                 type,
                 normalizedReference,
                 description,
-                arrayType,
                 itemReference,
                 items,
                 optional != null && optional,
@@ -196,11 +194,6 @@ final class SchemaLoader {
                 anyOf.stream().map(this::normalizeReference).toList(),
                 children
         );
-    }
-
-    private SchemaType getSchemaType(TomlTable table, String key) {
-        String value = getString(table, key);
-        return value == null ? null : SchemaType.fromSchemaName(value);
     }
 
     private Object getPropertyValue(TomlTable table, String key) {
@@ -283,7 +276,7 @@ final class SchemaLoader {
         return strings;
     }
 
-    private void validateRangeConstraints(String name, SchemaType type, SchemaType arrayType, String itemReference, Object min, Object max) {
+    private void validateRangeConstraints(String name, SchemaType type, String itemReference, Object min, Object max) {
         if (min == null && max == null) {
             return;
         }
@@ -295,15 +288,9 @@ final class SchemaLoader {
             throw new SchemaException(name + " cannot define min or max when type is any");
         }
         if (type == SchemaType.ARRAY) {
-            if (itemReference != null) {
-                throw new SchemaException(name + " cannot define min or max together with itemtype");
+            if (itemReference == null) {
+                throw new SchemaException(name + " can only define min or max when itemtype resolves to one comparable built-in type");
             }
-            SchemaType itemType = arrayType == null ? SchemaType.ANY : arrayType;
-            if (!isRangeComparable(itemType)) {
-                throw new SchemaException(name + " can only define min or max for arrays with integer, float, or temporal arraytype");
-            }
-            validateBoundaryMatchesType(name, "min", min, itemType);
-            validateBoundaryMatchesType(name, "max", max, itemType);
             return;
         }
         if (type != null && !isRangeComparable(type)) {
@@ -313,6 +300,55 @@ final class SchemaLoader {
             validateBoundaryMatchesType(name, "min", min, type);
             validateBoundaryMatchesType(name, "max", max, type);
         }
+    }
+
+    private void validateArrayRangeConstraints(
+            Map<String, SchemaDefinition> types,
+            Map<String, SchemaDefinition> definitions
+    ) {
+        for (SchemaDefinition definition : definitions.values()) {
+            if (definition.type() == SchemaType.ARRAY && (definition.min() != null || definition.max() != null)) {
+                Set<SchemaType> itemTypes = resolveItemTypes(definition.itemReference(), types, new HashSet<>());
+                if (itemTypes.size() != 1 || !isRangeComparable(itemTypes.iterator().next())) {
+                    throw new SchemaException(definition.name()
+                            + " can only define min or max when itemtype resolves to one comparable built-in type");
+                }
+                SchemaType itemType = itemTypes.iterator().next();
+                validateBoundaryMatchesType(definition.name(), "min", definition.min(), itemType);
+                validateBoundaryMatchesType(definition.name(), "max", definition.max(), itemType);
+            }
+            validateArrayRangeConstraints(types, definition.children());
+        }
+    }
+
+    private Set<SchemaType> resolveItemTypes(
+            String reference,
+            Map<String, SchemaDefinition> types,
+            Set<String> seenReferences
+    ) {
+        SchemaType builtIn = SchemaType.fromSchemaNameOptional(reference).orElse(null);
+        if (builtIn != null) {
+            return Set.of(builtIn);
+        }
+        if (!seenReferences.add(reference)) {
+            throw new SchemaException("Cyclic schema reference involving types." + reference);
+        }
+        SchemaDefinition definition = types.get(reference);
+        if (definition == null) {
+            throw new SchemaException("Unknown schema type reference: types." + reference);
+        }
+        if (definition.reference() != null) {
+            return resolveItemTypes(definition.reference(), types, seenReferences);
+        }
+        List<String> alternatives = definition.oneOf().isEmpty() ? definition.anyOf() : definition.oneOf();
+        if (!alternatives.isEmpty()) {
+            Set<SchemaType> itemTypes = new HashSet<>();
+            for (String alternative : alternatives) {
+                itemTypes.addAll(resolveItemTypes(alternative, types, new HashSet<>(seenReferences)));
+            }
+            return itemTypes;
+        }
+        return Set.of(definition.type());
     }
 
     private void validateRangeBoundary(String name, String key, Object value) {

--- a/reference-implementations/java/src/main/java/org/tomlschema/TomlSchemaCli.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/TomlSchemaCli.java
@@ -177,7 +177,7 @@ public final class TomlSchemaCli {
         String type = schemaType(value);
         schema.append("type = \"").append(type).append("\"\n");
         if ("array".equals(type) && value instanceof TomlArray array) {
-            schema.append("arraytype = \"").append(inferArrayType(array)).append("\"\n");
+            schema.append("itemtype = \"").append(inferArrayType(array)).append("\"\n");
         }
         if (value instanceof TomlTable table) {
             for (String childKey : table.keySet()) {

--- a/reference-implementations/java/src/main/java/org/tomlschema/TomlSchemaValidator.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/TomlSchemaValidator.java
@@ -136,31 +136,41 @@ final class TomlSchemaValidator {
             validateTupleArray(path, array, definition);
             return;
         }
-        SchemaType arrayType = definition.arrayType() == null ? SchemaType.ANY : definition.arrayType();
         SchemaDefinition itemDefinition = definition.itemReference() == null
                 ? null
                 : resolveReference(definition.itemReference(), new HashSet<>());
-        if (arrayType == SchemaType.ANY && itemDefinition == null) {
+        if (itemDefinition == null && definition.allowedValues().isEmpty()) {
             return;
         }
         for (int i = 0; i < array.size(); i++) {
             Object item = array.get(i);
             String itemPath = path + "[" + i + "]";
-            boolean matchesArrayType = true;
-            if (arrayType != SchemaType.ANY) {
-                validateType(itemPath, item, arrayType);
-                matchesArrayType = isType(item, arrayType);
-            }
-            if (!matchesArrayType) {
-                continue;
-            }
-            if (itemDefinition == null) {
-                validateAllowedValues(itemPath, item, definition);
-                validateRange(itemPath, item, definition);
-            } else {
+            if (itemDefinition != null) {
                 validateValue(itemPath, item, itemDefinition);
             }
+            if (!definition.allowedValues().isEmpty()) {
+                validateAllowedValues(itemPath, item, definition);
+            }
+            if ((definition.min() != null || definition.max() != null)
+                    && boundariesAreComparableWith(item, definition)) {
+                validateRange(itemPath, item, definition);
+            }
         }
+    }
+
+    private boolean boundariesAreComparableWith(Object value, SchemaDefinition definition) {
+        return boundaryIsComparableWith(value, definition.min())
+                && boundaryIsComparableWith(value, definition.max());
+    }
+
+    private boolean boundaryIsComparableWith(Object value, Object boundary) {
+        if (boundary == null) {
+            return true;
+        }
+        if (value instanceof Number && boundary instanceof Number) {
+            return true;
+        }
+        return value instanceof Comparable<?> && value.getClass().isInstance(boundary);
     }
 
     private void validateTupleArray(String path, TomlArray array, SchemaDefinition definition) {
@@ -275,7 +285,6 @@ final class TomlSchemaValidator {
                 referenced.type(),
                 null,
                 definition.description(),
-                referenced.arrayType(),
                 referenced.itemReference(),
                 referenced.items(),
                 definition.optional() || referenced.optional(),
@@ -312,7 +321,6 @@ final class TomlSchemaValidator {
         return new SchemaDefinition(
                 reference,
                 type,
-                null,
                 null,
                 null,
                 null,

--- a/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
+++ b/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
@@ -342,7 +342,6 @@ class TomlSchemaTest {
     @Test
     void rejectsConstraintsAndChildrenOnNamedTypeReference() throws IOException {
         List<String> invalidSiblings = List.of(
-                "arraytype = \"string\"",
                 "itemtype = \"string\"",
                 "items = [ \"string\" ]",
                 "allowedvalues = [ \"name\" ]",
@@ -372,6 +371,21 @@ class TomlSchemaTest {
             SchemaException error = assertThrows(SchemaException.class, () -> TomlSchema.load(schema));
             assertTrue(error.getMessage().contains("named type reference"), error::getMessage);
         }
+    }
+
+    @Test
+    void rejectsRemovedArraytypeAsUnsupported() throws IOException {
+        Path schema = write("removed-arraytype.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.values]
+                type = "array"
+                arraytype = "string"
+                """);
+
+        SchemaException error = assertThrows(SchemaException.class, () -> TomlSchema.load(schema));
+        assertTrue(error.getMessage().contains("unsupported property: arraytype"), error::getMessage);
     }
 
     @Test
@@ -459,7 +473,7 @@ class TomlSchemaTest {
 
                 [elements.values]
                 type = "array"
-                arraytype = "string"
+                itemtype = "string"
                 minoccurs = 1
                 """);
         Path maxOccurs = write("maxoccurs-alias.tosd", """
@@ -468,7 +482,7 @@ class TomlSchemaTest {
 
                 [elements.values]
                 type = "array"
-                arraytype = "string"
+                itemtype = "string"
                 maxoccurs = 2
                 """);
 
@@ -477,14 +491,14 @@ class TomlSchemaTest {
     }
 
     @Test
-    void requiresArrayItemsWhenArrayTypeIsArray() throws IOException {
+    void requiresArrayItemsWhenItemtypeIsArray() throws IOException {
         Path schema = write("nested-arrays.tosd", """
                 [toml-schema]
                 version = "1.0.0"
 
                 [elements.nested]
                 type = "array"
-                arraytype = "array"
+                itemtype = "array"
 
                 [elements.mixed]
                 type = "array"
@@ -525,7 +539,6 @@ class TomlSchemaTest {
 
                 [elements.products]
                 type = "array"
-                arraytype = "table"
                 itemtype = "types.product"
                 minlength = 2
                 """);
@@ -561,7 +574,6 @@ class TomlSchemaTest {
 
                 [elements.points]
                 type = "array"
-                arraytype = "table"
                 itemtype = "types.point"
                 """);
         Path document = write("points.toml", """
@@ -653,14 +665,14 @@ class TomlSchemaTest {
 
     @Test
     void rejectsTupleArraySchemaWithConflictingProperties() throws IOException {
-        Path withArrayType = write("tuple-arraytype-conflict.tosd", """
+        Path withItemtype = write("tuple-itemtype-conflict.tosd", """
                 [toml-schema]
                 version = "1.0.0"
 
                 [elements.value]
                 type = "array"
                 items = [ "types.coordinate", "types.label" ]
-                arraytype = "string"
+                itemtype = "string"
                 """);
         Path withLength = write("tuple-length-conflict.tosd", """
                 [toml-schema]
@@ -672,7 +684,7 @@ class TomlSchemaTest {
                 minlength = 2
                 """);
 
-        assertThrows(SchemaException.class, () -> TomlSchema.load(withArrayType));
+        assertThrows(SchemaException.class, () -> TomlSchema.load(withItemtype));
         assertThrows(SchemaException.class, () -> TomlSchema.load(withLength));
     }
 
@@ -761,7 +773,6 @@ class TomlSchemaTest {
 
                 [elements.entries]
                 type = "array"
-                arraytype = "table"
                 itemtype = "types.namedOrNumbered"
 
                 [types.namedOrNumbered]
@@ -882,7 +893,7 @@ class TomlSchemaTest {
 
                 [elements.thresholds]
                 type = "array"
-                arraytype = "float"
+                itemtype = "float"
                 min = -inf
                 max = inf
                 """);
@@ -895,6 +906,80 @@ class TomlSchemaTest {
         ValidationResult result = TomlSchema.load(schema).validate(document);
 
         assertTrue(result.isValid(), () -> result.errors().toString());
+    }
+
+    @Test
+    void appliesArrayRangesAndNamedItemConstraints() throws IOException {
+        Path schema = write("array-member-boundaries.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [types.constrainedInteger]
+                type = "integer"
+                min = 0
+                max = 100
+
+                [elements.values]
+                type = "array"
+                itemtype = "types.constrainedInteger"
+                min = -10
+                max = 10
+                """);
+        Path validDocument = write("array-member-boundaries-valid.toml", "values = [ 0, 10 ]");
+        Path invalidDocument = write("array-member-boundaries-invalid.toml", "values = [ -1, 11 ]");
+        TomlSchema loaded = TomlSchema.load(schema);
+
+        assertTrue(loaded.validate(validDocument).isValid());
+        ValidationResult invalid = loaded.validate(invalidDocument);
+        assertTrue(invalid.errors().stream().anyMatch(error ->
+                error.path().equals("$.values[0]") && error.message().equals("value is less than min")));
+        assertTrue(invalid.errors().stream().anyMatch(error ->
+                error.path().equals("$.values[1]") && error.message().equals("value is greater than max")));
+    }
+
+    @Test
+    void appliesArrayAllowedValuesWithoutItemtype() throws IOException {
+        Path schema = write("array-allowedvalues.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.values]
+                type = "array"
+                allowedvalues = [ "red", "green", "blue" ]
+                """);
+        Path validDocument = write("array-allowedvalues-valid.toml", """
+                values = [ "red", "blue" ]
+                """);
+        Path invalidDocument = write("array-allowedvalues-invalid.toml", """
+                values = [ "red", "yellow" ]
+                """);
+        TomlSchema loaded = TomlSchema.load(schema);
+
+        assertTrue(loaded.validate(validDocument).isValid());
+        ValidationResult invalid = loaded.validate(invalidDocument);
+        assertEquals(1, invalid.errors().size());
+        assertEquals("$.values[1]", invalid.errors().getFirst().path());
+        assertEquals("value is not in allowedvalues", invalid.errors().getFirst().message());
+    }
+
+    @Test
+    void rejectsArrayRangesForMixedItemAlternatives() throws IOException {
+        Path schema = write("mixed-array-member-boundaries.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [types.numeric]
+                oneof = [ "integer", "float" ]
+
+                [elements.values]
+                type = "array"
+                itemtype = "types.numeric"
+                min = 0
+                """);
+
+        SchemaException error = assertThrows(SchemaException.class, () -> TomlSchema.load(schema));
+        assertTrue(error.getMessage().contains("itemtype resolves to one comparable built-in type"),
+                error::getMessage);
     }
 
     @Test
@@ -1320,6 +1405,8 @@ class TomlSchemaTest {
         assertTrue(schemaText.contains("version = \"1.0.0\""));
         assertTrue(schemaText.contains("[elements.title]"));
         assertTrue(schemaText.contains("type = \"string\""));
+        assertTrue(schemaText.contains("itemtype = \"integer\""));
+        assertFalse(schemaText.contains("arraytype"));
         assertTrue(schemaText.contains("[elements.owner]"));
         assertTrue(schemaText.contains("[elements.owner.name]"));
         assertFalse(schemaText.contains("[elements.toml-schema]"));

--- a/reference-implementations/rust/Cargo.tosd
+++ b/reference-implementations/rust/Cargo.tosd
@@ -5,7 +5,7 @@ version = "1.0.0"
 
 [types.stringArray]
 type = "array"
-arraytype = "string"
+itemtype = "string"
 
 [types.workspaceInherited]
 type = "table"
@@ -189,12 +189,12 @@ type = "table"
 
     [types.target.crate-type]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
     [types.target.required-features]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
     [types.target.edition]
@@ -245,7 +245,7 @@ type = "table"
 
     [types.dependencyTable.features]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
     [types.dependencyTable.workspace]
@@ -389,17 +389,17 @@ type = "table"
 
     [types.workspace.members]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
     [types.workspace.exclude]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
     [types.workspace.default-members]
     type = "array"
-    arraytype = "string"
+    itemtype = "string"
     optional = true
 
     [types.workspace.package]
@@ -422,7 +422,7 @@ type = "table"
 
 [elements.cargo-features]
 type = "array"
-arraytype = "string"
+itemtype = "string"
 optional = true
 
 [elements.package]
@@ -435,25 +435,21 @@ optional = true
 
 [elements.bin]
 type = "array"
-arraytype = "table"
 itemtype = "types.target"
 optional = true
 
 [elements.example]
 type = "array"
-arraytype = "table"
 itemtype = "types.target"
 optional = true
 
 [elements.test]
 type = "array"
-arraytype = "table"
 itemtype = "types.target"
 optional = true
 
 [elements.bench]
 type = "array"
-arraytype = "table"
 itemtype = "types.target"
 optional = true
 

--- a/reference-implementations/rust/src/extract.rs
+++ b/reference-implementations/rust/src/extract.rs
@@ -40,8 +40,8 @@ fn append_definition(schema: &mut String, path: &[&str], value: &Value) {
         if let Value::Array(array) = value {
             writeln!(
                 schema,
-                "arraytype = \"{}\"",
-                infer_array_type(array).schema_name()
+                "itemtype = \"{}\"",
+                infer_item_type(array).schema_name()
             )
             .expect("write to String");
         }
@@ -81,7 +81,7 @@ fn schema_type_of_datetime(datetime: &Datetime) -> SchemaType {
     }
 }
 
-fn infer_array_type(array: &[Value]) -> SchemaType {
+fn infer_item_type(array: &[Value]) -> SchemaType {
     let Some(first) = array.first() else {
         return SchemaType::Any;
     };

--- a/reference-implementations/rust/src/schema.rs
+++ b/reference-implementations/rust/src/schema.rs
@@ -92,7 +92,6 @@ impl fmt::Display for SchemaType {
 pub const DEFINITION_KEYS: &[&str] = &[
     "type",
     "description",
-    "arraytype",
     "itemtype",
     "items",
     "allowedvalues",
@@ -122,7 +121,6 @@ pub struct Definition {
     type_name: Option<SchemaType>,
     reference: Option<String>,
     description: Option<String>,
-    array_type: Option<SchemaType>,
     item_reference: Option<String>,
     items: Vec<String>,
     optional: bool,
@@ -204,11 +202,13 @@ impl Schema {
         let elements_table = table.get("elements").and_then(Value::as_table);
         let types = parse_definitions("types", types_table, false)?;
         let elements = parse_definitions("elements", elements_table, true)?;
-        Ok(Schema {
+        let schema = Schema {
             source,
             types,
             elements,
-        })
+        };
+        schema.validate_array_range_definitions()?;
+        Ok(schema)
     }
 
     /// Returns the path the schema was loaded from.
@@ -235,6 +235,93 @@ impl Schema {
         if captures.get(2).map(|minor| minor.as_str()) != Some("0") {
             return Err(format!("unsupported TOML Schema minor version: {version}"));
         }
+        Ok(())
+    }
+
+    fn validate_array_range_definitions(&self) -> Result<(), String> {
+        for definition in self.types.values().chain(self.elements.values()) {
+            self.validate_array_range_definition(definition)?;
+        }
+        Ok(())
+    }
+
+    fn validate_array_range_definition(&self, definition: &Definition) -> Result<(), String> {
+        if definition.type_name == Some(SchemaType::Array)
+            && (definition.min.is_some() || definition.max.is_some())
+        {
+            let item_type = self.array_range_item_type(definition)?;
+            validate_boundary_matches_type(
+                &definition.name,
+                "min",
+                definition.min.as_ref(),
+                item_type,
+            )?;
+            validate_boundary_matches_type(
+                &definition.name,
+                "max",
+                definition.max.as_ref(),
+                item_type,
+            )?;
+        }
+        for child in definition.children.values() {
+            self.validate_array_range_definition(child)?;
+        }
+        Ok(())
+    }
+
+    fn array_range_item_type(&self, definition: &Definition) -> Result<SchemaType, String> {
+        let Some(reference) = definition.item_reference.as_deref() else {
+            return Err(format!(
+                "{} can only define min or max when itemtype resolves to one comparable built-in type",
+                definition.name
+            ));
+        };
+        let mut types = HashSet::new();
+        self.collect_reference_types(reference, &mut HashSet::new(), &mut types)?;
+        if types.len() != 1 {
+            return Err(format!(
+                "{} cannot define min or max when itemtype has mixed alternatives",
+                definition.name
+            ));
+        }
+        let item_type = *types.iter().next().expect("one item type");
+        if !item_type.is_range_comparable() {
+            return Err(format!(
+                "{} can only define min or max when itemtype resolves to one comparable built-in type",
+                definition.name
+            ));
+        }
+        Ok(item_type)
+    }
+
+    fn collect_reference_types(
+        &self,
+        reference: &str,
+        seen: &mut HashSet<String>,
+        types: &mut HashSet<SchemaType>,
+    ) -> Result<(), String> {
+        let normalized = normalize_reference(reference.to_string());
+        if let Some(type_name) = SchemaType::parse(&normalized) {
+            types.insert(type_name);
+            return Ok(());
+        }
+        if !seen.insert(normalized.clone()) {
+            return Err(format!("cyclic type reference: {normalized}"));
+        }
+        let definition = self
+            .types
+            .get(&normalized)
+            .ok_or_else(|| format!("unknown type reference: {reference}"))?;
+        if let Some(reference) = definition.reference.as_deref() {
+            self.collect_reference_types(reference, seen, types)?;
+        } else if !definition.one_of.is_empty() || !definition.any_of.is_empty() {
+            for alternative in definition.one_of.iter().chain(definition.any_of.iter()) {
+                self.collect_reference_types(alternative, seen, types)?;
+            }
+        } else if let Some(type_name) = definition.type_name {
+            types.insert(type_name);
+        }
+        seen.remove(&normalized);
         Ok(())
     }
 
@@ -321,6 +408,9 @@ fn parse_definitions(
 }
 
 fn parse_definition(name: &str, table: &Table) -> Result<Definition, String> {
+    if property_value(table, "arraytype").is_some() {
+        return Err(format!("{name} contains unsupported property: arraytype"));
+    }
     let type_selector = get_string(name, table, "type")?;
     let mut type_name = type_selector.as_deref().and_then(SchemaType::parse);
     let reference = type_selector
@@ -335,7 +425,6 @@ fn parse_definition(name: &str, table: &Table) -> Result<Definition, String> {
         }
     }
     let description = get_string(name, table, "description")?;
-    let array_type = get_schema_type(name, table, "arraytype")?;
     let item_reference = get_string(name, table, "itemtype")?;
     let items = get_string_array_values(name, table, "items")?;
     let optional = get_bool(name, table, "optional")?.unwrap_or(false);
@@ -374,11 +463,6 @@ fn parse_definition(name: &str, table: &Table) -> Result<Definition, String> {
         }
         type_name = Some(SchemaType::Table);
     }
-    if type_name != Some(SchemaType::Array) && array_type.is_some() {
-        return Err(format!(
-            "{name} can only define arraytype when type is array"
-        ));
-    }
     if !matches!(type_name, Some(SchemaType::Array | SchemaType::Collection))
         && item_reference.is_some()
     {
@@ -390,15 +474,17 @@ fn parse_definition(name: &str, table: &Table) -> Result<Definition, String> {
         return Err(format!("{name} can only define items when type is array"));
     }
     if !items.is_empty() {
-        if array_type.is_some() {
-            return Err(format!("{name} cannot define both items and arraytype"));
-        }
         if item_reference.is_some() {
             return Err(format!("{name} cannot define both items and itemtype"));
         }
         if min_length.is_some() || max_length.is_some() {
             return Err(format!(
                 "{name} cannot define minlength or maxlength together with items"
+            ));
+        }
+        if property_value(table, "min").is_some() || property_value(table, "max").is_some() {
+            return Err(format!(
+                "{name} cannot define min or max together with items"
             ));
         }
     }
@@ -421,14 +507,7 @@ fn parse_definition(name: &str, table: &Table) -> Result<Definition, String> {
     }
     let min = property_value(table, "min").cloned();
     let max = property_value(table, "max").cloned();
-    validate_range_constraints(
-        name,
-        type_name,
-        array_type,
-        item_reference.as_deref(),
-        min.as_ref(),
-        max.as_ref(),
-    )?;
+    validate_range_constraints(name, type_name, min.as_ref(), max.as_ref())?;
     validate_allowed_values_constraints(
         name,
         type_name,
@@ -444,7 +523,6 @@ fn parse_definition(name: &str, table: &Table) -> Result<Definition, String> {
         type_name,
         reference,
         description,
-        array_type,
         item_reference: item_reference.map(normalize_reference),
         items: normalize_references(items),
         optional,
@@ -464,8 +542,6 @@ fn parse_definition(name: &str, table: &Table) -> Result<Definition, String> {
 fn validate_range_constraints(
     name: &str,
     type_name: Option<SchemaType>,
-    array_type: Option<SchemaType>,
-    item_reference: Option<&str>,
     min: Option<&Value>,
     max: Option<&Value>,
 ) -> Result<(), String> {
@@ -484,19 +560,6 @@ fn validate_range_constraints(
         return Err(format!("{name} cannot define min or max when type is any"));
     }
     if type_name == Some(SchemaType::Array) {
-        if item_reference.is_some() {
-            return Err(format!(
-                "{name} cannot define min or max together with itemtype"
-            ));
-        }
-        let item_type = array_type.unwrap_or(SchemaType::Any);
-        if !item_type.is_range_comparable() {
-            return Err(format!(
-                "{name} can only define min or max for arrays with integer, float, or temporal arraytype"
-            ));
-        }
-        validate_boundary_matches_type(name, "min", min, item_type)?;
-        validate_boundary_matches_type(name, "max", max, item_type)?;
         return Ok(());
     }
     if let Some(type_name) = type_name {
@@ -792,7 +855,6 @@ impl<'schema> Validator<'schema> {
             self.validate_tuple_array(path, array, definition);
             return;
         }
-        let array_type = definition.array_type.unwrap_or(SchemaType::Any);
         let item_definition = match definition.item_reference.as_deref() {
             Some(reference) => match self.resolve_reference(reference, &mut HashSet::new()) {
                 Ok(referenced) => Some(referenced),
@@ -803,25 +865,28 @@ impl<'schema> Validator<'schema> {
             },
             None => None,
         };
-        if array_type == SchemaType::Any && item_definition.is_none() {
+        if item_definition.is_none() && definition.allowed_values.is_empty() {
             return;
         }
+        let range_type = if definition.min.is_some() || definition.max.is_some() {
+            match self.schema.array_range_item_type(definition) {
+                Ok(item_type) => Some(item_type),
+                Err(error) => {
+                    self.add(path, &error);
+                    return;
+                }
+            }
+        } else {
+            None
+        };
         for (index, item) in array.iter().enumerate() {
             let item_path = format!("{path}[{index}]");
-            let mut matches_array_type = true;
-            if array_type != SchemaType::Any {
-                self.validate_type(&item_path, item, array_type);
-                matches_array_type = value_matches_type(item, array_type);
+            if let Some(item_definition) = &item_definition {
+                self.validate_value(&item_path, item, item_definition);
             }
-            if !matches_array_type {
-                continue;
-            }
-            match &item_definition {
-                Some(item_definition) => self.validate_value(&item_path, item, item_definition),
-                None => {
-                    self.validate_allowed_values(&item_path, item, definition);
-                    self.validate_range(&item_path, item, definition);
-                }
+            self.validate_allowed_values(&item_path, item, definition);
+            if range_type.is_some_and(|item_type| value_matches_type(item, item_type)) {
+                self.validate_range(&item_path, item, definition);
             }
         }
     }
@@ -946,7 +1011,6 @@ impl<'schema> Validator<'schema> {
             type_name: referenced.type_name,
             reference: None,
             description: definition.description.clone(),
-            array_type: referenced.array_type,
             item_reference: referenced.item_reference,
             items: referenced.items,
             optional: definition.optional || referenced.optional,
@@ -1218,15 +1282,6 @@ fn normalize_references(references: Vec<String>) -> Vec<String> {
 
 fn is_nan(value: Option<&Value>) -> bool {
     matches!(value, Some(Value::Float(float)) if float.is_nan())
-}
-
-fn get_schema_type(name: &str, table: &Table, key: &str) -> Result<Option<SchemaType>, String> {
-    let Some(value) = get_string(name, table, key)? else {
-        return Ok(None);
-    };
-    SchemaType::parse(&value)
-        .map(Some)
-        .ok_or_else(|| format!("{name} has unsupported schema type: {value}"))
 }
 
 fn property_value<'a>(table: &'a Table, key: &str) -> Option<&'a Value> {

--- a/reference-implementations/rust/tests/integration.rs
+++ b/reference-implementations/rust/tests/integration.rs
@@ -468,6 +468,51 @@ maxlength = 2
 }
 
 #[test]
+fn validates_array_allowedvalues_without_itemtype() {
+    let directory = tempfile_dir("array-allowedvalues");
+    let schema_path = write_file(
+        &directory,
+        "schema.tosd",
+        r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.values]
+type = "array"
+allowedvalues = [ 1, 2 ]
+
+[elements.unrestricted]
+type = "array"
+allowedvalues = []
+"#,
+    );
+    let valid_document = write_file(
+        &directory,
+        "valid.toml",
+        r#"
+values = [ 1, 2 ]
+unrestricted = [ 1, "two", true ]
+"#,
+    );
+    let invalid_document = write_file(
+        &directory,
+        "invalid.toml",
+        r#"
+values = [ 1, 3 ]
+unrestricted = [ 1, "two", true ]
+"#,
+    );
+
+    let schema = Schema::load(&schema_path).expect("load array allowedvalues schema");
+    assert!(schema.validate_file(valid_document).valid());
+
+    let result = schema.validate_file(invalid_document);
+    assert_eq!(result.errors.len(), 1, "{:#?}", result.errors);
+    assert_eq!(result.errors[0].path, "$.values[1]");
+    assert_eq!(result.errors[0].message, "value is not in allowedvalues");
+}
+
+#[test]
 fn pattern_matches_unanchored() {
     let directory = tempfile_dir("pattern-unanchored");
     let schema_path = write_file(
@@ -553,7 +598,6 @@ anyof = [ "types.stringId", "types.intId" ]
 
 [elements.entries]
 type = "array"
-arraytype = "table"
 itemtype = "types.namedOrNumbered"
 "#,
     );
@@ -580,7 +624,7 @@ entries = [
 }
 
 #[test]
-fn requires_array_items_when_arraytype_is_array() {
+fn validates_nested_arrays_with_itemtype() {
     let directory = tempfile_dir("nested-arrays");
     let schema_path = write_file(
         &directory,
@@ -591,7 +635,7 @@ version = "1.0.0"
 
 [elements.nested]
 type = "array"
-arraytype = "array"
+itemtype = "array"
 
 [elements.mixed]
 type = "array"
@@ -626,6 +670,135 @@ mixed = [1, "two", [true]]
     let invalid_result = schema.validate_file(&invalid_path);
     assert!(!invalid_result.valid());
     assert!(has_path(&invalid_result, "$.nested[1]"));
+}
+
+#[test]
+fn validates_array_ranges_with_comparable_itemtypes() {
+    let directory = tempfile_dir("array-ranges");
+    let schema_path = write_file(
+        &directory,
+        "schema.tosd",
+        r#"
+[toml-schema]
+version = "1.0.0"
+
+[types.boundedInteger]
+type = "integer"
+min = 3
+max = 8
+
+[types.lowInteger]
+type = "integer"
+max = 6
+
+[types.integerAlternative]
+anyof = [ "types.boundedInteger", "types.lowInteger" ]
+
+[elements.direct]
+type = "array"
+itemtype = "integer"
+min = 2
+max = 4
+
+[elements.named]
+type = "array"
+itemtype = "types.boundedInteger"
+min = 0
+max = 20
+
+[elements.alternative]
+type = "array"
+itemtype = "types.integerAlternative"
+min = 4
+max = 5
+"#,
+    );
+    let valid_path = write_file(
+        &directory,
+        "valid.toml",
+        r#"
+direct = [2, 4]
+named = [3, 8]
+alternative = [4, 5]
+"#,
+    );
+    let invalid_path = write_file(
+        &directory,
+        "invalid.toml",
+        r#"
+direct = [1, 5]
+named = [2]
+alternative = [3, 6]
+"#,
+    );
+
+    let schema = Schema::load(&schema_path).expect("load comparable array ranges");
+    assert!(schema.validate_file(&valid_path).valid());
+
+    let result = schema.validate_file(&invalid_path);
+    for path in [
+        "$.direct[0]",
+        "$.direct[1]",
+        "$.named[0]",
+        "$.alternative[0]",
+        "$.alternative[1]",
+    ] {
+        assert!(
+            has_path(&result, path),
+            "expected error at {path}: {:#?}",
+            result.errors
+        );
+    }
+}
+
+#[test]
+fn rejects_array_ranges_with_mixed_itemtype_alternatives() {
+    let directory = tempfile_dir("mixed-array-ranges");
+    let schema_path = write_file(
+        &directory,
+        "schema.tosd",
+        r#"
+[toml-schema]
+version = "1.0.0"
+
+[types.mixed]
+oneof = [ "integer", "string" ]
+
+[elements.values]
+type = "array"
+itemtype = "types.mixed"
+min = 1
+"#,
+    );
+
+    let error = Schema::load(&schema_path).expect_err("reject mixed array range itemtype");
+    assert!(
+        error.contains("mixed alternatives"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn rejects_removed_arraytype_property() {
+    let directory = tempfile_dir("removed-arraytype");
+    let schema_path = write_file(
+        &directory,
+        "schema.tosd",
+        r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.values]
+type = "array"
+arraytype = "integer"
+"#,
+    );
+
+    let error = Schema::load(&schema_path).expect_err("arraytype must be unsupported");
+    assert!(
+        error.contains("unsupported property"),
+        "unexpected error: {error}"
+    );
 }
 
 #[test]
@@ -862,7 +1035,6 @@ optional = true
 #[test]
 fn rejects_constraints_and_children_on_named_type_reference() {
     let invalid_siblings = [
-        r#"arraytype = "string""#,
         r#"itemtype = "string""#,
         r#"items = [ "string" ]"#,
         r#"allowedvalues = [ "name" ]"#,
@@ -1010,7 +1182,7 @@ version = "1.0.0"
 
 [elements.values]
 type = "array"
-arraytype = "string"
+itemtype = "string"
 {alias} = 1
 "#
             ),
@@ -1132,7 +1304,7 @@ version = "1.0.0"
 [elements.value]
 type = "array"
 items = [ "types.coordinate", "types.label" ]
-arraytype = "string"
+itemtype = "string"
 "#,
         r#"
 [toml-schema]
@@ -1282,7 +1454,7 @@ location = "ignored.tosd"
         "[elements.owner]",
         "[elements.owner.name]",
         "[elements.site.\"google.com\"]",
-        "arraytype = \"integer\"",
+        "itemtype = \"integer\"",
     ] {
         assert!(
             schema_text.contains(expected),

--- a/toml-schema.abnf
+++ b/toml-schema.abnf
@@ -21,18 +21,17 @@ metadata-table    = toml-table-header-toml-schema-meta *toml-keyval
 
 schema-definition = schema-definition-table *definition-property *schema-definition
 
-schema-key = type / description / arraytype / itemtype / items / oneof / anyof
+schema-key = type / description / itemtype / items / oneof / anyof
            / allowedvalues / pattern / keypattern / optional / default / min / max
            / minlength / maxlength
 
-definition-property = type / description / arraytype / itemtype / items / oneof / anyof
+definition-property = type / description / itemtype / items / oneof / anyof
                     / allowedvalues / pattern / keypattern / optional / default / min / max
                     / minlength / maxlength
 
 version       = "version" keyval-sep semver-string
 type          = "type" keyval-sep type-reference
 description   = "description" keyval-sep toml-string
-arraytype     = "arraytype" keyval-sep array-built-in-type
 itemtype      = "itemtype" keyval-sep type-reference
 items         = "items" keyval-sep type-reference-array ; ordered type references for positional array validation
 oneof         = "oneof" keyval-sep type-reference-array
@@ -49,11 +48,7 @@ maxlength     = "maxlength" keyval-sep toml-integer ; strings count Unicode scal
 
 built-in-type = anytype / stringtype / integertype / floattype / booleantype
               / offsetdatetimetype / localdatetimetype / localdatetype / localtimetype
-              / arraytype-name / tabletype / collectiontype
-
-array-built-in-type = anytype / stringtype / integertype / floattype / booleantype
-                    / offsetdatetimetype / localdatetimetype / localdatetype / localtimetype
-                    / arraytype-name / tabletype
+              / array-type-name / tabletype / collectiontype
 
 type-reference       = built-in-type / toml-string
 type-reference-array = toml-array ; semantically intended to contain only type-reference values; element types are not constrained by this ABNF
@@ -69,7 +64,7 @@ offsetdatetimetype  = DQUOTE %x6f.66.66.73.65.74.2d.64.61.74.65.2d.74.69.6d.65 D
 localdatetimetype   = DQUOTE %x6c.6f.63.61.6c.2d.64.61.74.65.2d.74.69.6d.65 DQUOTE    ; "local-date-time"
 localdatetype       = DQUOTE %x6c.6f.63.61.6c.2d.64.61.74.65 DQUOTE                   ; "local-date"
 localtimetype       = DQUOTE %x6c.6f.63.61.6c.2d.74.69.6d.65 DQUOTE                   ; "local-time"
-arraytype-name      = DQUOTE %x61.72.72.61.79 DQUOTE                                  ; "array"
+array-type-name     = DQUOTE %x61.72.72.61.79 DQUOTE                                  ; "array"
 tabletype           = DQUOTE %x74.61.62.6c.65 DQUOTE                                  ; "table"
 collectiontype      = DQUOTE %x63.6f.6c.6c.65.63.74.69.6f.6e DQUOTE                   ; "collection"
 


### PR DESCRIPTION
`arraytype` and `itemtype` evolved into overlapping ways to describe homogeneous array members, leaving their relationship ambiguous. This change makes `itemtype` the single member selector for built-in and reusable schemas.

- Remove `arraytype` from the specification and ABNF, and reject it as unsupported syntax.
- Migrate examples, documentation, the visual editor, and schema extractors to emit `itemtype`.
- Align Java, Go, and Rust validation, including named references, same-kind alternatives, array ranges, and `allowedvalues` with or without an item schema.
- Keep `items` as the distinct fixed-position tuple form.

This is an intentional breaking cleanup: existing schemas that declare `arraytype` must migrate to the equivalent `itemtype` declaration.

**Validation**
- Java: 51 tests
- Go: full package suite
- Rust: 40 tests
- All reference implementations build successfully
- Checked-in `config.toml` validates through both explicit and document-declared schema lookup

Fixes: #70