### PR TITLE
Complete specification ambiguity conformance

### DIFF
--- a/REFERENCE_IMPLEMENTATIONS.md
+++ b/REFERENCE_IMPLEMENTATIONS.md
@@ -45,7 +45,7 @@ Validate using `[toml-schema].location` from the TOML document:
 java -jar reference-implementations/java/target/toml-schema-1.0.0-rc.2.jar validate config.toml
 ```
 
-For document-driven lookup, the Java CLI resolves a relative `[toml-schema].location` from the TOML document's directory. The document's `[toml-schema].version` is optional; when present, the CLI rejects a major-version mismatch with the resolved schema and warns about other unequal versions.
+For document-driven lookup, each reference CLI resolves a relative `[toml-schema].location` from the TOML document's directory. The document's `[toml-schema].version` is optional; when present, the CLI rejects a major-version mismatch with the resolved schema and warns about other unequal versions. Reference CLIs currently support local files and reject unsupported URI schemes explicitly.
 
 Validate the example schema against the TOML Schema self-schema:
 
@@ -207,6 +207,7 @@ Every reference implementation should:
 1. Require a schema document's `[toml-schema].version` to be a SemVer string compatible with the implementation's supported TOML Schema version.
 1. Validate the checked-in `config.toml` document against `config.tosd`.
 1. Support schema lookup through `[toml-schema].location`.
+1. Enforce the document schema-reference URI and optional language-version compatibility rules from `SPEC.md`.
 1. Validate `config.tosd` against `toml-schema.tosd`.
 1. Validate `toml-schema.tosd` against itself.
 1. Keep supported schema vocabulary aligned with `toml-schema.abnf` and `toml-schema.tosd`.

--- a/SPEC.md
+++ b/SPEC.md
@@ -35,6 +35,7 @@ The schema format follows the TOML specification, meaning that a TOML Schema is 
   - [Alternative Types - `oneof` and `anyof`](#alternative-types---oneof-and-anyof)
   - [Description - `description`](#description---description)
   - [Optionality - `optional`](#optionality---optional)
+  - [Default Value Hint - `default`](#default-value-hint---default)
   - [Pattern - `pattern`](#pattern---pattern)
   - [Key Pattern - `keypattern`](#key-pattern---keypattern)
 - [Parsers](#parsers)
@@ -267,6 +268,7 @@ allowedvalues = [ <array-with-enumeration-of-allowed-values> ]
 pattern = "<string-regex-for-string-validation>"
 keypattern = "<string-regex-for-collection-key-validation>"
 optional = true|false
+default = <toml-value>
 min = <integer | float | offset-date-time | local-date-time | local-date | local-time>
 max = <integer | float | offset-date-time | local-date-time | local-date | local-time>
 minlength = <integer>
@@ -758,6 +760,14 @@ Properties may be defined as optional in the schema. By default, optional equals
 
 Parsers must only skip a structure validation if the structure is optional in the TOML Schema and does not exist in the TOML document. For any other condition, the parser must validate the input against the schema.
 
+### Default Value Hint - `default`
+
+`default` is an optional advisory value for documentation, editors, and other authoring tools. It MAY contain any TOML value.
+
+`default` does not make a definition optional and does not affect validation. Validators MUST NOT insert the default when a value is absent, replace an invalid value, or otherwise modify the parsed TOML document. An absent required value remains invalid, and a present value is validated against the definition normally.
+
+Tools MAY offer the value to users when creating or editing a document, but applying it requires an explicit authoring action outside validation.
+
 ### Pattern - `pattern`
 
 This property is only used for validating `string` input. Parsers must validate the input with the provided regular expression.
@@ -833,6 +843,8 @@ version = "1.0.0" # optional
 An absolute `location` MUST be used unchanged. A relative `location` MUST be resolved against the referencing TOML document's location, not against the validator's current working directory or the resolved schema's location. For a TOML document stored in a local file, this means resolving a relative location from the document's parent directory.
 
 A validator that receives a TOML document without a base location, for example through standard input, cannot resolve a relative `location`. It MUST either obtain an explicit base URI from the caller or report that schema discovery failed. An absolute `location` does not require a document base. Implementations MAY limit the URI schemes they can retrieve, but MUST report an unsupported scheme rather than reinterpret its value as a relative local path.
+
+An implementation that supports the `file` scheme MUST require a hierarchical file URI that can be converted to a local path, such as `file:///schemas/config.tosd`. It MUST reject an opaque URI such as `file:schema.tosd` rather than reinterpret it as a path relative to the TOML document.
 
 `version` is OPTIONAL. When present, it denotes the expected TOML Schema **language version** in the resolved schema document's `[toml-schema].version`; it is not an application version or an author-defined revision of that schema. Its value MUST be a string containing a full SemVer version in `MAJOR.MINOR.PATCH` form, with the same syntax defined by [Schema Versioning](#schema-versioning).
 

--- a/examples/wrangler.tosd
+++ b/examples/wrangler.tosd
@@ -154,7 +154,6 @@ type = "table"
     optional = true
 
 [types.moduleRule]
-type = "table"
 
     [types.moduleRule.type]
     type = "string"
@@ -292,44 +291,58 @@ type = "table"
     type = "string"
 
 [types.idBinding]
-type = "types.simpleBinding"
+
+    [types.idBinding.binding]
+    type = "string"
 
     [types.idBinding.id]
     type = "string"
 
 [types.nameBinding]
-type = "types.simpleBinding"
+
+    [types.nameBinding.binding]
+    type = "string"
 
     [types.nameBinding.name]
     type = "string"
 
 [types.namespaceBinding]
-type = "types.simpleBinding"
+
+    [types.namespaceBinding.binding]
+    type = "string"
 
     [types.namespaceBinding.namespace]
     type = "string"
 
 [types.aiSearchInstance]
-type = "types.simpleBinding"
+
+    [types.aiSearchInstance.binding]
+    type = "string"
 
     [types.aiSearchInstance.instance_name]
     type = "string"
 
 [types.indexBinding]
-type = "types.simpleBinding"
+
+    [types.indexBinding.binding]
+    type = "string"
 
     [types.indexBinding.index_name]
     type = "string"
 
 [types.datasetBinding]
-type = "types.simpleBinding"
+
+    [types.datasetBinding.binding]
+    type = "string"
 
     [types.datasetBinding.dataset]
     type = "string"
     optional = true
 
 [types.serviceBinding]
-type = "types.simpleBinding"
+
+    [types.serviceBinding.binding]
+    type = "string"
 
     [types.serviceBinding.service]
     type = "string"
@@ -339,13 +352,17 @@ type = "types.simpleBinding"
     optional = true
 
 [types.certificateBinding]
-type = "types.simpleBinding"
+
+    [types.certificateBinding.binding]
+    type = "string"
 
     [types.certificateBinding.certificate_id]
     type = "string"
 
 [types.workflowBinding]
-type = "types.simpleBinding"
+
+    [types.workflowBinding.binding]
+    type = "string"
 
     [types.workflowBinding.class_name]
     type = "string"
@@ -369,7 +386,12 @@ type = "table"
     optional = true
 
 [types.dispatchNamespace]
-type = "types.namespaceBinding"
+
+    [types.dispatchNamespace.binding]
+    type = "string"
+
+    [types.dispatchNamespace.namespace]
+    type = "string"
 
     [types.dispatchNamespace.outbound]
     type = "types.dispatchOutbound"
@@ -460,7 +482,9 @@ type = "table"
     optional = true
 
 [types.queueProducer]
