### PR TITLE
Enforce TOML Schema structural validity

### DIFF
--- a/.github/extensions/tosd-editor/model.mjs
+++ b/.github/extensions/tosd-editor/model.mjs
@@ -11,7 +11,7 @@
 // node = { name, props: { <prop>: <editorValue> }, children: [ node, ... ] }
 //
 // Editor value encoding per property:
-//   type/itemtype/pattern/keypattern : plain string
+//   type/itemtype/description/pattern/keypattern : plain string
 //   optional                               : boolean
 //   minlength/maxlength                    : number
 //   items/oneof/anyof                      : string[]  (type references)
@@ -28,6 +28,7 @@ import {
 
 export const PROP_ORDER = [
     "type",
+    "description",
     "itemtype",
     "items",
     "oneof",
@@ -42,7 +43,7 @@ export const PROP_ORDER = [
     "optional",
 ];
 
-const STRING_PROPS = new Set(["type", "itemtype", "pattern", "keypattern"]);
+const STRING_PROPS = new Set(["type", "description", "itemtype", "pattern", "keypattern"]);
 const INT_PROPS = new Set(["minlength", "maxlength"]);
 const BOOL_PROPS = new Set(["optional"]);
 const REFLIST_PROPS = new Set(["items", "oneof", "anyof"]);
@@ -199,7 +200,7 @@ function encodeProp(key, raw) {
     if (INT_PROPS.has(key)) return Math.trunc(Number(raw));
     if (REFLIST_PROPS.has(key)) {
         const arr = (Array.isArray(raw) ? raw : []).map(String).filter((s) => s !== "");
-        return arr.length ? arr : undefined;
+        return arr;
     }
     if (VALUELIST_PROPS.has(key)) {
         const arr = (Array.isArray(raw) ? raw : [])
@@ -268,6 +269,7 @@ export function validateModel(model) {
         if (BUILTIN_TYPES.includes(name)) return true;
         return typeNames.has(name);
     };
+    const normalizeRef = (ref) => ref?.startsWith("types.") ? ref.slice(6) : ref;
 
     const resolvedKinds = (ref, seen = new Set()) => {
         if (!ref) return new Set();
@@ -298,12 +300,33 @@ export function validateModel(model) {
             issues.push({ level: "error", path: label, message: "`default` is not a TOML Schema property." });
         }
 
-        const exclusivity = ["type", "oneof", "anyof"].filter((k) => p[k] != null && p[k] !== "" && !(Array.isArray(p[k]) && p[k].length === 0));
+        const exclusivity = ["type", "oneof", "anyof"].filter((k) => Object.prototype.hasOwnProperty.call(p, k));
+        for (const key of ["type", "itemtype"]) {
+            if (Object.prototype.hasOwnProperty.call(p, key) && !String(p[key]).trim()) {
+                issues.push({ level: "error", path: label, message: `\`${key}\` must not be blank.` });
+            }
+        }
         if (exclusivity.length > 1) {
             issues.push({ level: "error", path: label, message: "`type`, `oneof`, and `anyof` are mutually exclusive." });
         }
         if (exclusivity.length === 0 && (!node.children || node.children.length === 0)) {
-            issues.push({ level: "warning", path: label, message: "No type, oneof, anyof, or children - defaults to an open table." });
+            issues.push({ level: "error", path: label, message: "A definition must select a type or contain child definitions." });
+        }
+        for (const unionKey of ["oneof", "anyof"]) {
+            if (Object.prototype.hasOwnProperty.call(p, unionKey) && (!Array.isArray(p[unionKey]) || p[unionKey].length === 0)) {
+                issues.push({ level: "error", path: label, message: `\`${unionKey}\` must contain at least one type reference.` });
+            }
+        }
+        if (Object.prototype.hasOwnProperty.call(p, "oneof") || Object.prototype.hasOwnProperty.call(p, "anyof")) {
+            const allowed = new Set(["oneof", "anyof", "description", "optional"]);
+            for (const key of Object.keys(p)) {
+                if (!allowed.has(key)) {
+                    issues.push({ level: "error", path: label, message: `A union cannot define \`${key}\`.` });
+                }
+            }
+        }
+        if ((node.children || []).length > 0 && !["table", "collection"].includes(p.type) && exclusivity.length > 0) {
+            issues.push({ level: "error", path: label, message: "Child definitions require the built-in type `table` or `collection`." });
         }
 
         if (p.items && p.itemtype) {
@@ -355,7 +378,9 @@ export function validateModel(model) {
         }
         for (const listKey of ["items", "oneof", "anyof"]) {
             for (const ref of p[listKey] || []) {
-                if (ref && !refExists(ref)) {
+                if (!String(ref).trim()) {
+                    issues.push({ level: "error", path: label, message: `Type references in ${listKey} must not be blank.` });
+                } else if (!refExists(ref)) {
                     issues.push({ level: "error", path: label, message: `Unknown type reference in ${listKey}: "${ref}".` });
                 }
             }
@@ -368,6 +393,24 @@ export function validateModel(model) {
 
     for (const t of model.types || []) walk(t, `types.${t.name}`);
     for (const e of model.elements || []) walk(e, `elements.${e.name}`);
+
+    const visited = new Set();
+    const visitSelector = (name, visiting = new Set()) => {
+        name = normalizeRef(name);
+        if (!name || BUILTIN_TYPES.includes(name) || visited.has(name) || !typesByName.has(name)) return;
+        if (visiting.has(name)) {
+            issues.push({ level: "error", path: `types.${name}`, message: "Cyclic type selector reference." });
+            return;
+        }
+        const nextVisiting = new Set(visiting).add(name);
+        const props = typesByName.get(name).props || {};
+        if (props.type) visitSelector(props.type, nextVisiting);
+        for (const ref of [...(props.oneof || []), ...(props.anyof || [])]) {
+            visitSelector(ref, nextVisiting);
+        }
+        visited.add(name);
+    };
+    for (const name of typeNames) visitSelector(name);
 
     if (!/^\d+\.\d+\.\d+/.test(model.version || "")) {
         issues.push({ level: "error", path: "toml-schema.version", message: "version must be a full SemVer string (e.g. 1.0.0)." });

--- a/SPEC.md
+++ b/SPEC.md
@@ -253,6 +253,24 @@ definitions. A named definition that declares a complete collection or selects
 
 `type`, `oneof`, and `anyof` are alternative ways to select the type of the current schema node. Every definition MUST declare exactly one of them, except that a definition with nested child definitions MAY omit all three and is then treated as `type = "table"`. Parsers MUST reject a definition that declares more than one of these properties, or that declares none of them and has no nested child definitions. `type` accepts either a built-in type name or a named reusable definition from `[types]`. Container member types are selected separately with `itemtype`: it validates each member of an `array` or each dynamically keyed value of a `collection`. `itemtype` requires the same definition to declare the built-in `type = "array"` or `type = "collection"`; it cannot be attached to another built-in or to a named type reference.
 
+Nested child definitions are valid only when the current node selects the
+built-in `table` or `collection` type, or when the node omits a selector and is
+therefore an implicit table. Parsers MUST reject child definitions attached to
+a scalar, `array`, named type reference, `oneof`, or `anyof` node rather than
+silently ignoring them.
+
+Every named reference used by `type`, `itemtype`, `items`, `oneof`, or `anyof`
+MUST resolve to a definition in `[types]`. Parsers MUST reject unresolved
+references at schema-load time, including references in definitions that are
+optional or not exercised by the document being validated.
+
+Type-selection references MUST be acyclic. A cycle composed of named `type`
+aliases, `oneof` alternatives, or `anyof` alternatives cannot resolve to a
+concrete definition and parsers MUST reject it at schema-load time. Structural
+recursion through table or collection children, array `itemtype`, or tuple
+`items` remains valid because each recursive step consumes a nested document
+value.
+
 ```toml
 [types]
 
@@ -697,6 +715,13 @@ The bare built-in names `any` and `collection` MUST NOT appear directly in
 fully defined collection or an intentionally unconstrained named branch.
 
 `type`, `oneof`, and `anyof` all select the current node's type and are mutually exclusive. A parser MUST reject a definition containing more than one of them.
+
+The array assigned to `oneof` or `anyof` MUST contain at least one type
+reference. A union definition MAY additionally declare only `description` and
+`optional`; it MUST NOT declare another validation property or any nested child
+definition. Parsers MUST reject empty unions and union siblings at schema-load
+time. Constraints required by an alternative belong in a named reusable
+definition referenced by the union.
 
 ```toml
 [types.stringId]

--- a/reference-implementations/go/schema.go
+++ b/reference-implementations/go/schema.go
@@ -39,6 +39,7 @@ var definitionKeys = map[string]bool{
 }
 
 var namedReferenceKeys = map[string]bool{"type": true, "description": true, "optional": true}
+var unionKeys = map[string]bool{"oneof": true, "anyof": true, "description": true, "optional": true}
 
 const currentTomlSchemaVersion = "1.0.0"
 
@@ -154,6 +155,15 @@ func LoadSchema(path string) (*Schema, error) {
 		return nil, err
 	}
 	schema := &Schema{source: path, version: version.(string), types: types, elements: elements}
+	if err := schema.validateReferences(types); err != nil {
+		return nil, err
+	}
+	if err := schema.validateReferences(elements); err != nil {
+		return nil, err
+	}
+	if err := schema.validateSelectorCycles(); err != nil {
+		return nil, err
+	}
 	if err := schema.validateArrayRanges(); err != nil {
 		return nil, err
 	}
@@ -250,6 +260,9 @@ func parseDefinition(name string, table map[string]any) (Definition, error) {
 	if err != nil {
 		return Definition{}, err
 	}
+	if propertyValue(table, "type") != nil && typeSelector == "" {
+		return Definition{}, fmt.Errorf("%s type must not be blank", name)
+	}
 	var typeName SchemaType
 	var reference string
 	if typeSelector != "" {
@@ -273,6 +286,9 @@ func parseDefinition(name string, table map[string]any) (Definition, error) {
 	itemReference, err := getString(table, "itemtype")
 	if err != nil {
 		return Definition{}, err
+	}
+	if propertyValue(table, "itemtype") != nil && itemReference == "" {
+		return Definition{}, fmt.Errorf("%s itemtype must not be blank", name)
 	}
 	items, err := getStringArrayValues(table, "items")
 	if err != nil {
@@ -302,6 +318,8 @@ func parseDefinition(name string, table map[string]any) (Definition, error) {
 	if err != nil {
 		return Definition{}, err
 	}
+	hasOneOf := propertyValue(table, "oneof") != nil
+	hasAnyOf := propertyValue(table, "anyof") != nil
 	oneOf, err := getStringArrayValues(table, "oneof")
 	if err != nil {
 		return Definition{}, err
@@ -309,6 +327,21 @@ func parseDefinition(name string, table map[string]any) (Definition, error) {
 	anyOf, err := getStringArrayValues(table, "anyof")
 	if err != nil {
 		return Definition{}, err
+	}
+	for property, references := range map[string][]string{
+		"items": items, "oneof": oneOf, "anyof": anyOf,
+	} {
+		for _, reference := range references {
+			if reference == "" {
+				return Definition{}, fmt.Errorf("%s %s references must not be blank", name, property)
+			}
+		}
+	}
+	if hasOneOf && len(oneOf) == 0 {
+		return Definition{}, fmt.Errorf("%s oneof must contain at least one type reference", name)
+	}
+	if hasAnyOf && len(anyOf) == 0 {
+		return Definition{}, fmt.Errorf("%s anyof must contain at least one type reference", name)
 	}
 	if err := rejectBareCollectionReference(name, "itemtype", itemReference); err != nil {
 		return Definition{}, err
@@ -329,10 +362,10 @@ func parseDefinition(name string, table map[string]any) (Definition, error) {
 	if typeSelector != "" {
 		typeSelectors++
 	}
-	if len(oneOf) > 0 {
+	if hasOneOf {
 		typeSelectors++
 	}
-	if len(anyOf) > 0 {
+	if hasAnyOf {
 		typeSelectors++
 	}
 	if typeSelectors > 1 {
@@ -354,11 +387,21 @@ func parseDefinition(name string, table map[string]any) (Definition, error) {
 			return Definition{}, fmt.Errorf("%s contains unsupported property: %s", name, key)
 		}
 	}
-	if typeName == "" && reference == "" && len(oneOf) == 0 && len(anyOf) == 0 {
+	if hasOneOf || hasAnyOf {
+		for key := range table {
+			if !unionKeys[key] {
+				return Definition{}, fmt.Errorf("%s union cannot define %s", name, key)
+			}
+		}
+	}
+	if typeName == "" && reference == "" && !hasOneOf && !hasAnyOf {
 		if len(children) == 0 {
 			return Definition{}, fmt.Errorf("%s must define type, oneof, anyof, or child definitions", name)
 		}
 		typeName = TypeTable
+	}
+	if len(children) > 0 && typeName != TypeTable && typeName != TypeCollection {
+		return Definition{}, fmt.Errorf("%s can only define children when type is table or collection", name)
 	}
 	if typeName != TypeArray && typeName != TypeCollection && itemReference != "" {
 		return Definition{}, fmt.Errorf("%s can only define itemtype when type is array or collection", name)
@@ -409,6 +452,67 @@ func parseDefinition(name string, table map[string]any) (Definition, error) {
 		minLength: minLength, maxLength: maxLength, oneOf: normalizeReferences(oneOf), anyOf: normalizeReferences(anyOf),
 		children: children,
 	}, nil
+}
+
+func (s *Schema) validateReferences(definitions map[string]Definition) error {
+	for _, definition := range definitions {
+		references := []string{definition.reference, definition.itemReference}
+		references = append(references, definition.items...)
+		references = append(references, definition.oneOf...)
+		references = append(references, definition.anyOf...)
+		for _, reference := range references {
+			if reference == "" {
+				continue
+			}
+			if _, builtIn := parseSchemaType(reference); builtIn {
+				continue
+			}
+			if _, exists := s.types[reference]; !exists {
+				return fmt.Errorf("%s contains unknown type reference: %s", definition.name, reference)
+			}
+		}
+		if err := s.validateReferences(definition.children); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Schema) validateSelectorCycles() error {
+	visited := map[string]bool{}
+	for typeName := range s.types {
+		if err := s.validateSelectorCycle(typeName, map[string]bool{}, visited); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Schema) validateSelectorCycle(typeName string, visiting, visited map[string]bool) error {
+	if _, builtIn := parseSchemaType(typeName); builtIn || visited[typeName] {
+		return nil
+	}
+	if visiting[typeName] {
+		return fmt.Errorf("cyclic type selector reference involving types.%s", typeName)
+	}
+	definition, exists := s.types[typeName]
+	if !exists {
+		return nil
+	}
+	visiting[typeName] = true
+	references := []string{definition.reference}
+	references = append(references, definition.oneOf...)
+	references = append(references, definition.anyOf...)
+	for _, reference := range references {
+		if reference != "" {
+			if err := s.validateSelectorCycle(reference, visiting, visited); err != nil {
+				return err
+			}
+		}
+	}
+	delete(visiting, typeName)
+	visited[typeName] = true
+	return nil
 }
 
 func rejectBareCollectionReferences(name, property string, references []string) error {

--- a/reference-implementations/go/schema_test.go
+++ b/reference-implementations/go/schema_test.go
@@ -621,6 +621,99 @@ flex = "abc"
 	}
 }
 
+func TestRejectsInvalidUnionStructureAndChildPlacement(t *testing.T) {
+	invalidDefinitions := []string{
+		`oneof = []`,
+		`anyof = []`,
+		"oneof = [ \"string\" ]\npattern = \"x\"",
+		"oneof = [ \"string\" ]\n\n[elements.value.child]\ntype = \"string\"",
+		"type = \"string\"\n\n[elements.value.child]\ntype = \"string\"",
+		"type = \"array\"\n\n[elements.value.child]\ntype = \"string\"",
+	}
+
+	for index, definition := range invalidDefinitions {
+		dir := t.TempDir()
+		schemaPath := write(t, dir, fmt.Sprintf("invalid-structure-%d.tosd", index), fmt.Sprintf(`
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+%s
+`, definition))
+		if _, err := LoadSchema(schemaPath); err == nil {
+			t.Fatalf("expected invalid structure %d to be rejected", index)
+		}
+	}
+}
+
+func TestValidatesReferenceGraphAtSchemaLoadTime(t *testing.T) {
+	invalidReferences := []string{
+		`type = ""`,
+		`type = "types.missing"`,
+		"type = \"array\"\nitemtype = \"\"",
+		"type = \"array\"\nitemtype = \"types.missing\"",
+		"type = \"array\"\nitems = [ \"\" ]",
+		"type = \"array\"\nitems = [ \"types.missing\" ]",
+		`oneof = [ "" ]`,
+		`oneof = [ "types.missing" ]`,
+		`anyof = [ "" ]`,
+		`anyof = [ "types.missing" ]`,
+		"type = \"table\"\n\n[elements.value.child]\ntype = \"types.missing\"",
+	}
+	for index, definition := range invalidReferences {
+		dir := t.TempDir()
+		schemaPath := write(t, dir, fmt.Sprintf("dangling-reference-%d.tosd", index), fmt.Sprintf(`
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+%s
+`, definition))
+		if _, err := LoadSchema(schemaPath); err == nil {
+			t.Fatalf("expected dangling reference %d to be rejected", index)
+		}
+	}
+
+	cycles := []string{
+		"[types.first]\ntype = \"types.second\"\n\n[types.second]\ntype = \"types.first\"",
+		"[types.first]\noneof = [ \"types.second\" ]\n\n[types.second]\nanyof = [ \"types.first\" ]",
+	}
+	for index, cycle := range cycles {
+		dir := t.TempDir()
+		schemaPath := write(t, dir, fmt.Sprintf("selector-cycle-%d.tosd", index), fmt.Sprintf(`
+[toml-schema]
+version = "1.0.0"
+
+%s
+
+[elements.value]
+type = "string"
+`, cycle))
+		if _, err := LoadSchema(schemaPath); err == nil {
+			t.Fatalf("expected selector cycle %d to be rejected", index)
+		}
+	}
+
+	dir := t.TempDir()
+	recursive := write(t, dir, "recursive-structure.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[types.node]
+type = "table"
+
+    [types.node.children]
+    type = "array"
+    itemtype = "types.node"
+
+[elements.root]
+type = "types.node"
+`)
+	if _, err := LoadSchema(recursive); err != nil {
+		t.Fatalf("expected structural recursion to load: %v", err)
+	}
+}
+
 func TestValidatesAllowedValuesForArrayWithoutItemtype(t *testing.T) {
 	dir := t.TempDir()
 	schemaPath := write(t, dir, "array-allowedvalues.tosd", `
@@ -701,18 +794,8 @@ version = "1.0.0"
 [elements.items]
 type = "table-collection"
 `)
-	documentPath := write(t, dir, "document.toml", `
-[items]
-name = "example"
-`)
-
-	schema, err := LoadSchema(schemaPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	result := schema.ValidateFile(documentPath)
-	if result.Valid() || !strings.Contains(result.Errors[0].Message, "unknown type reference") {
-		t.Fatalf("expected table-collection to be rejected as an unknown reference, got %#v", result.Errors)
+	if _, err := LoadSchema(schemaPath); err == nil {
+		t.Fatal("expected table-collection to be rejected at schema load time")
 	}
 }
 

--- a/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
@@ -30,6 +30,7 @@ final class SchemaLoader {
             "oneof", "anyof"
     );
     private static final Set<String> NAMED_REFERENCE_KEYS = Set.of("type", "description", "optional");
+    private static final Set<String> UNION_KEYS = Set.of("oneof", "anyof", "description", "optional");
 
     TomlSchema load(Path schemaPath) {
         TomlParseResult parsed;
@@ -44,6 +45,9 @@ final class SchemaLoader {
         String version = validateTopLevel(parsed);
         Map<String, SchemaDefinition> types = parseDefinitions("types", parsed.getTable("types"), false);
         Map<String, SchemaDefinition> elements = parseDefinitions("elements", parsed.getTable("elements"), true);
+        validateReferences(types, types);
+        validateReferences(types, elements);
+        validateSelectorCycles(types);
         validateArrayRangeConstraints(types, types);
         validateArrayRangeConstraints(types, elements);
         return new TomlSchema(schemaPath, version, types, elements);
@@ -121,8 +125,16 @@ final class SchemaLoader {
         Integer minLength = getInteger(table, "minlength");
         Integer maxLength = getInteger(table, "maxlength");
         List<Object> allowedValues = getArrayValues(table, "allowedvalues");
+        boolean hasOneOf = getPropertyValue(table, "oneof") != null;
+        boolean hasAnyOf = getPropertyValue(table, "anyof") != null;
         List<String> oneOf = getStringArrayValues(table, "oneof");
         List<String> anyOf = getStringArrayValues(table, "anyof");
+        if (hasOneOf && oneOf.isEmpty()) {
+            throw new SchemaException(name + " oneof must contain at least one type reference");
+        }
+        if (hasAnyOf && anyOf.isEmpty()) {
+            throw new SchemaException(name + " anyof must contain at least one type reference");
+        }
         rejectBareCollectionReference(name, "itemtype", itemReference);
         rejectBareCollectionReferences(name, "items", items);
         validateAlternativeReferences(name, "oneof", oneOf);
@@ -133,8 +145,8 @@ final class SchemaLoader {
             throw new SchemaException(name + " cannot use collection as a bare type reference");
         }
         int typeSelectors = (typeSelector == null ? 0 : 1)
-                + (oneOf.isEmpty() ? 0 : 1)
-                + (anyOf.isEmpty() ? 0 : 1);
+                + (hasOneOf ? 1 : 0)
+                + (hasAnyOf ? 1 : 0);
         if (typeSelectors > 1) {
             throw new SchemaException(name + " cannot define more than one of type, oneof, and anyof");
         }
@@ -151,11 +163,21 @@ final class SchemaLoader {
                 throw new SchemaException(name + " contains unsupported property: " + key);
             }
         }
-        if (type == null && normalizedReference == null && oneOf.isEmpty() && anyOf.isEmpty()) {
+        if (hasOneOf || hasAnyOf) {
+            for (String key : table.keySet()) {
+                if (!UNION_KEYS.contains(key)) {
+                    throw new SchemaException(name + " union cannot define " + key);
+                }
+            }
+        }
+        if (type == null && normalizedReference == null && !hasOneOf && !hasAnyOf) {
             if (children.isEmpty()) {
                 throw new SchemaException(name + " must define type, oneof, anyof, or child definitions");
             }
             type = SchemaType.TABLE;
+        }
+        if (!children.isEmpty() && type != SchemaType.TABLE && type != SchemaType.COLLECTION) {
+            throw new SchemaException(name + " can only define children when type is table or collection");
         }
         if (type != SchemaType.ARRAY && type != SchemaType.COLLECTION && itemReference != null) {
             throw new SchemaException(name + " can only define itemtype when type is array or collection");
@@ -213,6 +235,75 @@ final class SchemaLoader {
                 anyOf.stream().map(this::normalizeReference).toList(),
                 children
         );
+    }
+
+    private void validateReferences(
+            Map<String, SchemaDefinition> types,
+            Map<String, SchemaDefinition> definitions
+    ) {
+        for (SchemaDefinition definition : definitions.values()) {
+            validateReference(types, definition.name(), definition.reference());
+            validateReference(types, definition.name(), definition.itemReference());
+            for (String reference : definition.items()) {
+                validateReference(types, definition.name(), reference);
+            }
+            for (String reference : definition.oneOf()) {
+                validateReference(types, definition.name(), reference);
+            }
+            for (String reference : definition.anyOf()) {
+                validateReference(types, definition.name(), reference);
+            }
+            validateReferences(types, definition.children());
+        }
+    }
+
+    private void validateReference(
+            Map<String, SchemaDefinition> types,
+            String definitionName,
+            String reference
+    ) {
+        if (reference == null || SchemaType.fromSchemaNameOptional(reference).isPresent()) {
+            return;
+        }
+        if (!types.containsKey(reference)) {
+            throw new SchemaException(definitionName + " contains unknown type reference: " + reference);
+        }
+    }
+
+    private void validateSelectorCycles(Map<String, SchemaDefinition> types) {
+        Set<String> visited = new HashSet<>();
+        for (String typeName : types.keySet()) {
+            validateSelectorCycle(typeName, types, new HashSet<>(), visited);
+        }
+    }
+
+    private void validateSelectorCycle(
+            String typeName,
+            Map<String, SchemaDefinition> types,
+            Set<String> visiting,
+            Set<String> visited
+    ) {
+        if (SchemaType.fromSchemaNameOptional(typeName).isPresent() || visited.contains(typeName)) {
+            return;
+        }
+        if (!visiting.add(typeName)) {
+            throw new SchemaException("Cyclic type selector reference involving types." + typeName);
+        }
+        SchemaDefinition definition = types.get(typeName);
+        if (definition == null) {
+            return;
+        }
+        if (definition.reference() != null) {
+            validateSelectorCycle(definition.reference(), types, visiting, visited);
+        }
+        for (String reference : definition.oneOf()) {
+            validateSelectorCycle(reference, types, visiting, visited);
+        }
+        for (String reference : definition.anyOf()) {
+            validateSelectorCycle(reference, types, visiting, visited);
+        }
+        visiting.remove(typeName);
+        visited.add(typeName);
     }
 
     private void rejectBareCollectionReferences(String name, String property, List<String> references) {

--- a/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
+++ b/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
@@ -267,13 +267,7 @@ class TomlSchemaTest {
                 [elements.items]
                 type = "table-collection"
                 """);
-        Path document = write("table-collection-alias.toml", """
-                [items]
-                name = "example"
-                """);
-
-        TomlSchema loaded = TomlSchema.load(schema);
-        assertThrows(SchemaException.class, () -> loaded.validate(document));
+        assertThrows(SchemaException.class, () -> TomlSchema.load(schema));
     }
 
     @Test
@@ -543,6 +537,136 @@ class TomlSchemaTest {
 
             assertThrows(SchemaException.class, () -> TomlSchema.load(schema));
         }
+    }
+
+    @Test
+    void rejectsInvalidUnionStructureAndChildPlacement() throws IOException {
+        List<String> invalidDefinitions = List.of(
+                "oneof = []",
+                "anyof = []",
+                """
+                oneof = [ "string" ]
+                pattern = "x"
+                """,
+                """
+                oneof = [ "string" ]
+
+                [elements.value.child]
+                type = "string"
+                """,
+                """
+                type = "string"
+
+                [elements.value.child]
+                type = "string"
+                """,
+                """
+                type = "array"
+
+                [elements.value.child]
+                type = "string"
+                """
+        );
+
+        for (int index = 0; index < invalidDefinitions.size(); index++) {
+            Path schema = write("invalid-structure-" + index + ".tosd", """
+                    [toml-schema]
+                    version = "1.0.0"
+
+                    [elements.value]
+                    %s
+                    """.formatted(invalidDefinitions.get(index)));
+
+            assertThrows(SchemaException.class, () -> TomlSchema.load(schema));
+        }
+    }
+
+    @Test
+    void validatesReferenceGraphAtSchemaLoadTime() throws IOException {
+        List<String> invalidReferences = List.of(
+                "type = \"\"",
+                "type = \"types.missing\"",
+                """
+                type = "array"
+                itemtype = ""
+                """,
+                """
+                type = "array"
+                itemtype = "types.missing"
+                """,
+                """
+                type = "array"
+                items = [ "" ]
+                """,
+                """
+                type = "array"
+                items = [ "types.missing" ]
+                """,
+                "oneof = [ \"\" ]",
+                "oneof = [ \"types.missing\" ]",
+                "anyof = [ \"\" ]",
+                "anyof = [ \"types.missing\" ]",
+                """
+                type = "table"
+
+                [elements.value.child]
+                type = "types.missing"
+                """
+        );
+        for (int index = 0; index < invalidReferences.size(); index++) {
+            Path schema = write("dangling-reference-" + index + ".tosd", """
+                    [toml-schema]
+                    version = "1.0.0"
+
+                    [elements.value]
+                    %s
+                    """.formatted(invalidReferences.get(index)));
+
+            assertThrows(SchemaException.class, () -> TomlSchema.load(schema));
+        }
+
+        for (String cycle : List.of(
+                """
+                [types.first]
+                type = "types.second"
+
+                [types.second]
+                type = "types.first"
+                """,
+                """
+                [types.first]
+                oneof = [ "types.second" ]
+
+                [types.second]
+                anyof = [ "types.first" ]
+                """
+        )) {
+            Path schema = write("selector-cycle-" + cycle.hashCode() + ".tosd", """
+                    [toml-schema]
+                    version = "1.0.0"
+                    %s
+
+                    [elements.value]
+                    type = "string"
+                    """.formatted(cycle));
+            assertThrows(SchemaException.class, () -> TomlSchema.load(schema));
+        }
+
+        Path recursive = write("recursive-structure.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [types.node]
+                type = "table"
+
+                    [types.node.children]
+                    type = "array"
+                    itemtype = "types.node"
+
+                [elements.root]
+                type = "types.node"
+                """);
+        assertDoesNotThrow(() -> TomlSchema.load(recursive));
     }
 
     @Test

--- a/reference-implementations/rust/src/schema.rs
+++ b/reference-implementations/rust/src/schema.rs
@@ -215,6 +215,9 @@ impl Schema {
             types,
             elements,
         };
+        schema.validate_references(&schema.types)?;
+        schema.validate_references(&schema.elements)?;
+        schema.validate_selector_cycles()?;
         schema.validate_array_range_definitions()?;
         Ok(schema)
     }
@@ -255,6 +258,67 @@ impl Schema {
         for definition in self.types.values().chain(self.elements.values()) {
             self.validate_array_range_definition(definition)?;
         }
+        Ok(())
+    }
+
+    fn validate_references(
+        &self,
+        definitions: &BTreeMap<String, Definition>,
+    ) -> Result<(), String> {
+        for definition in definitions.values() {
+            for reference in definition
+                .reference
+                .iter()
+                .chain(definition.item_reference.iter())
+                .chain(definition.items.iter())
+                .chain(definition.one_of.iter())
+                .chain(definition.any_of.iter())
+            {
+                if SchemaType::parse(reference).is_none() && !self.types.contains_key(reference) {
+                    return Err(format!(
+                        "{} contains unknown type reference: {reference}",
+                        definition.name
+                    ));
+                }
+            }
+            self.validate_references(&definition.children)?;
+        }
+        Ok(())
+    }
+
+    fn validate_selector_cycles(&self) -> Result<(), String> {
+        let mut visited = HashSet::new();
+        for type_name in self.types.keys() {
+            self.validate_selector_cycle(type_name, &mut HashSet::new(), &mut visited)?;
+        }
+        Ok(())
+    }
+
+    fn validate_selector_cycle(
+        &self,
+        type_name: &str,
+        visiting: &mut HashSet<String>,
+        visited: &mut HashSet<String>,
+    ) -> Result<(), String> {
+        if SchemaType::parse(type_name).is_some() || visited.contains(type_name) {
+            return Ok(());
+        }
+        if !visiting.insert(type_name.to_string()) {
+            return Err(format!(
+                "cyclic type selector reference involving types.{type_name}"
+            ));
+        }
+        let Some(definition) = self.types.get(type_name) else {
+            return Ok(());
+        };
+        if let Some(reference) = definition.reference.as_deref() {
+            self.validate_selector_cycle(reference, visiting, visited)?;
+        }
+        for reference in definition.one_of.iter().chain(definition.any_of.iter()) {
+            self.validate_selector_cycle(reference, visiting, visited)?;
+        }
+        visiting.remove(type_name);
+        visited.insert(type_name.to_string());
         Ok(())
     }
 
@@ -503,8 +567,20 @@ fn parse_definition(name: &str, table: &Table) -> Result<Definition, String> {
     let min_length = get_unsigned_integer(name, table, "minlength")?;
     let max_length = get_unsigned_integer(name, table, "maxlength")?;
     let allowed_values = get_array_values(name, table, "allowedvalues")?;
+    let has_one_of = property_value(table, "oneof").is_some();
+    let has_any_of = property_value(table, "anyof").is_some();
     let one_of = get_string_array_values(name, table, "oneof")?;
     let any_of = get_string_array_values(name, table, "anyof")?;
+    if has_one_of && one_of.is_empty() {
+        return Err(format!(
+            "{name} oneof must contain at least one type reference"
+        ));
+    }
+    if has_any_of && any_of.is_empty() {
+        return Err(format!(
+            "{name} anyof must contain at least one type reference"
+        ));
+    }
     reject_bare_collection_reference(name, "itemtype", item_reference.as_deref())?;
     reject_bare_collection_references(name, "items", &items)?;
     validate_alternative_references(name, "oneof", &one_of)?;
@@ -517,9 +593,8 @@ fn parse_definition(name: &str, table: &Table) -> Result<Definition, String> {
             "{name} cannot use collection as a bare type reference"
         ));
     }
-    let type_selectors = usize::from(type_selector.is_some())
-        + usize::from(!one_of.is_empty())
-        + usize::from(!any_of.is_empty());
+    let type_selectors =
+        usize::from(type_selector.is_some()) + usize::from(has_one_of) + usize::from(has_any_of);
     if type_selectors > 1 {
         return Err(format!(
             "{name} cannot define more than one of type, oneof, and anyof"
@@ -537,13 +612,27 @@ fn parse_definition(name: &str, table: &Table) -> Result<Definition, String> {
             return Err(format!("{name} contains unsupported property: {key}"));
         }
     }
-    if type_name.is_none() && reference.is_none() && one_of.is_empty() && any_of.is_empty() {
+    if has_one_of || has_any_of {
+        for key in table.keys() {
+            if !matches!(key.as_str(), "oneof" | "anyof" | "description" | "optional") {
+                return Err(format!("{name} union cannot define {key}"));
+            }
+        }
+    }
+    if type_name.is_none() && reference.is_none() && !has_one_of && !has_any_of {
         if children.is_empty() {
             return Err(format!(
                 "{name} must define type, oneof, anyof, or child definitions"
             ));
         }
         type_name = Some(SchemaType::Table);
+    }
+    if !children.is_empty()
+        && !matches!(type_name, Some(SchemaType::Table | SchemaType::Collection))
+    {
+        return Err(format!(
+            "{name} can only define children when type is table or collection"
+        ));
     }
     if !matches!(type_name, Some(SchemaType::Array | SchemaType::Collection))
         && item_reference.is_some()

--- a/reference-implementations/rust/tests/integration.rs
+++ b/reference-implementations/rust/tests/integration.rs
@@ -863,6 +863,115 @@ flex = "abc"
 }
 
 #[test]
+fn rejects_invalid_union_structure_and_child_placement() {
+    let invalid_definitions = [
+        "oneof = []",
+        "anyof = []",
+        "oneof = [ \"string\" ]\npattern = \"x\"",
+        "oneof = [ \"string\" ]\n\n[elements.value.child]\ntype = \"string\"",
+        "type = \"string\"\n\n[elements.value.child]\ntype = \"string\"",
+        "type = \"array\"\n\n[elements.value.child]\ntype = \"string\"",
+    ];
+
+    for (index, definition) in invalid_definitions.iter().enumerate() {
+        let directory = tempfile_dir(&format!("invalid-structure-{index}"));
+        let schema_path = write_file(
+            &directory,
+            "schema.tosd",
+            &format!(
+                r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+{definition}
+"#
+            ),
+        );
+        Schema::load(&schema_path).expect_err("invalid structure must be rejected");
+    }
+}
+
+#[test]
+fn validates_reference_graph_at_schema_load_time() {
+    let invalid_references = [
+        "type = \"\"",
+        "type = \"types.missing\"",
+        "type = \"array\"\nitemtype = \"\"",
+        "type = \"array\"\nitemtype = \"types.missing\"",
+        "type = \"array\"\nitems = [ \"\" ]",
+        "type = \"array\"\nitems = [ \"types.missing\" ]",
+        "oneof = [ \"\" ]",
+        "oneof = [ \"types.missing\" ]",
+        "anyof = [ \"\" ]",
+        "anyof = [ \"types.missing\" ]",
+        "type = \"table\"\n\n[elements.value.child]\ntype = \"types.missing\"",
+    ];
+    for (index, definition) in invalid_references.iter().enumerate() {
+        let directory = tempfile_dir(&format!("dangling-reference-{index}"));
+        let schema_path = write_file(
+            &directory,
+            "schema.tosd",
+            &format!(
+                r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+{definition}
+"#
+            ),
+        );
+        Schema::load(&schema_path).expect_err("dangling reference must be rejected");
+    }
+
+    let cycles = [
+        "[types.first]\ntype = \"types.second\"\n\n[types.second]\ntype = \"types.first\"",
+        "[types.first]\noneof = [ \"types.second\" ]\n\n[types.second]\nanyof = [ \"types.first\" ]",
+    ];
+    for (index, cycle) in cycles.iter().enumerate() {
+        let directory = tempfile_dir(&format!("selector-cycle-{index}"));
+        let schema_path = write_file(
+            &directory,
+            "schema.tosd",
+            &format!(
+                r#"
+[toml-schema]
+version = "1.0.0"
+
+{cycle}
+
+[elements.value]
+type = "string"
+"#
+            ),
+        );
+        Schema::load(&schema_path).expect_err("selector cycle must be rejected");
+    }
+
+    let directory = tempfile_dir("recursive-structure");
+    let schema_path = write_file(
+        &directory,
+        "schema.tosd",
+        r#"
+[toml-schema]
+version = "1.0.0"
+
+[types.node]
+type = "table"
+
+    [types.node.children]
+    type = "array"
+    itemtype = "types.node"
+
+[elements.root]
+type = "types.node"
+"#,
+    );
+    Schema::load(&schema_path).expect("structural recursion should load");
+}
+
+#[test]
 fn rejects_types_named_after_built_ins() {
     let directory = tempfile_dir("reserved-built-in");
     let schema_path = write_file(
@@ -898,21 +1007,7 @@ version = "1.0.0"
 type = "table-collection"
 "#,
     );
-    let document_path = write_file(
-        &directory,
-        "document.toml",
-        r#"
-[items]
-name = "example"
-"#,
-    );
-
-    let schema = Schema::load(&schema_path).expect("schema should parse the named reference");
-    let result = schema.validate_file(&document_path);
-    assert!(result
-        .errors
-        .iter()
-        .any(|error| error.message.contains("unknown type reference")));
+    Schema::load(&schema_path).expect_err("unknown reference must fail at schema load time");
 }
 
 #[test]


### PR DESCRIPTION
Malformed schema structures could previously survive loading and fail only when exercised, be silently ignored, or recurse indefinitely during validation. This makes structural validity explicit and consistent across the specification, all reference implementations, and the visual editor.

## Changes

- require non-empty `oneof` and `anyof` arrays and restrict union siblings to `description` and `optional`
- reject child definitions on scalar, array, named-reference, and union nodes while preserving implicit tables and explicit table/collection children
- resolve every `type`, `itemtype`, `items`, `oneof`, and `anyof` reference when loading a schema
- reject blank references and selector cycles while allowing structural recursion through children and container members
- add matching Java, Go, Rust, and editor regression coverage

## Validation

- Java Maven test suite
- Go test suite
- Rust test suite
- TOSD editor structural model probes