### PR TITLE
Define bare collection and any reference semantics

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -237,6 +237,20 @@ Type references are strings accepted by `type`, `itemtype`, `items`, `oneof`, an
 
 Built-in type names are reserved and MUST NOT be used as `[types]` definition names. The reserved names are `any`, `string`, `integer`, `float`, `boolean`, `offset-date-time`, `local-date-time`, `local-date`, `local-time`, `array`, `table`, and `collection`.
 
+Two built-in names have context-specific restrictions:
+
+- `collection` is valid for `type` only when the same definition declares
+  `itemtype`. It MUST NOT be used as a bare reference in `itemtype`, `items`,
+  `oneof`, or `anyof`, because those locations cannot supply the collection's
+  dynamic-value rule. Parsers MUST reject such references at schema-load time.
+- `any` is valid for `type`, `itemtype`, and `items`, but it MUST NOT appear
+  directly in `oneof` or `anyof`. Parsers MUST reject a direct `any` alternative
+  at schema-load time.
+
+These restrictions apply to bare built-in references, not to named reusable
+definitions. A named definition that declares a complete collection or selects
+`type = "any"` remains a valid reference.
+
 `type`, `oneof`, and `anyof` are alternative ways to select the type of the current schema node. Every definition MUST declare exactly one of them, except that a definition with nested child definitions MAY omit all three and is then treated as `type = "table"`. Parsers MUST reject a definition that declares more than one of these properties, or that declares none of them and has no nested child definitions. `type` accepts either a built-in type name or a named reusable definition from `[types]`. Container member types are selected separately with `itemtype`: it validates each member of an `array` or each dynamically keyed value of a `collection`. `itemtype` requires the same definition to declare the built-in `type = "array"` or `type = "collection"`; it cannot be attached to another built-in or to a named type reference.
 
 ```toml
@@ -358,6 +372,10 @@ Both `minlength` and `maxlength` MUST be integers `>= 0`. When both are present,
 ### Conditions on `any`
 
 No min/max condition may be applied to type `any`. The parser must show an error if this happens.
+
+An unconstrained value may declare `type = "any"`, and arrays may use `any` in
+`itemtype` or `items`. A direct `any` entry in `oneof` or `anyof` is malformed
+because it would add an unconstrained branch to an alternative type selector.
 
 ### Block Types
 
@@ -523,6 +541,11 @@ A `collection` is also a `table` and, therefore, it may have nested, schema-rest
 
 A `collection` requires `itemtype` to define the type of its dynamic child values. Each dynamic child must be given a unique key in the TOML document. `itemtype` may reference a built-in type or a named reusable definition.
 
+The built-in `collection` cannot itself be used as `itemtype` or as an entry in
+`items`, `oneof`, or `anyof`: those bare references provide no place to declare
+the nested collection's required `itemtype`. Define a reusable collection with
+its own `itemtype` and reference that named definition instead.
+
 When collection values may have alternative types, define those alternatives in a reusable `[types]` definition with `oneof` or `anyof`, then reference that definition with `itemtype`. This keeps `oneof` and `anyof` consistently scoped to the current node rather than changing their meaning on a container.
 
 A `collection` may additionally constrain the **keys** (entry names) of its dynamic children with `keypattern`. See [Key Pattern - `keypattern`](#key-pattern---keypattern).
@@ -662,6 +685,10 @@ Use `oneof` or `anyof` when a value may validate against alternative type refere
 - `anyof`: at least one referenced type must validate.
 
 These properties can be used anywhere a schema definition can appear, including an `[elements]` field, a reusable `[types]` definition, and a type referenced through `itemtype` for array or collection items. Alternatives may reference built-in type names directly or named definitions when a branch needs constraints.
+
+The bare built-in names `any` and `collection` MUST NOT appear directly in
+`oneof` or `anyof`. Use a named reusable definition when an alternative needs a
+fully defined collection or an intentionally unconstrained named branch.
 
 `type`, `oneof`, and `anyof` all select the current node's type and are mutually exclusive. A parser MUST reject a definition containing more than one of them.
 

--- a/reference-implementations/go/schema.go
+++ b/reference-implementations/go/schema.go
@@ -302,6 +302,21 @@ func parseDefinition(name string, table map[string]any) (Definition, error) {
 	if err != nil {
 		return Definition{}, err
 	}
+	if err := rejectBareCollectionReference(name, "itemtype", itemReference); err != nil {
+		return Definition{}, err
+	}
+	if err := rejectBareCollectionReferences(name, "items", items); err != nil {
+		return Definition{}, err
+	}
+	if err := validateAlternativeReferences(name, "oneof", oneOf); err != nil {
+		return Definition{}, err
+	}
+	if err := validateAlternativeReferences(name, "anyof", anyOf); err != nil {
+		return Definition{}, err
+	}
+	if typeSelector != "" && typeName != TypeCollection && normalizeReference(typeSelector) == string(TypeCollection) {
+		return Definition{}, fmt.Errorf("%s cannot use collection as a bare type reference", name)
+	}
 	typeSelectors := 0
 	if typeSelector != "" {
 		typeSelectors++
@@ -376,6 +391,35 @@ func parseDefinition(name string, table map[string]any) (Definition, error) {
 		minLength: minLength, maxLength: maxLength, oneOf: normalizeReferences(oneOf), anyOf: normalizeReferences(anyOf),
 		children: children,
 	}, nil
+}
+
+func rejectBareCollectionReferences(name, property string, references []string) error {
+	for _, reference := range references {
+		if err := rejectBareCollectionReference(name, property, normalizeReference(reference)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func rejectBareCollectionReference(name, property, reference string) error {
+	if normalizeReference(reference) == string(TypeCollection) {
+		return fmt.Errorf("%s cannot use collection as a bare %s reference", name, property)
+	}
+	return nil
+}
+
+func validateAlternativeReferences(name, property string, references []string) error {
+	for _, reference := range references {
+		normalized := normalizeReference(reference)
+		if err := rejectBareCollectionReference(name, property, normalized); err != nil {
+			return err
+		}
+		if normalized == string(TypeAny) {
+			return fmt.Errorf("%s cannot use any directly in %s", name, property)
+		}
+	}
+	return nil
 }
 
 func validateRangeConstraints(name string, typeName SchemaType, min, max any) error {

--- a/reference-implementations/go/schema_test.go
+++ b/reference-implementations/go/schema_test.go
@@ -874,6 +874,94 @@ port = 8080
 	}
 }
 
+func TestRejectsBareCollectionAndAnyAlternativeReferences(t *testing.T) {
+	dir := t.TempDir()
+	invalidDefinitions := map[string]string{
+		"collection-without-itemtype": `
+type = "collection"
+`,
+		"prefixed-collection": `
+type = "types.collection"
+`,
+		"collection-itemtype": `
+type = "array"
+itemtype = "collection"
+`,
+		"collection-items": `
+type = "array"
+items = [ "collection" ]
+`,
+		"collection-oneof": `
+oneof = [ "collection", "string" ]
+`,
+		"collection-anyof": `
+anyof = [ "collection", "string" ]
+`,
+		"any-oneof": `
+oneof = [ "any", "string" ]
+`,
+		"any-anyof": `
+anyof = [ "any", "string" ]
+`,
+	}
+
+	for name, definition := range invalidDefinitions {
+		t.Run(name, func(t *testing.T) {
+			schemaPath := write(t, dir, name+".tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+`+definition)
+
+			if _, err := LoadSchema(schemaPath); err == nil {
+				t.Fatal("expected bare reference to be rejected")
+			}
+		})
+	}
+}
+
+func TestAllowsAnyOutsideAlternativesAndNamedCollections(t *testing.T) {
+	dir := t.TempDir()
+	schemaPath := write(t, dir, "valid-special-references.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[types.stringMap]
+type = "collection"
+itemtype = "string"
+
+[elements.direct]
+type = "any"
+
+[elements.values]
+type = "array"
+itemtype = "any"
+
+[elements.tuple]
+type = "array"
+items = [ "any" ]
+
+[elements.maps]
+type = "array"
+itemtype = "types.stringMap"
+`)
+	documentPath := write(t, dir, "valid-special-references.toml", `
+direct = { key = 1 }
+values = [ 1, "two" ]
+tuple = [ true ]
+maps = [ { one = "1", two = "2" } ]
+`)
+
+	schema, err := LoadSchema(schemaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result := schema.ValidateFile(documentPath); !result.Valid() {
+		t.Fatalf("expected valid special references, got %#v", result.Errors)
+	}
+}
+
 func TestRejectsInvalidTypeSelectorCardinality(t *testing.T) {
 	dir := t.TempDir()
 	invalidDefinitions := map[string]string{

--- a/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
@@ -123,6 +123,15 @@ final class SchemaLoader {
         List<Object> allowedValues = getArrayValues(table, "allowedvalues");
         List<String> oneOf = getStringArrayValues(table, "oneof");
         List<String> anyOf = getStringArrayValues(table, "anyof");
+        rejectBareCollectionReference(name, "itemtype", itemReference);
+        rejectBareCollectionReferences(name, "items", items);
+        validateAlternativeReferences(name, "oneof", oneOf);
+        validateAlternativeReferences(name, "anyof", anyOf);
+        if (typeSelector != null
+                && type != SchemaType.COLLECTION
+                && normalizeReference(typeSelector).equals(SchemaType.COLLECTION.schemaName())) {
+            throw new SchemaException(name + " cannot use collection as a bare type reference");
+        }
         int typeSelectors = (typeSelector == null ? 0 : 1)
                 + (oneOf.isEmpty() ? 0 : 1)
                 + (anyOf.isEmpty() ? 0 : 1);
@@ -194,6 +203,28 @@ final class SchemaLoader {
                 anyOf.stream().map(this::normalizeReference).toList(),
                 children
         );
+    }
+
+    private void rejectBareCollectionReferences(String name, String property, List<String> references) {
+        for (String reference : references) {
+            rejectBareCollectionReference(name, property, normalizeReference(reference));
+        }
+    }
+
+    private void rejectBareCollectionReference(String name, String property, String reference) {
+        if (SchemaType.COLLECTION.schemaName().equals(reference)) {
+            throw new SchemaException(name + " cannot use collection as a bare " + property + " reference");
+        }
+    }
+
+    private void validateAlternativeReferences(String name, String property, List<String> references) {
+        for (String reference : references) {
+            String normalizedReference = normalizeReference(reference);
+            rejectBareCollectionReference(name, property, normalizedReference);
+            if (SchemaType.ANY.schemaName().equals(normalizedReference)) {
+                throw new SchemaException(name + " cannot use any directly in " + property);
+            }
+        }
     }
 
     private Object getPropertyValue(TomlTable table, String key) {

--- a/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
+++ b/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
@@ -417,6 +417,85 @@ class TomlSchemaTest {
     }
 
     @Test
+    void rejectsBareCollectionAndAnyAlternativeReferences() throws IOException {
+        List<String> invalidDefinitions = List.of(
+                """
+                type = "collection"
+                """,
+                """
+                type = "types.collection"
+                """,
+                """
+                type = "array"
+                itemtype = "collection"
+                """,
+                """
+                type = "array"
+                items = [ "collection" ]
+                """,
+                """
+                oneof = [ "collection", "string" ]
+                """,
+                """
+                anyof = [ "collection", "string" ]
+                """,
+                """
+                oneof = [ "any", "string" ]
+                """,
+                """
+                anyof = [ "any", "string" ]
+                """
+        );
+
+        for (int index = 0; index < invalidDefinitions.size(); index++) {
+            Path schema = write("invalid-bare-reference-" + index + ".tosd", """
+                    [toml-schema]
+                    version = "1.0.0"
+
+                    [elements.value]
+                    %s
+                    """.formatted(invalidDefinitions.get(index)));
+
+            assertThrows(SchemaException.class, () -> TomlSchema.load(schema));
+        }
+    }
+
+    @Test
+    void allowsAnyOutsideAlternativesAndNamedCollections() throws IOException {
+        Path schema = write("valid-special-references.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [types.stringMap]
+                type = "collection"
+                itemtype = "string"
+
+                [elements.direct]
+                type = "any"
+
+                [elements.values]
+                type = "array"
+                itemtype = "any"
+
+                [elements.tuple]
+                type = "array"
+                items = [ "any" ]
+
+                [elements.maps]
+                type = "array"
+                itemtype = "types.stringMap"
+                """);
+        Path document = write("valid-special-references.toml", """
+                direct = { key = 1 }
+                values = [ 1, "two" ]
+                tuple = [ true ]
+                maps = [ { one = "1", two = "2" } ]
+                """);
+
+        assertTrue(TomlSchema.load(schema).validate(document).isValid());
+    }
+
+    @Test
     void rejectsInvalidTypeSelectorCardinality() throws IOException {
         List<String> invalidDefinitions = List.of(
                 """

--- a/reference-implementations/rust/src/schema.rs
+++ b/reference-implementations/rust/src/schema.rs
@@ -435,6 +435,18 @@ fn parse_definition(name: &str, table: &Table) -> Result<Definition, String> {
     let allowed_values = get_array_values(name, table, "allowedvalues")?;
     let one_of = get_string_array_values(name, table, "oneof")?;
     let any_of = get_string_array_values(name, table, "anyof")?;
+    reject_bare_collection_reference(name, "itemtype", item_reference.as_deref())?;
+    reject_bare_collection_references(name, "items", &items)?;
+    validate_alternative_references(name, "oneof", &one_of)?;
+    validate_alternative_references(name, "anyof", &any_of)?;
+    if type_selector.as_deref().is_some_and(|selector| {
+        type_name != Some(SchemaType::Collection)
+            && normalize_reference(selector.to_string()) == SchemaType::Collection.schema_name()
+    }) {
+        return Err(format!(
+            "{name} cannot use collection as a bare type reference"
+        ));
+    }
     let type_selectors = usize::from(type_selector.is_some())
         + usize::from(!one_of.is_empty())
         + usize::from(!any_of.is_empty());
@@ -537,6 +549,46 @@ fn parse_definition(name: &str, table: &Table) -> Result<Definition, String> {
         any_of: normalize_references(any_of),
         children,
     })
+}
+
+fn reject_bare_collection_references(
+    name: &str,
+    property: &str,
+    references: &[String],
+) -> Result<(), String> {
+    for reference in references {
+        reject_bare_collection_reference(name, property, Some(reference.as_str()))?;
+    }
+    Ok(())
+}
+
+fn reject_bare_collection_reference(
+    name: &str,
+    property: &str,
+    reference: Option<&str>,
+) -> Result<(), String> {
+    if reference.is_some_and(|reference| {
+        normalize_reference(reference.to_string()) == SchemaType::Collection.schema_name()
+    }) {
+        return Err(format!(
+            "{name} cannot use collection as a bare {property} reference"
+        ));
+    }
+    Ok(())
+}
+
+fn validate_alternative_references(
+    name: &str,
+    property: &str,
+    references: &[String],
+) -> Result<(), String> {
+    for reference in references {
+        reject_bare_collection_reference(name, property, Some(reference.as_str()))?;
+        if normalize_reference(reference.clone()) == SchemaType::Any.schema_name() {
+            return Err(format!("{name} cannot use any directly in {property}"));
+        }
+    }
+    Ok(())
 }
 
 fn validate_range_constraints(

--- a/reference-implementations/rust/tests/integration.rs
+++ b/reference-implementations/rust/tests/integration.rs
@@ -1120,6 +1120,131 @@ port = 8080
 }
 
 #[test]
+fn rejects_bare_collection_and_any_alternative_references() {
+    let directory = tempfile_dir("invalid-bare-references");
+    let invalid_definitions = [
+        (
+            "collection-without-itemtype.tosd",
+            r#"
+type = "collection"
+"#,
+        ),
+        (
+            "prefixed-collection.tosd",
+            r#"
+type = "types.collection"
+"#,
+        ),
+        (
+            "collection-itemtype.tosd",
+            r#"
+type = "array"
+itemtype = "collection"
+"#,
+        ),
+        (
+            "collection-items.tosd",
+            r#"
+type = "array"
+items = [ "collection" ]
+"#,
+        ),
+        (
+            "collection-oneof.tosd",
+            r#"
+oneof = [ "collection", "string" ]
+"#,
+        ),
+        (
+            "collection-anyof.tosd",
+            r#"
+anyof = [ "collection", "string" ]
+"#,
+        ),
+        (
+            "any-oneof.tosd",
+            r#"
+oneof = [ "any", "string" ]
+"#,
+        ),
+        (
+            "any-anyof.tosd",
+            r#"
+anyof = [ "any", "string" ]
+"#,
+        ),
+    ];
+
+    for (file_name, definition) in invalid_definitions {
+        let schema_path = write_file(
+            &directory,
+            file_name,
+            &format!(
+                r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+{definition}
+"#
+            ),
+        );
+
+        Schema::load(&schema_path).expect_err("expected bare reference rejection");
+    }
+}
+
+#[test]
+fn allows_any_outside_alternatives_and_named_collections() {
+    let directory = tempfile_dir("valid-special-references");
+    let schema_path = write_file(
+        &directory,
+        "schema.tosd",
+        r#"
+[toml-schema]
+version = "1.0.0"
+
+[types.stringMap]
+type = "collection"
+itemtype = "string"
+
+[elements.direct]
+type = "any"
+
+[elements.values]
+type = "array"
+itemtype = "any"
+
+[elements.tuple]
+type = "array"
+items = [ "any" ]
+
+[elements.maps]
+type = "array"
+itemtype = "types.stringMap"
+"#,
+    );
+    let document_path = write_file(
+        &directory,
+        "document.toml",
+        r#"
+direct = { key = 1 }
+values = [ 1, "two" ]
+tuple = [ true ]
+maps = [ { one = "1", two = "2" } ]
+"#,
+    );
+
+    let schema = Schema::load(&schema_path).expect("expected valid special references");
+    let result = schema.validate_file(&document_path);
+    assert!(
+        result.valid(),
+        "expected valid special references, got {:?}",
+        result.errors
+    );
+}
+
+#[test]
 fn rejects_invalid_type_selector_cardinality() {
     let directory = tempfile_dir("invalid-type-selectors");
     let invalid_definitions = [


### PR DESCRIPTION
Bare `collection` references cannot describe their required dynamic value type, while direct `any` alternatives make `oneof` and `anyof` ineffective or ambiguous. This change defines deterministic schema-load behavior for both cases.

## Summary

- require inline collections to declare `itemtype` and reject bare `collection` in member and alternative references
- allow `any` for `type`, `itemtype`, and tuple `items`, but reject it directly in `oneof` and `anyof`
- enforce the rules consistently in the Java, Go, and Rust loaders
- add aligned positive and negative conformance coverage across all reference implementations

## Testing

- `mvn -f reference-implementations/java/pom.xml test`
- `go test ./...` from `reference-implementations/go`
- `cargo test --manifest-path reference-implementations/rust/Cargo.toml`

Fixes: #72