-type = "types.simpleBinding"
+
+    [types.queueProducer.binding]
+    type = "string"
 
     [types.queueProducer.delivery_delay]
     type = "types.numberValue"
@@ -521,7 +545,9 @@ type = "table"
     optional = true
 
 [types.secretsStoreSecret]
-type = "types.simpleBinding"
+
+    [types.secretsStoreSecret.binding]
+    type = "string"
 
     [types.secretsStoreSecret.store_id]
     type = "string"

--- a/reference-implementations/go/README.md
+++ b/reference-implementations/go/README.md
@@ -72,6 +72,11 @@ func main() {
 }
 ```
 
+For schema discovery through a document's `[toml-schema].location`, use
+`ResolveSchemaFromDocument`. Its `SchemaResolution` exposes the parsed document,
+resolved schema language version, and non-major version mismatch warnings.
+`SchemaFromDocument` remains available when callers do not need warning details.
+
 ## Conformance
 
 The test suite includes `abnf_conformance_test.go`, which reads [`toml-schema.abnf`](../../toml-schema.abnf) and asserts that the implementation's supported schema keys and built-in type names match the grammar.

--- a/reference-implementations/go/cmd/toml-schema/main.go
+++ b/reference-implementations/go/cmd/toml-schema/main.go
@@ -42,12 +42,15 @@ func run(args []string, out, errOut io.Writer) int {
 }
 
 func validateWithEmbeddedSchema(documentPath string, out, errOut io.Writer) int {
-	schema, document, err := tomlschema.SchemaFromDocument(documentPath)
+	resolution, err := tomlschema.ResolveSchemaFromDocument(documentPath)
 	if err != nil {
 		fmt.Fprintln(errOut, err)
 		return 2
 	}
-	return report(schema.Validate(document), documentPath, out, errOut)
+	for _, warning := range resolution.Warnings {
+		fmt.Fprintln(errOut, warning)
+	}
+	return report(resolution.Schema.Validate(resolution.Document), documentPath, out, errOut)
 }
 
 func validate(schemaPath, documentPath string, out, errOut io.Writer) int {

--- a/reference-implementations/go/cmd/toml-schema/main_test.go
+++ b/reference-implementations/go/cmd/toml-schema/main_test.go
@@ -37,6 +37,140 @@ location = "schema.tosd"
 	}
 }
 
+func TestCLIAllowsDocumentSchemaVersionToBeOmitted(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "schema.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[elements.title]
+type = "string"
+`)
+	documentPath := writeFile(t, dir, "document.toml", `
+title = "Example"
+
+[toml-schema]
+location = "schema.tosd"
+`)
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+
+	exitCode := run([]string{"validate", documentPath}, &out, &errOut)
+
+	if exitCode != 0 || errOut.Len() != 0 {
+		t.Fatalf("expected successful validation without a warning, got %d: %s", exitCode, errOut.String())
+	}
+}
+
+func TestCLIWarnsOnNonMajorDocumentSchemaVersionMismatch(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "schema.tosd", `
+[toml-schema]
+version = "1.0.1"
+
+[elements.title]
+type = "string"
+`)
+	documentPath := writeFile(t, dir, "document.toml", `
+title = "Example"
+
+[toml-schema]
+version = "1.0.0"
+location = "schema.tosd"
+`)
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+
+	exitCode := run([]string{"validate", documentPath}, &out, &errOut)
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d: %s", exitCode, errOut.String())
+	}
+	const expected = "Warning: document expects TOML Schema version 1.0.0, but resolved schema uses 1.0.1\n"
+	if errOut.String() != expected {
+		t.Fatalf("expected warning %q, got %q", expected, errOut.String())
+	}
+}
+
+func TestCLIRejectsMajorDocumentSchemaVersionMismatch(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "schema.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[elements.title]
+type = "string"
+`)
+	documentPath := writeFile(t, dir, "document.toml", `
+title = "Example"
+
+[toml-schema]
+version = "2.0.0"
+location = "schema.tosd"
+`)
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+
+	exitCode := run([]string{"validate", documentPath}, &out, &errOut)
+
+	if exitCode != 2 {
+		t.Fatalf("expected exit code 2, got %d", exitCode)
+	}
+	if !strings.Contains(errOut.String(),
+		"Document expects TOML Schema major version 2.0.0, but resolved schema uses 1.0.0") {
+		t.Fatalf("unexpected error: %q", errOut.String())
+	}
+}
+
+func TestCLIRejectsMalformedDocumentSchemaVersions(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "schema.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[elements.title]
+type = "string"
+`)
+	for name, version := range map[string]string{
+		"shorthand":  `"1.0"`,
+		"non-string": "1",
+	} {
+		t.Run(name, func(t *testing.T) {
+			documentPath := writeFile(t, dir, name+".toml", `
+title = "Example"
+
+[toml-schema]
+version = `+version+`
+location = "schema.tosd"
+`)
+			var out bytes.Buffer
+			var errOut bytes.Buffer
+
+			exitCode := run([]string{"validate", documentPath}, &out, &errOut)
+
+			if exitCode != 2 || !strings.Contains(errOut.String(), "Document [toml-schema].version must") {
+				t.Fatalf("expected malformed version error, got %d: %q", exitCode, errOut.String())
+			}
+		})
+	}
+}
+
+func TestCLIRejectsUnsupportedSchemaLocationScheme(t *testing.T) {
+	dir := t.TempDir()
+	documentPath := writeFile(t, dir, "document.toml", `
+[toml-schema]
+location = "https://example.com/schema.tosd"
+`)
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+
+	exitCode := run([]string{"validate", documentPath}, &out, &errOut)
+
+	if exitCode != 2 || !strings.Contains(errOut.String(), "Unsupported schema location URI scheme: https") {
+		t.Fatalf("expected unsupported scheme error, got %d: %q", exitCode, errOut.String())
+	}
+}
+
 func TestCLIExtractsSchemaFromTomlDocument(t *testing.T) {
 	dir := t.TempDir()
 	documentPath := writeFile(t, dir, "extract-source.toml", `

--- a/reference-implementations/go/schema.go
+++ b/reference-implementations/go/schema.go
@@ -3,9 +3,11 @@ package tomlschema
 import (
 	"fmt"
 	"math"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -76,6 +78,7 @@ func parseSchemaType(value string) (SchemaType, bool) {
 
 type Schema struct {
 	source   string
+	version  string
 	types    map[string]Definition
 	elements map[string]Definition
 }
@@ -134,7 +137,8 @@ func LoadSchema(path string) (*Schema, error) {
 	if !ok {
 		return nil, fmt.Errorf("[toml-schema] must contain version")
 	}
-	if err := validateSchemaVersion(version); err != nil {
+	parsedVersion, err := validateSchemaVersion(version)
+	if err != nil {
 		return nil, err
 	}
 	for key := range metadata {
@@ -150,7 +154,7 @@ func LoadSchema(path string) (*Schema, error) {
 	if err != nil {
 		return nil, err
 	}
-	schema := &Schema{source: path, types: types, elements: elements}
+	schema := &Schema{source: path, version: parsedVersion.value, types: types, elements: elements}
 	if err := schema.validateArrayRanges(); err != nil {
 		return nil, err
 	}
@@ -161,22 +165,40 @@ func LoadDocument(path string) (map[string]any, error) {
 	return parseTOMLFile(path)
 }
 
-func validateSchemaVersion(value any) error {
+type schemaVersion struct {
+	value string
+	major string
+	minor string
+}
+
+func parseVersion(value any, property string) (schemaVersion, error) {
 	version, ok := value.(string)
 	if !ok {
-		return fmt.Errorf("[toml-schema].version must be a SemVer string")
+		return schemaVersion{}, fmt.Errorf("%s must be a SemVer string", property)
 	}
 	matches := semverPattern.FindStringSubmatch(version)
 	if matches == nil {
-		return fmt.Errorf("[toml-schema].version must use SemVer MAJOR.MINOR.PATCH syntax")
+		return schemaVersion{}, fmt.Errorf("%s must use SemVer MAJOR.MINOR.PATCH syntax", property)
 	}
-	if matches[1] != "1" {
-		return fmt.Errorf("unsupported TOML Schema major version: %s", version)
+	return schemaVersion{value: version, major: matches[1], minor: matches[2]}, nil
+}
+
+func validateSchemaVersion(value any) (schemaVersion, error) {
+	version, err := parseVersion(value, "[toml-schema].version")
+	if err != nil {
+		return schemaVersion{}, err
 	}
-	if matches[2] != "0" {
-		return fmt.Errorf("unsupported TOML Schema minor version: %s", version)
+	if version.major != "1" {
+		return schemaVersion{}, fmt.Errorf("unsupported TOML Schema major version: %s", version.value)
 	}
-	return nil
+	if version.minor != "0" {
+		return schemaVersion{}, fmt.Errorf("unsupported TOML Schema minor version: %s", version.value)
+	}
+	return version, nil
+}
+
+func (s *Schema) Version() string {
+	return s.version
 }
 
 func (s *Schema) ValidateFile(path string) ValidationResult {
@@ -926,25 +948,135 @@ func (v *validator) add(path, message string) {
 	v.errors = append(v.errors, ValidationError{Path: path, Message: message})
 }
 
-func SchemaFromDocument(documentPath string) (*Schema, map[string]any, error) {
+type SchemaResolution struct {
+	Schema          *Schema
+	Document        map[string]any
+	DocumentVersion string
+	SchemaVersion   string
+	Warnings        []string
+}
+
+func ResolveSchemaFromDocument(documentPath string) (*SchemaResolution, error) {
 	document, err := parseTOMLFile(documentPath)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	metadata, ok := asMap(document["toml-schema"])
 	if !ok {
-		return nil, nil, fmt.Errorf("document does not contain [toml-schema].location")
+		return nil, fmt.Errorf("Document must contain a [toml-schema] table")
 	}
 	location, ok := metadata["location"].(string)
 	if !ok || strings.TrimSpace(location) == "" {
-		return nil, nil, fmt.Errorf("document does not contain [toml-schema].location")
+		return nil, fmt.Errorf("Document [toml-schema].location must be a non-empty string")
 	}
-	schemaPath := filepath.Clean(filepath.Join(filepath.Dir(documentPath), location))
+	schemaPath, err := resolveSchemaPath(documentPath, location)
+	if err != nil {
+		return nil, err
+	}
 	schema, err := LoadSchema(schemaPath)
+	if err != nil {
+		return nil, err
+	}
+	resolution := &SchemaResolution{
+		Schema:        schema,
+		Document:      document,
+		SchemaVersion: schema.Version(),
+	}
+	if value, present := metadata["version"]; present {
+		expected, err := parseVersion(value, "Document [toml-schema].version")
+		if err != nil {
+			return nil, err
+		}
+		resolution.DocumentVersion = expected.value
+		actual, err := parseVersion(schema.Version(), "[toml-schema].version")
+		if err != nil {
+			return nil, err
+		}
+		if expected.major != actual.major {
+			return nil, fmt.Errorf(
+				"Document expects TOML Schema major version %s, but resolved schema uses %s",
+				expected.value, actual.value)
+		}
+		if expected.value != actual.value {
+			resolution.Warnings = append(resolution.Warnings, fmt.Sprintf(
+				"Warning: document expects TOML Schema version %s, but resolved schema uses %s",
+				expected.value, actual.value))
+		}
+	}
+	return resolution, nil
+}
+
+func SchemaFromDocument(documentPath string) (*Schema, map[string]any, error) {
+	resolution, err := ResolveSchemaFromDocument(documentPath)
 	if err != nil {
 		return nil, nil, err
 	}
-	return schema, document, nil
+	return resolution.Schema, resolution.Document, nil
+}
+
+func resolveSchemaPath(documentPath, location string) (string, error) {
+	if filepath.IsAbs(location) {
+		return filepath.Clean(location), nil
+	}
+	if hasInvalidURIReferenceCharacter(location) {
+		return "", fmt.Errorf("Invalid [toml-schema].location URI: %s", location)
+	}
+	reference, err := url.Parse(location)
+	if err != nil {
+		return "", fmt.Errorf("Invalid [toml-schema].location URI: %s: %w", location, err)
+	}
+	documentAbsolute, err := filepath.Abs(documentPath)
+	if err != nil {
+		return "", fmt.Errorf("unable to resolve document path %s: %w", documentPath, err)
+	}
+	documentURI := &url.URL{Scheme: "file", Path: filepath.ToSlash(documentAbsolute)}
+	resolved := documentURI.ResolveReference(reference)
+	if !strings.EqualFold(resolved.Scheme, "file") {
+		return "", fmt.Errorf("Unsupported schema location URI scheme: %s", resolved.Scheme)
+	}
+	path, err := localPathFromFileURI(resolved)
+	if err != nil {
+		return "", fmt.Errorf("Invalid file schema location: %s: %w", location, err)
+	}
+	return filepath.Clean(path), nil
+}
+
+func hasInvalidURIReferenceCharacter(reference string) bool {
+	for _, character := range reference {
+		if character <= ' ' || character == 0x7f {
+			return true
+		}
+		switch character {
+		case '\\', '"', '<', '>', '^', '`', '{', '|', '}':
+			return true
+		}
+	}
+	return false
+}
+
+func localPathFromFileURI(uri *url.URL) (string, error) {
+	if uri.Opaque != "" || uri.User != nil || uri.RawQuery != "" || uri.ForceQuery || uri.Fragment != "" {
+		return "", fmt.Errorf("file URI contains unsupported components")
+	}
+	if uri.Host != "" && !strings.EqualFold(uri.Host, "localhost") {
+		return "", fmt.Errorf("file URI has a non-local host")
+	}
+	escapedPath := strings.ToLower(uri.EscapedPath())
+	if strings.Contains(escapedPath, "%2f") || strings.Contains(escapedPath, "%5c") {
+		return "", fmt.Errorf("file URI contains an encoded path separator")
+	}
+	path := uri.Path
+	if path == "" || strings.ContainsRune(path, 0) {
+		return "", fmt.Errorf("file URI does not contain a safe path")
+	}
+	if runtime.GOOS == "windows" && len(path) >= 3 && path[0] == '/' && path[2] == ':' {
+		path = path[1:]
+	}
+	path = filepath.FromSlash(path)
+	if !filepath.IsAbs(path) {
+		return "", fmt.Errorf("file URI path is not absolute")
+	}
+	return path, nil
 }
 
 func propertyValue(table map[string]any, key string) any {

--- a/reference-implementations/go/schema_test.go
+++ b/reference-implementations/go/schema_test.go
@@ -2,6 +2,7 @@ package tomlschema
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -21,10 +22,17 @@ func TestValidatesCheckedInExample(t *testing.T) {
 	}
 }
 
