### PR TITLE
Fix priority TOML Schema inconsistencies

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -40,4 +40,4 @@ This repository contains the TOML Schema specification/proposal plus reference i
 - Root `[toml-schema]` in TOML documents is reserved metadata and ignored during application validation unless the schema explicitly defines `[elements.toml-schema]`.
 - Optionality defaults to required behavior. Only mark a schema node optional with `optional = true` when the TOML document may omit that structure.
 - Tables with no defined child structure are intentionally open-ended; tables with defined child properties are intended to validate exactly against those children.
-- `pattern` applies to string validation, and the README specifies Perl/PCRE-compatible regular expressions for parsers.
+- `pattern` applies to string validation, and the specification defines the portable RE2 regular-expression profile required of parsers.

--- a/.github/extensions/tosd-editor/client.js
+++ b/.github/extensions/tosd-editor/client.js
@@ -576,12 +576,12 @@ function renderEditor() {
     // string pattern + allowedvalues for simple types
     if (t === "string") {
         box.append(textField("pattern", "Pattern (regex)", p.pattern || "", (v) => setProp(p, "pattern", v), true,
-            "PCRE-compatible regular expression."));
+            "Portable RE2-profile regular expression."));
     }
     // collection key pattern
     if (t === "collection") {
         box.append(textField("keypattern", "Key pattern (regex)", p.keypattern || "", (v) => setProp(p, "keypattern", v), true,
-            "PCRE-compatible regex every dynamic entry key must match."));
+            "Portable RE2-profile regex every dynamic entry key must match."));
     }
     if (SIMPLE_TYPES.includes(t) || t === "array") {
         box.append(listField("allowedvalues", "Allowed values (enum)", p.allowedvalues || [],
@@ -608,14 +608,13 @@ function renderEditor() {
         box.append(row);
     }
 
-    // optional + default (always available)
+    // optional (always available)
     box.append(checkboxField("optional", "Optional (may be omitted in the document)", !!p.optional, (v) => {
         if (v) p.optional = true;
         else delete p.optional;
         markDirty();
         renderTree();
     }));
-    box.append(textField("default", "Default value (TOML token)", p.default || "", (v) => setProp(p, "default", v), true));
 
     // Show-all advanced toggle
     const toggle = el("button", {
@@ -637,7 +636,7 @@ function renderEditor() {
 function advancedAll(p) {
     const wrap = el("div");
     wrap.append(el("div", { class: "section-title", text: "All properties" }));
-    const allProps = ["type", "itemtype", "pattern", "keypattern", "min", "max", "default"];
+    const allProps = ["type", "itemtype", "pattern", "keypattern", "min", "max"];
     for (const key of allProps) {
         wrap.append(textField(key, key, p[key] != null ? String(p[key]) : "", (v) => setProp(p, key, v), true));
     }

--- a/.github/extensions/tosd-editor/extension.mjs
+++ b/.github/extensions/tosd-editor/extension.mjs
@@ -95,7 +95,7 @@ function buildGeneratePrompt(desc) {
         '- Include a [toml-schema] table with version = "1.0.0".',
         "- Describe the document's top-level structure under [elements]; use nested tables like [elements.<name>.<child>] for sub-tables.",
         '- Put reusable definitions under [types.<name>] and reference them with type = "types.<name>". Use itemtype = "types.<name>" for array and collection members.',
-        "- Use only TOSD property keys: type (string, integer, float, boolean, offset-date-time, local-date-time, local-date, local-time, array, table, collection), optional, default, min, max, minlength, maxlength, pattern, allowedvalues, itemtype, items, oneof, anyof.",
+        "- Use only TOSD property keys: type (string, integer, float, boolean, offset-date-time, local-date-time, local-date, local-time, array, table, collection), optional, min, max, minlength, maxlength, pattern, keypattern, allowedvalues, itemtype, items, oneof, anyof.",
         "- Mark fields that may be omitted with optional = true; everything is required by default.",
     ].join("\n");
 }

--- a/.github/extensions/tosd-editor/model.mjs
+++ b/.github/extensions/tosd-editor/model.mjs
@@ -16,7 +16,7 @@
 //   minlength/maxlength                    : number
 //   items/oneof/anyof                      : string[]  (type references)
 //   allowedvalues                          : string[]  (TOML value tokens)
-//   min/max/default                        : string    (TOML value token)
+//   min/max                                : string    (TOML value token)
 
 import {
     parseToml,
@@ -40,7 +40,6 @@ export const PROP_ORDER = [
     "minlength",
     "maxlength",
     "optional",
-    "default",
 ];
 
 const STRING_PROPS = new Set(["type", "itemtype", "pattern", "keypattern"]);
@@ -48,7 +47,7 @@ const INT_PROPS = new Set(["minlength", "maxlength"]);
 const BOOL_PROPS = new Set(["optional"]);
 const REFLIST_PROPS = new Set(["items", "oneof", "anyof"]);
 const VALUELIST_PROPS = new Set(["allowedvalues"]);
-const VALUE_PROPS = new Set(["min", "max", "default"]);
+const VALUE_PROPS = new Set(["min", "max"]);
 
 const ALL_PROPS = new Set(PROP_ORDER);
 
@@ -105,7 +104,7 @@ function tableToNode(name, table) {
             node.children.push(tableToNode(key, value));
         } else if (ALL_PROPS.has(key)) {
             node.props[key] = decodeProp(key, value);
-        } else if (key === "arraytype") {
+        } else if (key === "arraytype" || key === "default") {
             // Preserve removed syntax long enough for validation to report it.
             node.props[key] = String(value);
         } else {
@@ -295,6 +294,9 @@ export function validateModel(model) {
         if (p.arraytype != null) {
             issues.push({ level: "error", path: label, message: "`arraytype` is not supported; use `itemtype`." });
         }
+        if (p.default != null) {
+            issues.push({ level: "error", path: label, message: "`default` is not a TOML Schema property." });
+        }
 
         const exclusivity = ["type", "oneof", "anyof"].filter((k) => p[k] != null && p[k] !== "" && !(Array.isArray(p[k]) && p[k].length === 0));
         if (exclusivity.length > 1) {
@@ -327,23 +329,23 @@ export function validateModel(model) {
             if (t === "any") {
                 issues.push({ level: "error", path: label, message: "`min`/`max` cannot be applied to type `any`." });
             } else if (!ok) {
-                issues.push({ level: "warning", path: label, message: "`min`/`max` only apply to numeric/temporal types, or arrays of them." });
+                issues.push({ level: "error", path: label, message: "`min`/`max` only apply to numeric/temporal types, or arrays of them." });
             }
         }
 
         if ((p.minlength != null || p.maxlength != null)) {
             const t = p.type;
-            if (t && !["string", "array", "collection"].includes(t)) {
-                issues.push({ level: "warning", path: label, message: "`minlength`/`maxlength` only apply to string, array, or collection." });
+            if (!["string", "array", "collection"].includes(t)) {
+                issues.push({ level: "error", path: label, message: "`minlength`/`maxlength` require the built-in type string, array, or collection." });
             }
         }
 
-        if (p.pattern && p.type && p.type !== "string") {
-            issues.push({ level: "warning", path: label, message: `\`pattern\` is ignored on \`${p.type}\` — it only validates \`string\` values.` });
+        if (Object.prototype.hasOwnProperty.call(p, "pattern") && p.type !== "string") {
+            issues.push({ level: "error", path: label, message: "`pattern` requires the built-in type `string`." });
         }
 
-        if (p.keypattern && p.type && p.type !== "collection") {
-            issues.push({ level: "warning", path: label, message: `\`keypattern\` only applies to \`collection\` — it validates dynamic entry keys.` });
+        if (Object.prototype.hasOwnProperty.call(p, "keypattern") && p.type !== "collection") {
+            issues.push({ level: "error", path: label, message: "`keypattern` requires the built-in type `collection`." });
         }
 
         for (const ref of [p.type, p.itemtype]) {

--- a/.github/extensions/tosd-editor/toml.mjs
+++ b/.github/extensions/tosd-editor/toml.mjs
@@ -7,7 +7,7 @@
 //     the resulting tree therefore always represents a sub-table — i.e. a child
 //     schema definition.
 //   * Inline tables ({ a = 1 }) are tagged as { __inline: true, value: {...} }
-//     so they are never confused with sub-tables (relevant only for `default`).
+//     so they are never confused with sub-tables.
 //   * Date/time values are tagged as { __datetime: kind, value: "..." } so the
 //     serializer emits them bare instead of quoting them.
 //

--- a/SPEC.md
+++ b/SPEC.md
@@ -369,6 +369,12 @@ For `array` and `collection` values, length is counted as the number of items or
 
 Both `minlength` and `maxlength` MUST be integers `>= 0`. When both are present, `minlength` MUST be less than or equal to `maxlength`. A schema violating either rule is malformed and parsers MUST reject it at schema-load time.
 
+`minlength` and `maxlength` are valid only on definitions whose selected type is
+the built-in `string`, `array`, or `collection`. They cannot be attached to
+another built-in type, an alternative selector, or a named type reference.
+Parsers MUST reject an incompatible length constraint at schema-load time rather
+than silently ignoring it.
+
 ### Conditions on `any`
 
 No min/max condition may be applied to type `any`. The parser must show an error if this happens.
@@ -713,7 +719,7 @@ Use a named reusable definition whenever an alternative needs constraints such a
 ```toml
 [types.dependencyVersion]
 type = "string"
-pattern = "^\\d+\\.\\d+\\.\\d+$"
+pattern = "^[0-9]+\\.[0-9]+\\.[0-9]+$"
 
 [types.inlineDependency]
 type = "table"
@@ -760,11 +766,29 @@ Parsers must only skip a structure validation if the structure is optional in th
 
 ### Pattern - `pattern`
 
-This property is only used for validating `string` input. Parsers must validate the input with the provided regular expression.
+This property is only valid on a definition whose selected type is the built-in
+`string`. It cannot be attached to another built-in type, an alternative
+selector, or a named type reference. Parsers MUST reject an incompatible
+`pattern` at schema-load time rather than silently ignoring it.
 
-Parsers must support Perl/PCRE syntax. Parsers may support more extensions and other syntaxes.
+The portable TOML Schema regular-expression profile consists of literals,
+escaped metacharacters, `.`, character classes and ranges, negated character
+classes, concatenation, alternation, capturing and non-capturing groups, the
+anchors `^` and `$`, and the greedy quantifiers `?`, `*`, `+`, `{n}`, `{n,}`,
+and `{n,m}`. These constructs use the syntax documented by the
+[RE2 syntax reference](https://github.com/google/re2/wiki/Syntax). Parsers MUST
+support this profile.
 
-The pattern is not implicitly anchored. A value validates if the regular expression matches anywhere in the string. Authors who require a full-string match must anchor the expression with `^` and `$` (or `\A` and `\z`).
+Character-class shorthands such as `\d`, `\s`, and `\w` are outside the
+portable profile because regular-expression engines disagree about whether
+they use ASCII or Unicode membership. Backreferences, look-around assertions,
+atomic groups, conditionals, and recursion are also outside the portable
+profile. Parsers MAY accept additional constructs, but schemas that use those
+extensions are not portable between TOML Schema implementations.
+
+The pattern is not implicitly anchored. A value validates if the regular
+expression matches anywhere in the string. Authors who require a full-string
+match must anchor the expression with `^` and `$`.
 
 ### Key Pattern - `keypattern`
 
@@ -780,7 +804,11 @@ Keys that are explicitly declared as fixed child definitions of the collection (
 key-value pairs) are validated by their own definitions and are not subject to `keypattern`. Only
 dynamic, user-provided keys are matched against the pattern.
 
-Parsers must support Perl/PCRE syntax, the same flavor as [`pattern`](#pattern---pattern). Like `pattern`, `keypattern` is not implicitly anchored: a key validates if the regular expression matches anywhere in the key string. Authors who require a full-key match must anchor the expression with `^` and `$`.
+Parsers MUST support the same portable RE2 regular-expression profile as
+[`pattern`](#pattern---pattern). Like `pattern`, `keypattern` is not implicitly
+anchored: a key validates if the regular expression matches anywhere in the key
+string. Authors who require a full-key match must anchor the expression with
+`^` and `$`.
 
 **Example:**
 

--- a/reference-implementations/go/cmd/toml-schema/main.go
+++ b/reference-implementations/go/cmd/toml-schema/main.go
@@ -47,6 +47,9 @@ func validateWithEmbeddedSchema(documentPath string, out, errOut io.Writer) int 
 		fmt.Fprintln(errOut, err)
 		return 2
 	}
+	for _, warning := range schema.Warnings() {
+		fmt.Fprintln(errOut, warning)
+	}
 	return report(schema.Validate(document), documentPath, out, errOut)
 }
 

--- a/reference-implementations/go/cmd/toml-schema/main_test.go
+++ b/reference-implementations/go/cmd/toml-schema/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -34,6 +36,69 @@ location = "schema.tosd"
 	}
 	if !strings.Contains(out.String(), "is valid") {
 		t.Fatalf("expected valid output, got %q", out.String())
+	}
+}
+
+func TestCLIResolvesFileURIAndEnforcesDocumentSchemaVersion(t *testing.T) {
+	dir := t.TempDir()
+	schemaPath := writeFile(t, dir, "schema.tosd", `
+[toml-schema]
+version = "1.0.1"
+
+[elements.title]
+type = "string"
+`)
+	fileURI := (&url.URL{Scheme: "file", Path: filepath.ToSlash(schemaPath)}).String()
+	tests := []struct {
+		name         string
+		version      string
+		location     string
+		wantExitCode int
+		wantError    string
+	}{
+		{
+			name:         "file-uri-warning",
+			version:      `version = "1.0.0"`,
+			location:     fileURI,
+			wantExitCode: 0,
+			wantError:    "Warning: document expects TOML Schema version 1.0.0, but resolved schema uses 1.0.1",
+		},
+		{
+			name:         "major-version-mismatch",
+			version:      `version = "2.0.0"`,
+			location:     fileURI,
+			wantExitCode: 2,
+			wantError:    "document expects TOML Schema major version 2.0.0, but resolved schema uses 1.0.1",
+		},
+		{
+			name:         "unsupported-scheme",
+			location:     "https://example.com/schema.tosd",
+			wantExitCode: 2,
+			wantError:    "unsupported schema location URI scheme: https",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			documentPath := writeFile(t, dir, test.name+".toml", fmt.Sprintf(`
+title = "Example"
+
+[toml-schema]
+%s
+location = %q
+`, test.version, test.location))
+			var out bytes.Buffer
+			var errOut bytes.Buffer
+
+			exitCode := run([]string{"validate", documentPath}, &out, &errOut)
+
+			if exitCode != test.wantExitCode {
+				t.Fatalf("expected exit code %d, got %d: %s", test.wantExitCode, exitCode, errOut.String())
+			}
+			if !strings.Contains(errOut.String(), test.wantError) {
+				t.Fatalf("expected %q, got %q", test.wantError, errOut.String())
+			}
+		})
 	}
 }
 

--- a/reference-implementations/go/schema.go
+++ b/reference-implementations/go/schema.go
@@ -3,6 +3,7 @@ package tomlschema
 import (
 	"fmt"
 	"math"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -32,7 +33,7 @@ const (
 
 var definitionKeys = map[string]bool{
 	"type": true, "description": true, "itemtype": true, "items": true,
-	"allowedvalues": true, "pattern": true, "keypattern": true, "optional": true, "default": true, "min": true,
+	"allowedvalues": true, "pattern": true, "keypattern": true, "optional": true, "min": true,
 	"max": true, "minlength": true, "maxlength": true,
 	"oneof": true, "anyof": true,
 }
@@ -76,6 +77,8 @@ func parseSchemaType(value string) (SchemaType, bool) {
 
 type Schema struct {
 	source   string
+	version  string
+	warnings []string
 	types    map[string]Definition
 	elements map[string]Definition
 }
@@ -150,11 +153,16 @@ func LoadSchema(path string) (*Schema, error) {
 	if err != nil {
 		return nil, err
 	}
-	schema := &Schema{source: path, types: types, elements: elements}
+	schema := &Schema{source: path, version: version.(string), types: types, elements: elements}
 	if err := schema.validateArrayRanges(); err != nil {
 		return nil, err
 	}
 	return schema, nil
+}
+
+// Warnings returns non-fatal warnings produced while discovering this schema.
+func (s *Schema) Warnings() []string {
+	return append([]string(nil), s.warnings...)
 }
 
 func LoadDocument(path string) (map[string]any, error) {
@@ -373,6 +381,16 @@ func parseDefinition(name string, table map[string]any) (Definition, error) {
 	}
 	if keyPattern != nil && typeName != TypeCollection {
 		return Definition{}, fmt.Errorf("%s can only define keypattern when type is collection", name)
+	}
+	if pattern != nil && typeName != TypeString {
+		return Definition{}, fmt.Errorf("%s can only define pattern when type is string", name)
+	}
+	if (minLength != nil || maxLength != nil) &&
+		typeName != TypeString && typeName != TypeArray && typeName != TypeCollection {
+		return Definition{}, fmt.Errorf(
+			"%s can only define minlength or maxlength when type is string, array, or collection",
+			name,
+		)
 	}
 	if typeName == TypeCollection && itemReference == "" {
 		return Definition{}, fmt.Errorf("%s must define itemtype when type is collection", name)
@@ -939,12 +957,71 @@ func SchemaFromDocument(documentPath string) (*Schema, map[string]any, error) {
 	if !ok || strings.TrimSpace(location) == "" {
 		return nil, nil, fmt.Errorf("document does not contain [toml-schema].location")
 	}
-	schemaPath := filepath.Clean(filepath.Join(filepath.Dir(documentPath), location))
+	schemaPath, err := resolveSchemaLocation(documentPath, location)
+	if err != nil {
+		return nil, nil, err
+	}
 	schema, err := LoadSchema(schemaPath)
 	if err != nil {
 		return nil, nil, err
 	}
+	if expectedVersion, present := metadata["version"]; present {
+		warning, err := compareDocumentSchemaVersion(expectedVersion, schema.version)
+		if err != nil {
+			return nil, nil, err
+		}
+		if warning != "" {
+			schema.warnings = append(schema.warnings, warning)
+		}
+	}
 	return schema, document, nil
+}
+
+func resolveSchemaLocation(documentPath, location string) (string, error) {
+	absoluteDocumentPath, err := filepath.Abs(documentPath)
+	if err != nil {
+		return "", fmt.Errorf("invalid document path: %w", err)
+	}
+	base := &url.URL{Scheme: "file", Path: filepath.ToSlash(absoluteDocumentPath)}
+	reference, err := url.Parse(location)
+	if err != nil {
+		return "", fmt.Errorf("invalid [toml-schema].location URI: %s: %w", location, err)
+	}
+	resolved := base.ResolveReference(reference)
+	if !strings.EqualFold(resolved.Scheme, "file") {
+		return "", fmt.Errorf("unsupported schema location URI scheme: %s", resolved.Scheme)
+	}
+	if resolved.Host != "" && !strings.EqualFold(resolved.Host, "localhost") {
+		return "", fmt.Errorf("unsupported file schema location host: %s", resolved.Host)
+	}
+	return filepath.Clean(filepath.FromSlash(resolved.Path)), nil
+}
+
+func compareDocumentSchemaVersion(value any, actual string) (string, error) {
+	expected, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("document [toml-schema].version must be a SemVer string")
+	}
+	expectedParts := semverPattern.FindStringSubmatch(expected)
+	if expectedParts == nil {
+		return "", fmt.Errorf("document [toml-schema].version must use SemVer MAJOR.MINOR.PATCH syntax")
+	}
+	actualParts := semverPattern.FindStringSubmatch(actual)
+	if expectedParts[1] != actualParts[1] {
+		return "", fmt.Errorf(
+			"document expects TOML Schema major version %s, but resolved schema uses %s",
+			expected,
+			actual,
+		)
+	}
+	if expected != actual {
+		return fmt.Sprintf(
+			"Warning: document expects TOML Schema version %s, but resolved schema uses %s",
+			expected,
+			actual,
+		), nil
+	}
+	return "", nil
 }
 
 func propertyValue(table map[string]any, key string) any {
@@ -1000,9 +1077,13 @@ func getPattern(name string, table map[string]any) (*regexp.Regexp, error) {
 }
 
 func getPatternKey(name string, table map[string]any, key string) (*regexp.Regexp, error) {
-	pattern, err := getString(table, key)
-	if err != nil || pattern == "" {
-		return nil, err
+	value := propertyValue(table, key)
+	if value == nil {
+		return nil, nil
+	}
+	pattern, ok := value.(string)
+	if !ok {
+		return nil, fmt.Errorf("expected %s to be a string", key)
 	}
 	compiled, err := regexp.Compile(pattern)
 	if err != nil {

--- a/reference-implementations/go/schema_test.go
+++ b/reference-implementations/go/schema_test.go
@@ -358,6 +358,14 @@ type = "string"
 minlength = 5
 maxlength = 2
 `,
+		"incompatible-length": `
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "boolean"
+minlength = 1
+`,
 	}
 
 	for name, content := range cases {
@@ -1028,6 +1036,43 @@ keypattern = "^[a-z]+$"
 
 	if _, err := LoadSchema(schemaPath); err == nil {
 		t.Fatal("expected keypattern on a scalar to be rejected")
+	}
+}
+
+func TestRejectsPatternOnNonStringAndUndocumentedDefault(t *testing.T) {
+	dir := t.TempDir()
+	cases := map[string]string{
+		"pattern-integer": `
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "integer"
+pattern = "^[0-9]+$"
+`,
+		"empty-pattern-integer": `
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "integer"
+pattern = ""
+`,
+		"default": `
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "string"
+default = "value"
+`,
+	}
+	for name, content := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := LoadSchema(write(t, dir, name+".tosd", content)); err == nil {
+				t.Fatal("expected malformed schema to be rejected")
+			}
+		})
 	}
 }
 

--- a/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
@@ -26,7 +26,7 @@ final class SchemaLoader {
     static final Set<String> TOP_LEVEL_KEYS = Set.of("toml-schema", "types", "elements");
     static final Set<String> DEFINITION_KEYS = Set.of(
             "type", "description", "itemtype", "items", "allowedvalues", "pattern",
-            "keypattern", "optional", "default", "min", "max", "minlength", "maxlength",
+            "keypattern", "optional", "min", "max", "minlength", "maxlength",
             "oneof", "anyof"
     );
     private static final Set<String> NAMED_REFERENCE_KEYS = Set.of("type", "description", "optional");
@@ -177,6 +177,16 @@ final class SchemaLoader {
         if (keyPattern != null && type != SchemaType.COLLECTION) {
             throw new SchemaException(name + " can only define keypattern when type is collection");
         }
+        if (pattern != null && type != SchemaType.STRING) {
+            throw new SchemaException(name + " can only define pattern when type is string");
+        }
+        if ((minLength != null || maxLength != null)
+                && type != SchemaType.STRING
+                && type != SchemaType.ARRAY
+                && type != SchemaType.COLLECTION) {
+            throw new SchemaException(name
+                    + " can only define minlength or maxlength when type is string, array, or collection");
+        }
         if (type == SchemaType.COLLECTION && itemReference == null) {
             throw new SchemaException(name + " must define itemtype when type is collection");
         }
@@ -274,10 +284,37 @@ final class SchemaLoader {
             return null;
         }
         try {
-            return Pattern.compile(pattern);
+            return Pattern.compile(toJavaPattern(pattern));
         } catch (PatternSyntaxException e) {
             throw new SchemaException(definitionName + " has invalid " + key + ": " + pattern, e);
         }
+    }
+
+    private String toJavaPattern(String pattern) {
+        StringBuilder translated = new StringBuilder(pattern.length());
+        boolean escaped = false;
+        boolean inCharacterClass = false;
+        for (int index = 0; index < pattern.length(); index++) {
+            char current = pattern.charAt(index);
+            if (escaped) {
+                translated.append(current);
+                escaped = false;
+            } else if (current == '\\') {
+                translated.append(current);
+                escaped = true;
+            } else if (current == '[') {
+                translated.append(current);
+                inCharacterClass = true;
+            } else if (current == ']' && inCharacterClass) {
+                translated.append(current);
+                inCharacterClass = false;
+            } else if (current == '$' && !inCharacterClass) {
+                translated.append("\\z");
+            } else {
+                translated.append(current);
+            }
+        }
+        return translated.toString();
     }
 
     private List<Object> getArrayValues(TomlTable table, String key) {

--- a/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
+++ b/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
@@ -210,6 +210,23 @@ class TomlSchemaTest {
     }
 
     @Test
+    void patternUsesRe2EndAnchorSemantics() throws IOException {
+        Path schema = write("pattern-end-anchor.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.value]
+                type = "string"
+                pattern = "^foo$"
+                """);
+        Path document = write("pattern-end-anchor.toml", """
+                value = "foo\\n"
+                """);
+
+        assertFalse(TomlSchema.load(schema).validate(document).isValid());
+    }
+
+    @Test
     void stringLengthCountsUnicodeScalarValues() throws IOException {
         Path schema = write("unicode-length.tosd", """
                 [toml-schema]
@@ -555,6 +572,29 @@ class TomlSchemaTest {
                 """);
 
         assertThrows(SchemaException.class, () -> TomlSchema.load(schema));
+    }
+
+    @Test
+    void rejectsPatternOnNonStringAndUndocumentedDefault() throws IOException {
+        Path patternSchema = write("pattern-integer.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.value]
+                type = "integer"
+                pattern = "^[0-9]+$"
+                """);
+        Path defaultSchema = write("default.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.value]
+                type = "string"
+                default = "value"
+                """);
+
+        assertThrows(SchemaException.class, () -> TomlSchema.load(patternSchema));
+        assertThrows(SchemaException.class, () -> TomlSchema.load(defaultSchema));
     }
 
     @Test
@@ -1163,10 +1203,19 @@ class TomlSchemaTest {
                 minlength = 5
                 maxlength = 2
                 """);
+        Path incompatibleLengthSchema = write("boolean-length.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.value]
+                type = "boolean"
+                minlength = 1
+                """);
 
         assertThrows(SchemaException.class, () -> TomlSchema.load(negativeLengthSchema));
         assertThrows(SchemaException.class, () -> TomlSchema.load(negativeMaxLengthSchema));
         assertThrows(SchemaException.class, () -> TomlSchema.load(invertedLengthSchema));
+        assertThrows(SchemaException.class, () -> TomlSchema.load(incompatibleLengthSchema));
     }
 
     @Test

--- a/reference-implementations/rust/Cargo.lock
+++ b/reference-implementations/rust/Cargo.lock
@@ -12,16 +12,140 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "icu_collections"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
+
+[[package]]
+name = "icu_properties"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
+
+[[package]]
+name = "icu_provider"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -34,10 +158,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "litemap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -87,6 +232,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,7 +257,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -116,6 +270,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +290,38 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -147,6 +345,7 @@ version = "1.0.0-rc.2"
 dependencies = [
  "regex",
  "toml",
+ "url",
 ]
 
 [[package]]
@@ -180,7 +379,108 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+
+[[package]]
+name = "writeable"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]

--- a/reference-implementations/rust/Cargo.toml
+++ b/reference-implementations/rust/Cargo.toml
@@ -19,3 +19,4 @@ path = "src/main.rs"
 [dependencies]
 toml = "1"
 regex = "1"
+url = "2"

--- a/reference-implementations/rust/src/cli.rs
+++ b/reference-implementations/rust/src/cli.rs
@@ -44,7 +44,12 @@ fn validate_with_embedded_schema(
     err: &mut dyn Write,
 ) -> u8 {
     match schema_from_document(document_path) {
-        Ok((schema, document)) => report(schema.validate(&document), document_path, out, err),
+        Ok((schema, document)) => {
+            for warning in schema.warnings() {
+                let _ = writeln!(err, "{warning}");
+            }
+            report(schema.validate(&document), document_path, out, err)
+        }
         Err(error) => {
             let _ = writeln!(err, "{error}");
             2

--- a/reference-implementations/rust/src/schema.rs
+++ b/reference-implementations/rust/src/schema.rs
@@ -13,6 +13,7 @@ use std::path::{Path, PathBuf};
 use regex::Regex;
 use toml::value::{Datetime, Offset};
 use toml::{Table, Value};
+use url::Url;
 
 /// Built-in TOML Schema types.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -98,7 +99,6 @@ pub const DEFINITION_KEYS: &[&str] = &[
     "pattern",
     "keypattern",
     "optional",
-    "default",
     "min",
     "max",
     "minlength",
@@ -159,6 +159,8 @@ impl ValidationResult {
 #[derive(Debug, Clone)]
 pub struct Schema {
     source: PathBuf,
+    version: String,
+    warnings: Vec<String>,
     types: BTreeMap<String, Definition>,
     elements: BTreeMap<String, Definition>,
 }
@@ -193,6 +195,10 @@ impl Schema {
             .get("version")
             .ok_or_else(|| "[toml-schema] must contain version".to_string())?;
         Self::validate_schema_version(version)?;
+        let version = version
+            .as_str()
+            .expect("schema version was validated as a string")
+            .to_string();
         for key in metadata.keys() {
             if key != "version" && key != "meta" {
                 return Err(format!("unsupported [toml-schema] key: {key}"));
@@ -204,6 +210,8 @@ impl Schema {
         let elements = parse_definitions("elements", elements_table, true)?;
         let schema = Schema {
             source,
+            version,
+            warnings: Vec::new(),
             types,
             elements,
         };
@@ -214,6 +222,11 @@ impl Schema {
     /// Returns the path the schema was loaded from.
     pub fn source(&self) -> &Path {
         &self.source
+    }
+
+    /// Returns non-fatal warnings produced while discovering this schema.
+    pub fn warnings(&self) -> &[String] {
+        &self.warnings
     }
 
     fn validate_schema_version(value: &Value) -> Result<(), String> {
@@ -370,10 +383,67 @@ pub fn schema_from_document<P: AsRef<Path>>(document_path: P) -> Result<(Schema,
         .map(str::trim)
         .filter(|location| !location.is_empty())
         .ok_or_else(|| "document does not contain [toml-schema].location".to_string())?;
-    let directory = document_path.parent().unwrap_or_else(|| Path::new("."));
-    let schema_path = directory.join(location);
-    let schema = Schema::load(&schema_path)?;
+    let schema_path = resolve_schema_location(document_path, location)?;
+    let mut schema = Schema::load(&schema_path)?;
+    if let Some(expected_version) = metadata.get("version") {
+        if let Some(warning) = compare_document_schema_version(expected_version, &schema.version)? {
+            schema.warnings.push(warning);
+        }
+    }
     Ok((schema, document))
+}
+
+fn resolve_schema_location(document_path: &Path, location: &str) -> Result<PathBuf, String> {
+    let absolute_document_path = if document_path.is_absolute() {
+        document_path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map_err(|error| format!("invalid current directory: {error}"))?
+            .join(document_path)
+    };
+    let base = Url::from_file_path(&absolute_document_path)
+        .map_err(|_| format!("invalid document path: {}", document_path.display()))?;
+    let resolved = base
+        .join(location)
+        .map_err(|error| format!("invalid [toml-schema].location URI: {location}: {error}"))?;
+    if resolved.scheme() != "file" {
+        return Err(format!(
+            "unsupported schema location URI scheme: {}",
+            resolved.scheme()
+        ));
+    }
+    resolved
+        .to_file_path()
+        .map_err(|_| format!("invalid file schema location: {location}"))
+}
+
+fn compare_document_schema_version(value: &Value, actual: &str) -> Result<Option<String>, String> {
+    let expected = value
+        .as_str()
+        .ok_or_else(|| "document [toml-schema].version must be a SemVer string".to_string())?;
+    let semver = Regex::new(
+        r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-((?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$",
+    )
+    .expect("valid SemVer regex");
+    let expected_parts = semver.captures(expected).ok_or_else(|| {
+        "document [toml-schema].version must use SemVer MAJOR.MINOR.PATCH syntax".to_string()
+    })?;
+    let actual_parts = semver
+        .captures(actual)
+        .expect("loaded schema version was already validated");
+    if expected_parts.get(1).map(|part| part.as_str())
+        != actual_parts.get(1).map(|part| part.as_str())
+    {
+        return Err(format!(
+            "document expects TOML Schema major version {expected}, but resolved schema uses {actual}"
+        ));
+    }
+    if expected != actual {
+        return Ok(Some(format!(
+            "Warning: document expects TOML Schema version {expected}, but resolved schema uses {actual}"
+        )));
+    }
+    Ok(None)
 }
 
 fn parse_toml_file(path: &Path) -> Result<Table, String> {
@@ -503,6 +573,21 @@ fn parse_definition(name: &str, table: &Table) -> Result<Definition, String> {
     if key_pattern.is_some() && type_name != Some(SchemaType::Collection) {
         return Err(format!(
             "{name} can only define keypattern when type is collection"
+        ));
+    }
+    if pattern.is_some() && type_name != Some(SchemaType::String) {
+        return Err(format!(
+            "{name} can only define pattern when type is string"
+        ));
+    }
+    if (min_length.is_some() || max_length.is_some())
+        && !matches!(
+            type_name,
+            Some(SchemaType::String | SchemaType::Array | SchemaType::Collection)
+        )
+    {
+        return Err(format!(
+            "{name} can only define minlength or maxlength when type is string, array, or collection"
         ));
     }
     if type_name == Some(SchemaType::Collection) && item_reference.is_none() {

--- a/reference-implementations/rust/tests/integration.rs
+++ b/reference-implementations/rust/tests/integration.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 
 use toml_schema::cli::run;
 use toml_schema::schema::{Schema, ValidationResult};
+use url::Url;
 
 fn repository_root() -> PathBuf {
     // Tests run from `reference-implementations/rust`.
@@ -383,6 +384,17 @@ version = "1.0.0"
 type = "string"
 minlength = 5
 maxlength = 2
+"#,
+        ),
+        (
+            "incompatible-length",
+            r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "boolean"
+minlength = 1
 "#,
         ),
     ];
@@ -977,6 +989,39 @@ keypattern = "^[a-z]+$"
 
     let error = Schema::load(&schema_path).expect_err("expected keypattern on scalar rejection");
     assert!(error.contains("keypattern"));
+}
+
+#[test]
+fn rejects_pattern_on_non_string_and_undocumented_default() {
+    let directory = tempfile_dir("invalid-pattern-and-default");
+    let cases = [
+        (
+            "pattern-integer",
+            r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "integer"
+pattern = "^[0-9]+$"
+"#,
+        ),
+        (
+            "default",
+            r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "string"
+default = "value"
+"#,
+        ),
+    ];
+    for (name, content) in cases {
+        let schema_path = write_file(&directory, &format!("{name}.tosd"), content);
+        Schema::load(&schema_path).expect_err("expected malformed schema");
+    }
 }
 
 #[test]
@@ -1582,6 +1627,71 @@ location = "schema.tosd"
         stdout.contains("is valid"),
         "expected valid output, got {stdout:?}"
     );
+}
+
+#[test]
+fn cli_resolves_file_uri_and_enforces_document_schema_version() {
+    let directory = tempfile_dir("cli-schema-reference-semantics");
+    let schema_path = write_file(
+        &directory,
+        "schema.tosd",
+        r#"
+[toml-schema]
+version = "1.0.1"
+
+[elements.title]
+type = "string"
+"#,
+    );
+    let file_uri = Url::from_file_path(&schema_path)
+        .expect("schema file URI")
+        .to_string();
+    let cases = [
+        (
+            "file-uri-warning",
+            r#"version = "1.0.0""#,
+            file_uri.as_str(),
+            0,
+            "Warning: document expects TOML Schema version 1.0.0, but resolved schema uses 1.0.1",
+        ),
+        (
+            "major-version-mismatch",
+            r#"version = "2.0.0""#,
+            file_uri.as_str(),
+            2,
+            "document expects TOML Schema major version 2.0.0, but resolved schema uses 1.0.1",
+        ),
+        (
+            "unsupported-scheme",
+            "",
+            "https://example.com/schema.tosd",
+            2,
+            "unsupported schema location URI scheme: https",
+        ),
+    ];
+
+    for (name, version, location, expected_code, expected_error) in cases {
+        let document_path = write_file(
+            &directory,
+            &format!("{name}.toml"),
+            &format!(
+                r#"
+title = "Example"
+
+[toml-schema]
+{version}
+location = {location:?}
+"#
+            ),
+        );
+        let (exit_code, _stdout, stderr) = capture(&["validate", document_path.to_str().unwrap()]);
+
+        assert_eq!(exit_code, expected_code, "{stderr}");
+        assert!(
+            stderr.contains(expected_error),
+            "expected {expected_error:?}, got {stderr:?}"
+        );
+    }
 }
 
 #[test]

--- a/toml-schema.abnf
+++ b/toml-schema.abnf
@@ -22,11 +22,11 @@ metadata-table    = toml-table-header-toml-schema-meta *toml-keyval
 schema-definition = schema-definition-table *definition-property *schema-definition
 
 schema-key = type / description / itemtype / items / oneof / anyof
-           / allowedvalues / pattern / keypattern / optional / default / min / max
+           / allowedvalues / pattern / keypattern / optional / min / max
            / minlength / maxlength
 
 definition-property = type / description / itemtype / items / oneof / anyof
-                    / allowedvalues / pattern / keypattern / optional / default / min / max
+                    / allowedvalues / pattern / keypattern / optional / min / max
                     / minlength / maxlength
 
 version       = "version" keyval-sep semver-string
@@ -40,7 +40,6 @@ allowedvalues = "allowedvalues" keyval-sep toml-array
 pattern       = "pattern" keyval-sep toml-string
 keypattern    = "keypattern" keyval-sep toml-string ; collection dynamic-entry keys must match this regular expression
 optional      = "optional" keyval-sep toml-boolean
-default       = "default" keyval-sep toml-value
 min           = "min" keyval-sep range-boundary
 max           = "max" keyval-sep range-boundary
 minlength     = "minlength" keyval-sep toml-integer ; strings count Unicode scalar values after TOML parsing


### PR DESCRIPTION
TOML Schema currently permits several constructs that are either silently ignored or interpreted differently across reference implementations. This aligns the normative specification, grammar, validators, and visual editor so schema authors receive consistent behavior.

## Summary

- Reject `pattern`, `minlength`, and `maxlength` when attached to incompatible node types instead of silently ignoring them.
- Align Go and Rust schema discovery with the URI resolution and document-version warning/error semantics already defined by the specification.
- Define a portable RE2-based regular-expression profile and align Java's end-anchor behavior with it.
- Remove the undocumented and inert `default` property from the grammar, implementations, editor, and generation guidance.
- Update the TOSD editor to surface removed or incompatible properties as errors.
- Add regression coverage across Java, Go, and Rust, including file URI discovery, version mismatches, empty patterns, and portable anchor behavior.

## Validation

- Java Maven test suite
- Go test suite
- Rust test suite with the locked dependency graph
- TOSD editor syntax and model validation checks