-func TestLoadsExamplesMigratedFromReferenceSpecialization(t *testing.T) {
-	for _, name := range []string{"hugo.tosd", "netlify.tosd"} {
-		t.Run(name, func(t *testing.T) {
-			if _, err := LoadSchema(filepath.Join(fixture("examples"), name)); err != nil {
+func TestLoadsAllCheckedInExamples(t *testing.T) {
+	examples, err := filepath.Glob(filepath.Join(fixture("examples"), "*.tosd"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(examples) == 0 {
+		t.Fatal("expected checked-in schema examples")
+	}
+	for _, example := range examples {
+		t.Run(filepath.Base(example), func(t *testing.T) {
+			if _, err := LoadSchema(example); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -89,6 +97,33 @@ extra = true
 	}
 	if result := schemaSchema.ValidateFile(schemaPath); !result.Valid() {
 		t.Fatalf("expected self-schema to accept empty [elements], got %#v", result.Errors)
+	}
+}
+
+func TestValidatesReservedTomlSchemaElementWhenDefined(t *testing.T) {
+	dir := t.TempDir()
+	schemaPath := write(t, dir, "metadata-schema.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[elements.toml-schema]
+type = "table"
+
+[elements.toml-schema.location]
+type = "string"
+`)
+	schema, err := LoadSchema(schemaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	valid := map[string]any{"toml-schema": map[string]any{"location": "schema.tosd"}}
+	if result := schema.Validate(valid); !result.Valid() {
+		t.Fatalf("expected defined reserved metadata to validate, got %#v", result.Errors)
+	}
+	invalid := map[string]any{"toml-schema": map[string]any{"location": int64(1)}}
+	result := schema.Validate(invalid)
+	if result.Valid() || !hasPath(result, "$.toml-schema.location") {
+		t.Fatalf("expected defined reserved metadata to be validated, got %#v", result.Errors)
 	}
 }
 
@@ -803,6 +838,33 @@ optional = true
 	}
 }
 
+func TestDefaultIsAdvisoryAndDoesNotAffectValidation(t *testing.T) {
+	dir := t.TempDir()
+	schemaPath := write(t, dir, "advisory-default.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[elements.port]
+type = "integer"
+default = 8080
+min = 1
+`)
+	schema, err := LoadSchema(schemaPath)
+	if err != nil {
+		t.Fatalf("expected definition with default to load: %v", err)
+	}
+
+	if result := schema.Validate(map[string]any{}); result.Valid() || !hasPath(result, "$.port") {
+		t.Fatalf("expected omitted required field to remain invalid, got %#v", result.Errors)
+	}
+	if result := schema.Validate(map[string]any{"port": int64(0)}); result.Valid() || !hasPath(result, "$.port") {
+		t.Fatalf("expected present value to be validated rather than replaced by default, got %#v", result.Errors)
+	}
+	if result := schema.Validate(map[string]any{"port": int64(42)}); !result.Valid() {
+		t.Fatalf("expected valid present value to remain unchanged, got %#v", result.Errors)
+	}
+}
+
 func TestRejectsConstraintsAndChildrenOnNamedTypeReference(t *testing.T) {
 	invalidSiblings := []string{
 		`itemtype = "string"`,
@@ -1237,18 +1299,127 @@ type = "string"
 title = "Example"
 
 [toml-schema]
-version = "1.0.0"
 location = "schema.tosd"
 `)
 
-	schema, document, err := SchemaFromDocument(documentPath)
+	resolution, err := ResolveSchemaFromDocument(documentPath)
 
 	if err != nil {
 		t.Fatal(err)
 	}
-	result := schema.Validate(document)
+	if resolution.DocumentVersion != "" || resolution.SchemaVersion != "1.0.0" ||
+		resolution.Schema.Version() != "1.0.0" || len(resolution.Warnings) != 0 {
+		t.Fatalf("unexpected resolution metadata: %#v", resolution)
+	}
+	result := resolution.Schema.Validate(resolution.Document)
 	if !result.Valid() {
 		t.Fatalf("expected valid document, got %#v", result.Errors)
+	}
+	if _, _, err := SchemaFromDocument(documentPath); err != nil {
+		t.Fatalf("expected compatibility resolver to accept omitted version: %v", err)
+	}
+}
+
+func TestResolvesAbsolutePathAndFileURILocations(t *testing.T) {
+	dir := t.TempDir()
+	schemaPath := write(t, dir, "schema.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[elements.title]
+type = "string"
+`)
+	fileURI := (&url.URL{Scheme: "file", Path: filepath.ToSlash(schemaPath)}).String()
+	for name, location := range map[string]string{
+		"absolute-path": schemaPath,
+		"file-uri":      fileURI,
+	} {
+		t.Run(name, func(t *testing.T) {
+			documentPath := write(t, dir, name+".toml", fmt.Sprintf(`
+title = "Example"
+
+[toml-schema]
+location = %q
+`, location))
+			if _, _, err := SchemaFromDocument(documentPath); err != nil {
+				t.Fatalf("expected %s to resolve: %v", location, err)
+			}
+		})
+	}
+}
+
+func TestEnforcesDocumentSchemaVersionDuringLibraryDiscovery(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "schema.tosd", `
+[toml-schema]
+version = "1.0.1"
+
+[elements.title]
+type = "string"
+`)
+	document := func(name, version string) string {
+		return write(t, dir, name+".toml", fmt.Sprintf(`
+title = "Example"
+
+[toml-schema]
+version = %s
+location = "schema.tosd"
+`, version))
+	}
+
+	warningResolution, err := ResolveSchemaFromDocument(document("warning", `"1.0.0"`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	const warning = "Warning: document expects TOML Schema version 1.0.0, but resolved schema uses 1.0.1"
+	if warningResolution.DocumentVersion != "1.0.0" ||
+		len(warningResolution.Warnings) != 1 || warningResolution.Warnings[0] != warning {
+		t.Fatalf("unexpected warning resolution: %#v", warningResolution)
+	}
+	if _, _, err := SchemaFromDocument(document("warning-compatibility", `"1.0.0"`)); err != nil {
+		t.Fatalf("expected compatibility resolver to continue after a non-major mismatch: %v", err)
+	}
+
+	for _, test := range []struct {
+		name     string
+		version  string
+		expected string
+	}{
+		{"major-mismatch", `"2.0.0"`, "Document expects TOML Schema major version 2.0.0, but resolved schema uses 1.0.1"},
+		{"shorthand", `"1.0"`, "Document [toml-schema].version must use SemVer MAJOR.MINOR.PATCH syntax"},
+		{"non-string", "1", "Document [toml-schema].version must be a SemVer string"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			documentPath := document(test.name, test.version)
+			if _, _, err := SchemaFromDocument(documentPath); err == nil || !strings.Contains(err.Error(), test.expected) {
+				t.Fatalf("expected %q, got %v", test.expected, err)
+			}
+		})
+	}
+}
+
+func TestRejectsInvalidSchemaLocationURIsDuringLibraryDiscovery(t *testing.T) {
+	dir := t.TempDir()
+	for _, test := range []struct {
+		name     string
+		location string
+		expected string
+	}{
+		{"unsupported-scheme", "https://example.com/schema.tosd", "Unsupported schema location URI scheme: https"},
+		{"malformed-reference", "schema%zz.tosd", "Invalid [toml-schema].location URI"},
+		{"opaque-file-uri", "file:schema.tosd", "Invalid file schema location"},
+		{"remote-file-host", "file://example.com/schema.tosd", "Invalid file schema location"},
+		{"file-uri-query", "file:///schema.tosd?version=1", "Invalid file schema location"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			documentPath := write(t, dir, test.name+".toml", fmt.Sprintf(`
+[toml-schema]
+location = %q
+`, test.location))
+			if _, _, err := SchemaFromDocument(documentPath); err == nil || !strings.Contains(err.Error(), test.expected) {
+				t.Fatalf("expected %q, got %v", test.expected, err)
+			}
+		})
 	}
 }
 

--- a/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
+++ b/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
@@ -29,10 +29,35 @@ class TomlSchemaTest {
     }
 
     @Test
-    void loadsExamplesMigratedFromReferenceSpecialization() {
-        for (String schema : List.of("examples/hugo.tosd", "examples/netlify.tosd")) {
+    void loadsCheckedInExamples() {
+        for (String schema : List.of(
+                "examples/gitlab-runner.tosd",
+                "examples/hugo.tosd",
+                "examples/netlify.tosd",
+                "examples/pyproject.tosd",
+                "examples/wrangler.tosd")) {
             assertDoesNotThrow(() -> TomlSchema.load(fixture(schema)), schema);
         }
+    }
+
+    @Test
+    void treatsDefaultAsAnAdvisoryHint() throws IOException {
+        Path schemaPath = write("default-hint.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.port]
+                type = "integer"
+                default = 8080
+                """);
+        Path missing = write("missing-default.toml", "");
+        Path invalid = write("invalid-default.toml", "port = \"8080\"");
+        Path valid = write("valid-default.toml", "port = 8081");
+        TomlSchema schema = TomlSchema.load(schemaPath);
+
+        assertFalse(schema.validate(missing).isValid());
+        assertFalse(schema.validate(invalid).isValid());
+        assertTrue(schema.validate(valid).isValid());
     }
 
     @Test
@@ -1486,6 +1511,26 @@ class TomlSchemaTest {
         assertEquals(2, exitCode);
         assertTrue(err.toString(StandardCharsets.UTF_8).contains(
                 "Unsupported schema location URI scheme: https"));
+    }
+
+    @Test
+    void cliRejectsOpaqueFileSchemaLocationUri() throws IOException {
+        Path document = write("document.toml", """
+                title = "Example"
+
+                [toml-schema]
+                location = "file:schema.tosd"
+                """);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+        int exitCode = TomlSchemaCli.run(
+                new String[]{"validate", document.toString()},
+                new PrintStream(out, true, StandardCharsets.UTF_8),
+                new PrintStream(err, true, StandardCharsets.UTF_8));
+
+        assertEquals(2, exitCode);
+        assertTrue(err.toString(StandardCharsets.UTF_8).contains("Invalid file schema location"));
     }
 
     @Test

--- a/reference-implementations/rust/Cargo.lock
+++ b/reference-implementations/rust/Cargo.lock
@@ -12,16 +12,140 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "icu_collections"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
+
+[[package]]
+name = "icu_properties"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
+
+[[package]]
+name = "icu_provider"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -34,10 +158,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "litemap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -87,6 +232,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,7 +257,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -116,6 +270,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +290,38 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -147,6 +345,7 @@ version = "1.0.0-rc.2"
 dependencies = [
  "regex",
  "toml",
+ "url",
 ]
 
 [[package]]
@@ -180,7 +379,108 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+
+[[package]]
+name = "writeable"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]

--- a/reference-implementations/rust/Cargo.toml
+++ b/reference-implementations/rust/Cargo.toml
@@ -19,3 +19,4 @@ path = "src/main.rs"
 [dependencies]
 toml = "1"
 regex = "1"
+url = "2"

--- a/reference-implementations/rust/README.md
+++ b/reference-implementations/rust/README.md
@@ -64,6 +64,11 @@ let result = schema.validate_file("config.toml");
 assert!(result.valid());
 ```
 
+For schema discovery through a document's `[toml-schema].location`, use
+`resolve_schema_from_document`. Its `DocumentSchemaResolution` exposes the parsed
+document, resolved schema, and non-major version mismatch warnings.
+`schema_from_document` remains available when callers do not need warning details.
+
 ## Conformance
 
 The test suite includes an ABNF conformance test (`tests/abnf_conformance.rs`) that reads [`toml-schema.abnf`](../../toml-schema.abnf) and asserts that the implementation's supported schema keys and built-in type names match the grammar.

--- a/reference-implementations/rust/src/cli.rs
+++ b/reference-implementations/rust/src/cli.rs
@@ -5,7 +5,7 @@ use std::io::Write;
 use std::path::Path;
 
 use crate::extract::generate_schema;
-use crate::schema::{schema_from_document, Schema, ValidationResult};
+use crate::schema::{resolve_schema_from_document, Schema, ValidationResult};
 
 /// Executes a single CLI invocation. Returns the desired process exit code
 /// (`0` on success, `1` for validation failures, `2` for usage/IO errors).
@@ -43,8 +43,18 @@ fn validate_with_embedded_schema(
     out: &mut dyn Write,
     err: &mut dyn Write,
 ) -> u8 {
-    match schema_from_document(document_path) {
-        Ok((schema, document)) => report(schema.validate(&document), document_path, out, err),
+    match resolve_schema_from_document(document_path) {
+        Ok(resolution) => {
+            for warning in resolution.warnings {
+                let _ = writeln!(err, "{warning}");
+            }
+            report(
+                resolution.schema.validate(&resolution.document),
+                document_path,
+                out,
+                err,
+            )
+        }
         Err(error) => {
             let _ = writeln!(err, "{error}");
             2
@@ -67,12 +77,7 @@ fn validate_explicit(
     }
 }
 
-fn extract(
-    document_path: &str,
-    schema_path: &str,
-    out: &mut dyn Write,
-    err: &mut dyn Write,
-) -> u8 {
+fn extract(document_path: &str, schema_path: &str, out: &mut dyn Write, err: &mut dyn Write) -> u8 {
     let path = Path::new(document_path);
     let content = match fs::read_to_string(path) {
         Ok(content) => content,
@@ -116,7 +121,13 @@ fn report(
 
 fn usage(stream: &mut dyn Write) {
     let _ = writeln!(stream, "Usage:");
-    let _ = writeln!(stream, "  toml-schema validate <schema.tosd> <document.toml>");
+    let _ = writeln!(
+        stream,
+        "  toml-schema validate <schema.tosd> <document.toml>"
+    );
     let _ = writeln!(stream, "  toml-schema validate <document.toml>");
-    let _ = writeln!(stream, "  toml-schema extract <document.toml> <schema.tosd>");
+    let _ = writeln!(
+        stream,
+        "  toml-schema extract <document.toml> <schema.tosd>"
+    );
 }

--- a/reference-implementations/rust/src/lib.rs
+++ b/reference-implementations/rust/src/lib.rs
@@ -9,5 +9,6 @@ pub mod extract;
 pub mod schema;
 
 pub use schema::{
-    Definition, Schema, SchemaType, ValidationError, ValidationResult, DEFINITION_KEYS,
+    resolve_schema_from_document, schema_from_document, Definition, DocumentSchemaResolution,
+    Schema, SchemaType, ValidationError, ValidationResult, DEFINITION_KEYS,
 };

--- a/reference-implementations/rust/src/schema.rs
+++ b/reference-implementations/rust/src/schema.rs
@@ -13,6 +13,7 @@ use std::path::{Path, PathBuf};
 use regex::Regex;
 use toml::value::{Datetime, Offset};
 use toml::{Table, Value};
+use url::Url;
 
 /// Built-in TOML Schema types.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -159,8 +160,25 @@ impl ValidationResult {
 #[derive(Debug, Clone)]
 pub struct Schema {
     source: PathBuf,
+    version: String,
     types: BTreeMap<String, Definition>,
     elements: BTreeMap<String, Definition>,
+}
+
+#[derive(Debug, Clone)]
+struct LanguageVersion {
+    value: String,
+    major: String,
+    minor: String,
+}
+
+/// A schema resolved from a data document, including diagnostics that do not
+/// prevent validation.
+#[derive(Debug, Clone)]
+pub struct DocumentSchemaResolution {
+    pub schema: Schema,
+    pub document: Table,
+    pub warnings: Vec<String>,
 }
 
 impl Schema {
@@ -192,7 +210,7 @@ impl Schema {
         let version = metadata
             .get("version")
             .ok_or_else(|| "[toml-schema] must contain version".to_string())?;
-        Self::validate_schema_version(version)?;
+        let version = Self::validate_schema_version(version)?;
         for key in metadata.keys() {
             if key != "version" && key != "meta" {
                 return Err(format!("unsupported [toml-schema] key: {key}"));
@@ -204,6 +222,7 @@ impl Schema {
         let elements = parse_definitions("elements", elements_table, true)?;
         let schema = Schema {
             source,
+            version: version.value,
             types,
             elements,
         };
@@ -216,26 +235,34 @@ impl Schema {
         &self.source
     }
 
-    fn validate_schema_version(value: &Value) -> Result<(), String> {
-        let Some(version) = value.as_str() else {
-            return Err("[toml-schema].version must be a SemVer string".to_string());
-        };
-        let semver = Regex::new(
-            r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-((?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$",
+    /// Returns the TOML Schema language version declared by this schema.
+    pub fn version(&self) -> &str {
+        &self.version
+    }
+
+    fn validate_schema_version(value: &Value) -> Result<LanguageVersion, String> {
+        let version = parse_language_version(value, "[toml-schema].version")?;
+        if version.major != "1" {
+            return Err(format!(
+                "unsupported TOML Schema major version: {}",
+                version.value
+            ));
+        }
+        if version.minor != "0" {
+            return Err(format!(
+                "unsupported TOML Schema minor version: {}",
+                version.value
+            ));
+        }
+        Ok(version)
+    }
+
+    fn language_version(&self) -> LanguageVersion {
+        parse_language_version(
+            &Value::String(self.version.clone()),
+            "[toml-schema].version",
         )
-        .expect("valid SemVer regex");
-        let Some(captures) = semver.captures(version) else {
-            return Err(
-                "[toml-schema].version must use SemVer MAJOR.MINOR.PATCH syntax".to_string(),
-            );
-        };
-        if captures.get(1).map(|major| major.as_str()) != Some("1") {
-            return Err(format!("unsupported TOML Schema major version: {version}"));
-        }
-        if captures.get(2).map(|minor| minor.as_str()) != Some("0") {
-            return Err(format!("unsupported TOML Schema minor version: {version}"));
-        }
-        Ok(())
+        .expect("schema version was validated during loading")
     }
 
     fn validate_array_range_definitions(&self) -> Result<(), String> {
@@ -354,26 +381,157 @@ impl Schema {
     }
 }
 
+fn parse_language_version(value: &Value, property: &str) -> Result<LanguageVersion, String> {
+    let Some(version) = value.as_str() else {
+        return Err(format!("{property} must be a SemVer string"));
+    };
+    let semver = Regex::new(
+        r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-((?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$",
+    )
+    .expect("valid SemVer regex");
+    let Some(captures) = semver.captures(version) else {
+        return Err(format!(
+            "{property} must use SemVer MAJOR.MINOR.PATCH syntax"
+        ));
+    };
+    Ok(LanguageVersion {
+        value: version.to_string(),
+        major: captures
+            .get(1)
+            .expect("SemVer major capture")
+            .as_str()
+            .to_string(),
+        minor: captures
+            .get(2)
+            .expect("SemVer minor capture")
+            .as_str()
+            .to_string(),
+    })
+}
+
 /// Loads a TOML Schema document referenced by a TOML document via
 /// `[toml-schema].location` and returns the schema together with the parsed
 /// document.
 pub fn schema_from_document<P: AsRef<Path>>(document_path: P) -> Result<(Schema, Table), String> {
+    let resolution = resolve_schema_from_document(document_path)?;
+    Ok((resolution.schema, resolution.document))
+}
+
+/// Resolves a document's schema and returns non-fatal version diagnostics for
+/// callers, such as the CLI, that can surface warnings.
+pub fn resolve_schema_from_document<P: AsRef<Path>>(
+    document_path: P,
+) -> Result<DocumentSchemaResolution, String> {
     let document_path = document_path.as_ref();
     let document = parse_toml_file(document_path)?;
     let metadata = document
         .get("toml-schema")
         .and_then(Value::as_table)
-        .ok_or_else(|| "document does not contain [toml-schema].location".to_string())?;
+        .ok_or_else(|| "Document must contain a [toml-schema] table".to_string())?;
     let location = metadata
         .get("location")
         .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|location| !location.is_empty())
-        .ok_or_else(|| "document does not contain [toml-schema].location".to_string())?;
-    let directory = document_path.parent().unwrap_or_else(|| Path::new("."));
-    let schema_path = directory.join(location);
+        .filter(|location| !location.trim().is_empty())
+        .ok_or_else(|| "Document [toml-schema].location must be a non-empty string".to_string())?;
+    let schema_path = resolve_schema_path(document_path, location)?;
     let schema = Schema::load(&schema_path)?;
-    Ok((schema, document))
+    let mut warnings = Vec::new();
+    if let Some(expected_value) = metadata.get("version") {
+        let expected = parse_language_version(expected_value, "Document [toml-schema].version")?;
+        let actual = schema.language_version();
+        if expected.major != actual.major {
+            return Err(format!(
+                "Document expects TOML Schema major version {}, but resolved schema uses {}",
+                expected.value, actual.value
+            ));
+        }
+        if expected.value != actual.value {
+            warnings.push(format!(
+                "Warning: document expects TOML Schema version {}, but resolved schema uses {}",
+                expected.value, actual.value
+            ));
+        }
+    }
+    Ok(DocumentSchemaResolution {
+        schema,
+        document,
+        warnings,
+    })
+}
+
+fn resolve_schema_path(document_path: &Path, location: &str) -> Result<PathBuf, String> {
+    let location_is_absolute_path = Path::new(location).is_absolute();
+    if !location_is_absolute_path && has_invalid_uri_reference_character(location) {
+        return Err(format!("Invalid [toml-schema].location URI: {location}"));
+    }
+    if !location_is_absolute_path && has_non_hierarchical_file_scheme(location) {
+        return Err(format!("Invalid file schema location: {location}"));
+    }
+    let absolute_document = if document_path.is_absolute() {
+        document_path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map_err(|error| format!("Unable to resolve document path: {error}"))?
+            .join(document_path)
+    };
+    let document_uri = Url::from_file_path(&absolute_document)
+        .map_err(|_| format!("Invalid document file path: {}", document_path.display()))?;
+    let resolved = if location_is_absolute_path {
+        Url::from_file_path(location)
+            .map_err(|_| format!("Invalid file schema location: {location}"))?
+    } else {
+        document_uri
+            .join(location)
+            .map_err(|_| format!("Invalid [toml-schema].location URI: {location}"))?
+    };
+    if resolved.scheme() != "file" {
+        return Err(format!(
+            "Unsupported schema location URI scheme: {}",
+            resolved.scheme()
+        ));
+    }
+    if resolved.query().is_some() || resolved.fragment().is_some() {
+        return Err(format!("Invalid file schema location: {location}"));
+    }
+    if contains_percent_encoded_separator(resolved.path()) {
+        return Err(format!("Invalid file schema location: {location}"));
+    }
+    resolved
+        .to_file_path()
+        .map_err(|_| format!("Invalid file schema location: {location}"))
+}
+
+fn has_non_hierarchical_file_scheme(reference: &str) -> bool {
+    match Url::parse(reference) {
+        Ok(url) if url.scheme().eq_ignore_ascii_case("file") => {
+            !reference[url.scheme().len() + 1..].starts_with('/')
+        }
+        _ => false,
+    }
+}
+
+fn has_invalid_uri_reference_character(reference: &str) -> bool {
+    reference.chars().any(|character| {
+        character <= ' '
+            || character == '\u{7f}'
+            || matches!(
+                character,
+                '\\' | '"' | '<' | '>' | '^' | '`' | '{' | '|' | '}'
+            )
+    })
+}
+
+fn contains_percent_encoded_separator(path: &str) -> bool {
+    path.as_bytes().windows(3).any(|window| {
+        window[0] == b'%'
+            && matches!(
+                (
+                    window[1].to_ascii_lowercase(),
+                    window[2].to_ascii_lowercase()
+                ),
+                (b'2', b'f') | (b'5', b'c')
+            )
+    })
 }
 
 fn parse_toml_file(path: &Path) -> Result<Table, String> {

--- a/reference-implementations/rust/tests/integration.rs
+++ b/reference-implementations/rust/tests/integration.rs
@@ -7,7 +7,9 @@ use std::io::Cursor;
 use std::path::{Path, PathBuf};
 
 use toml_schema::cli::run;
-use toml_schema::schema::{Schema, ValidationResult};
+use toml_schema::schema::{
+    resolve_schema_from_document, schema_from_document, Schema, ValidationResult,
+};
 
 fn repository_root() -> PathBuf {
     // Tests run from `reference-implementations/rust`.
@@ -60,8 +62,18 @@ fn validates_checked_in_example() {
 
 #[test]
 fn loads_examples_migrated_from_reference_specialization() {
-    for name in ["hugo.tosd", "netlify.tosd"] {
-        let path = fixture("examples").join(name);
+    let examples = fixture("examples");
+    let mut paths: Vec<PathBuf> = fs::read_dir(&examples)
+        .expect("read examples directory")
+        .map(|entry| entry.expect("read example entry").path())
+        .filter(|path| {
+            path.extension()
+                .is_some_and(|extension| extension == "tosd")
+        })
+        .collect();
+    paths.sort();
+    assert!(!paths.is_empty(), "expected checked-in schema examples");
+    for path in paths {
         Schema::load(&path)
             .unwrap_or_else(|error| panic!("failed to load {}: {error}", path.display()));
     }
@@ -148,6 +160,42 @@ extra = true
 }
 
 #[test]
+fn validates_reserved_metadata_when_the_schema_defines_it() {
+    let directory = tempfile_dir("defined-metadata");
+    let schema_path = write_file(
+        &directory,
+        "schema.tosd",
+        r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.toml-schema]
+type = "table"
+
+[elements.toml-schema.location]
+type = "string"
+"#,
+    );
+    let document_path = write_file(
+        &directory,
+        "document.toml",
+        r#"
+[toml-schema]
+location = 42
+"#,
+    );
+
+    let schema = Schema::load(schema_path).expect("load metadata schema");
+    let result = schema.validate_file(document_path);
+
+    assert!(
+        has_path(&result, "$.toml-schema.location"),
+        "expected reserved metadata to be validated, got {:#?}",
+        result.errors
+    );
+}
+
+#[test]
 fn accepts_string_descriptions_and_rejects_other_values() {
     let directory = tempfile_dir("descriptions");
     let described_schema = write_file(
@@ -186,6 +234,44 @@ description = 42
 "#,
     );
     Schema::load(&invalid_schema).expect_err("non-string description should be rejected");
+}
+
+#[test]
+fn treats_default_as_advisory_without_changing_validation() {
+    let directory = tempfile_dir("advisory-default");
+    let schema_path = write_file(
+        &directory,
+        "schema.tosd",
+        r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.port]
+type = "integer"
+default = 8080
+"#,
+    );
+    let omitted = write_file(&directory, "omitted.toml", "");
+    let invalid_present = write_file(&directory, "invalid-present.toml", r#"port = "8080""#);
+    let valid_present = write_file(&directory, "valid-present.toml", "port = 9000");
+
+    let schema = Schema::load(schema_path).expect("schema with default should load");
+    let omitted_result = schema.validate_file(omitted);
+    assert!(
+        has_path(&omitted_result, "$.port"),
+        "default must not insert an omitted required value: {:#?}",
+        omitted_result.errors
+    );
+    let invalid_result = schema.validate_file(invalid_present);
+    assert!(
+        has_path(&invalid_result, "$.port"),
+        "default must not replace an invalid present value: {:#?}",
+        invalid_result.errors
+    );
+    assert!(
+        schema.validate_file(valid_present).valid(),
+        "a valid present value should be validated normally"
+    );
 }
 
 #[test]
@@ -1585,6 +1671,257 @@ location = "schema.tosd"
 }
 
 #[test]
+fn schema_discovery_accepts_relative_absolute_and_file_uri_locations() {
+    let directory = tempfile_dir("schema-location-forms");
+    let schemas = directory.join("schemas");
+    let documents = directory.join("documents");
+    fs::create_dir_all(&schemas).expect("create schemas directory");
+    fs::create_dir_all(&documents).expect("create documents directory");
+    let schema_path = write_file(
+        &schemas,
+        "schema.tosd",
+        r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.title]
+type = "string"
+"#,
+    );
+    let file_uri = url::Url::from_file_path(&schema_path).expect("schema file URI");
+    let locations = [
+        "../schemas/schema.tosd".to_string(),
+        "%2e%2e/schemas/schema.tosd".to_string(),
+        schema_path.display().to_string(),
+        file_uri.to_string(),
+    ];
+
+    for (index, location) in locations.iter().enumerate() {
+        let document_path = write_file(
+            &documents,
+            &format!("document-{index}.toml"),
+            &format!(
+                r#"
+title = "Example"
+
+[toml-schema]
+location = "{location}"
+"#
+            ),
+        );
+        let (schema, document) =
+            schema_from_document(&document_path).expect("discover schema from document");
+        assert_eq!(schema.version(), "1.0.0");
+        assert!(schema.validate(&document).valid());
+    }
+}
+
+#[test]
+fn cli_allows_document_schema_version_to_be_omitted() {
+    let directory = tempfile_dir("omitted-document-version");
+    write_simple_schema(&directory, "1.0.0");
+    let document_path = write_file(
+        &directory,
+        "document.toml",
+        r#"
+title = "Example"
+
+[toml-schema]
+location = "schema.tosd"
+"#,
+    );
+
+    let (exit_code, _stdout, stderr) = capture(&["validate", document_path.to_str().unwrap()]);
+
+    assert_eq!(exit_code, 0, "{stderr}");
+    assert_eq!(stderr, "");
+}
+
+#[test]
+fn schema_discovery_exposes_non_major_version_warning_to_the_cli() {
+    let directory = tempfile_dir("document-version-warning");
+    write_simple_schema(&directory, "1.0.1");
+    let document_path = write_file(
+        &directory,
+        "document.toml",
+        r#"
+title = "Example"
+
+[toml-schema]
+version = "1.0.0"
+location = "schema.tosd"
+"#,
+    );
+
+    let resolution =
+        resolve_schema_from_document(&document_path).expect("resolve schema with warning");
+    assert_eq!(resolution.schema.version(), "1.0.1");
+    assert_eq!(
+        resolution.warnings,
+        ["Warning: document expects TOML Schema version 1.0.0, but resolved schema uses 1.0.1"]
+    );
+    schema_from_document(&document_path).expect("legacy discovery API remains successful");
+
+    let (exit_code, stdout, stderr) = capture(&["validate", document_path.to_str().unwrap()]);
+    assert_eq!(exit_code, 0, "{stderr}");
+    assert!(stdout.contains("is valid"));
+    assert!(stderr.contains(
+        "Warning: document expects TOML Schema version 1.0.0, but resolved schema uses 1.0.1"
+    ));
+}
+
+#[test]
+fn schema_discovery_rejects_major_version_mismatch() {
+    let directory = tempfile_dir("document-major-version");
+    write_simple_schema(&directory, "1.0.0");
+    let document_path = write_file(
+        &directory,
+        "document.toml",
+        r#"
+title = "Example"
+
+[toml-schema]
+version = "2.0.0"
+location = "schema.tosd"
+"#,
+    );
+
+    let error = schema_from_document(&document_path).expect_err("reject major mismatch");
+    assert!(error.contains(
+        "Document expects TOML Schema major version 2.0.0, but resolved schema uses 1.0.0"
+    ));
+
+    let (exit_code, _stdout, stderr) = capture(&["validate", document_path.to_str().unwrap()]);
+    assert_eq!(exit_code, 2);
+    assert!(stderr.contains(&error));
+}
+
+#[test]
+fn schema_discovery_rejects_malformed_document_versions() {
+    let directory = tempfile_dir("malformed-document-version");
+    write_simple_schema(&directory, "1.0.0");
+    for (name, version) in [("shorthand", "\"1.0\""), ("non-string", "1")] {
+        let document_path = write_file(
+            &directory,
+            &format!("{name}.toml"),
+            &format!(
+                r#"
+title = "Example"
+
+[toml-schema]
+version = {version}
+location = "schema.tosd"
+"#
+            ),
+        );
+
+        let error = schema_from_document(&document_path).expect_err("reject invalid version");
+        assert!(
+            error.starts_with("Document [toml-schema].version must"),
+            "{error}"
+        );
+        let (exit_code, _stdout, stderr) = capture(&["validate", document_path.to_str().unwrap()]);
+        assert_eq!(exit_code, 2);
+        assert!(stderr.contains("Document [toml-schema].version must"));
+    }
+}
+
+#[test]
+fn schema_discovery_rejects_unsupported_and_malformed_location_uris() {
+    let directory = tempfile_dir("invalid-location-uri");
+    for (name, location, expected) in [
+        (
+            "unsupported",
+            "https://example.com/schema.tosd",
+            "Unsupported schema location URI scheme: https",
+        ),
+        (
+            "malformed",
+            "http://[invalid/schema.tosd",
+            "Invalid [toml-schema].location URI",
+        ),
+    ] {
+        let document_path = write_file(
+            &directory,
+            &format!("{name}.toml"),
+            &format!(
+                r#"
+[toml-schema]
+location = "{location}"
+"#
+            ),
+        );
+
+        let error = schema_from_document(&document_path).expect_err("reject invalid location");
+        assert!(error.contains(expected), "{error}");
+        let (exit_code, _stdout, stderr) = capture(&["validate", document_path.to_str().unwrap()]);
+        assert_eq!(exit_code, 2);
+        assert!(stderr.contains(expected), "{stderr}");
+    }
+}
+
+#[test]
+fn schema_discovery_rejects_unsafe_schema_location_separators() {
+    let directory = tempfile_dir("unsafe-location-separators");
+    for (name, document, expected) in [
+        (
+            "backslash",
+            "[toml-schema]\nlocation = 'schemas\\schema.tosd'\n",
+            "Invalid [toml-schema].location URI",
+        ),
+        (
+            "encoded-slash",
+            "[toml-schema]\nlocation = \"schemas%2Fschema.tosd\"\n",
+            "Invalid file schema location",
+        ),
+        (
+            "encoded-backslash",
+            "[toml-schema]\nlocation = \"schemas%5cschema.tosd\"\n",
+            "Invalid file schema location",
+        ),
+    ] {
+        let document_path = write_file(&directory, &format!("{name}.toml"), document);
+
+        let error = schema_from_document(&document_path).expect_err("reject unsafe separator");
+        assert!(error.contains(expected), "{error}");
+        let (exit_code, _stdout, stderr) = capture(&["validate", document_path.to_str().unwrap()]);
+        assert_eq!(exit_code, 2);
+        assert!(stderr.contains(expected), "{stderr}");
+    }
+}
+
+#[test]
+fn schema_discovery_rejects_non_hierarchical_file_locations() {
+    let directory = tempfile_dir("non-hierarchical-file-location");
+    for (index, location) in [
+        "file:schema.tosd",
+        "file:../schema.tosd",
+        "FiLe:schema.tosd",
+    ]
+    .iter()
+    .enumerate()
+    {
+        let document_path = write_file(
+            &directory,
+            &format!("document-{index}.toml"),
+            &format!(
+                r#"
+[toml-schema]
+location = "{location}"
+"#
+            ),
+        );
+
+        let error =
+            schema_from_document(&document_path).expect_err("reject non-hierarchical file URI");
+        assert!(error.contains("Invalid file schema location"), "{error}");
+        let (exit_code, _stdout, stderr) = capture(&["validate", document_path.to_str().unwrap()]);
+        assert_eq!(exit_code, 2);
+        assert!(stderr.contains("Invalid file schema location"), "{stderr}");
+    }
+}
+
+#[test]
 fn cli_extracts_schema_from_toml_document() {
     let directory = tempfile_dir("cli-extracts-schema");
     let document_path = write_file(
@@ -1665,6 +2002,22 @@ fn cli_reports_unknown_command() {
     let (exit_code, _stdout, stderr) = capture(&["wat"]);
     assert_eq!(exit_code, 2);
     assert!(stderr.contains("Unknown command"));
+}
+
+fn write_simple_schema(directory: &Path, version: &str) -> PathBuf {
+    write_file(
+        directory,
+        "schema.tosd",
+        &format!(
+            r#"
+[toml-schema]
+version = "{version}"
+
+[elements.title]
+type = "string"
+"#
+        ),
+    )
 }
 
 fn tempfile_dir(name: &str) -> PathBuf {


### PR DESCRIPTION
## Summary

- align document-driven schema URI and language-version handling across Java, Go, and Rust
- define `default` as an advisory authoring hint with no validation-time mutation
- repair the Wrangler schema's invalid reference specialization and validate every checked-in example
- add cross-implementation conformance coverage for the remaining ambiguity edge cases

## Validation

- `mvn -B -q -f reference-implementations/java/pom.xml package`
- `go test ./...`
- `cargo test --locked --quiet`
- Java, Go, and Rust checked-in validation and extraction flows

Closes #61