### PR TITLE
Define exact TOML value semantics

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -346,6 +346,20 @@ For a non-array simple type, when `allowedvalues` is combined with `pattern`, `m
 
 After a schema with `allowedvalues` has been loaded successfully, a document value is valid when it is a member of `allowedvalues`. Parsers do not need to re-evaluate the other constraints for that document value because every enumerated value has already been checked against them while loading the schema.
 
+Numeric membership compares mathematical values after TOML parsing. Integer
+comparison MUST remain exact across the full TOML signed 64-bit range, including
+when one operand is a float; implementations MUST NOT convert both operands to a
+binary float when that would lose integer precision. Positive and negative zero
+are equal. NaN is equal to NaN for `allowedvalues` membership, but is unequal to
+every other value.
+
+Temporal membership requires the same TOML temporal type and the same parsed
+fields, including the numeric UTC offset for an offset date-time. Equivalent
+spellings of the same field value, such as `.1` and `.100` fractional seconds or
+`Z` and `+00:00`, are equal. Two offset date-times that identify the same instant
+but have different local fields or numeric offsets therefore compare equal for
+range ordering but are distinct `allowedvalues` members.
+
 The rules for applying `allowedvalues` to array items are defined separately under [Observations on Conditions to Arrays](#observations-on-conditions-to-arrays).
 
 Example:
@@ -376,6 +390,20 @@ A `min` or `max` boundary must be a TOML value that is comparable with the schem
 `nan`, `+nan`, and `-nan` are not valid `min` or `max` boundaries because NaN is unordered. `inf`, `+inf`, and `-inf` are valid float boundaries.
 
 Date/time boundaries compare only against values of the same TOML temporal type. For example, an `offset-date-time` boundary applies to `offset-date-time` values, not to `local-date-time` values.
+
+Numeric ranges use mathematical ordering after TOML parsing. Integer-to-integer
+ordering MUST remain exact across the full signed 64-bit range. Mixed
+integer/float ordering MUST compare the exact integer with the parsed binary
+floating-point value without first rounding the integer to that floating-point
+format. Positive and negative zero have the same position. A document NaN is
+unordered and never satisfies a range constraint.
+
+Offset date-times are ordered by the instant they identify after applying their
+offset; representations of the same instant compare equal even when their local
+fields and offsets differ. Local date-times, local dates, and local times are
+ordered lexicographically by their parsed fields, from the largest component to
+the smallest, including fractional seconds. No timezone or daylight-saving
+conversion is applied to a local temporal value.
 
 ### Length - `minlength` and `maxlength`
 

--- a/reference-implementations/go/schema.go
+++ b/reference-implementations/go/schema.go
@@ -3,6 +3,7 @@ package tomlschema
 import (
 	"fmt"
 	"math"
+	"math/big"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -682,8 +683,7 @@ func validateBoundaryMatchesType(name, key string, value any, typeName SchemaTyp
 func boundaryMatchesType(value any, typeName SchemaType) bool {
 	switch typeName {
 	case TypeInteger, TypeFloat:
-		_, ok := numeric(value)
-		return ok
+		return isNumeric(value)
 	case TypeOffsetDateTime:
 		_, ok := value.(time.Time)
 		return ok
@@ -1264,10 +1264,8 @@ func isType(value any, typeName SchemaType) bool {
 }
 
 func compare(value, boundary any) (int, error) {
-	if valueNumber, ok := numeric(value); ok {
-		if boundaryNumber, ok := numeric(boundary); ok {
-			return compareFloat(valueNumber, boundaryNumber), nil
-		}
+	if isNumeric(value) && isNumeric(boundary) {
+		return compareNumbers(value, boundary)
 	}
 	switch value := value.(type) {
 	case time.Time:
@@ -1298,24 +1296,97 @@ func compare(value, boundary any) (int, error) {
 	return 0, fmt.Errorf("cannot compare %s with boundary %s", typeNameOf(value), typeNameOf(boundary))
 }
 
-func numeric(value any) (float64, bool) {
-	switch value := value.(type) {
-	case int64:
-		return float64(value), true
-	case float64:
-		return value, true
+func valuesEqual(allowed, value any) bool {
+	if isNumeric(allowed) && isNumeric(value) {
+		if isNaN(allowed) || isNaN(value) {
+			return isNaN(allowed) && isNaN(value)
+		}
+		comparison, err := compareNumbers(allowed, value)
+		return err == nil && comparison == 0
+	}
+	switch allowed := allowed.(type) {
+	case time.Time:
+		value, ok := value.(time.Time)
+		return ok && offsetDateTimesEqual(allowed, value)
+	case toml.LocalDateTime:
+		value, ok := value.(toml.LocalDateTime)
+		return ok && allowed.LocalDate == value.LocalDate &&
+			localTimesEqual(allowed.LocalTime, value.LocalTime)
+	case toml.LocalDate:
+		value, ok := value.(toml.LocalDate)
+		return ok && allowed == value
+	case toml.LocalTime:
+		value, ok := value.(toml.LocalTime)
+		return ok && localTimesEqual(allowed, value)
+	}
+	return fmt.Sprintf("%#v", allowed) == fmt.Sprintf("%#v", value)
+}
+
+func offsetDateTimesEqual(left, right time.Time) bool {
+	_, leftOffset := left.Zone()
+	_, rightOffset := right.Zone()
+	return left.Year() == right.Year() &&
+		left.Month() == right.Month() &&
+		left.Day() == right.Day() &&
+		left.Hour() == right.Hour() &&
+		left.Minute() == right.Minute() &&
+		left.Second() == right.Second() &&
+		left.Nanosecond() == right.Nanosecond() &&
+		leftOffset == rightOffset
+}
+
+func localTimesEqual(left, right toml.LocalTime) bool {
+	return left.Hour == right.Hour &&
+		left.Minute == right.Minute &&
+		left.Second == right.Second &&
+		left.Nanosecond == right.Nanosecond
+}
+
+func isNumeric(value any) bool {
+	switch value.(type) {
+	case int64, float64:
+		return true
 	default:
-		return 0, false
+		return false
 	}
 }
 
-func valuesEqual(allowed, value any) bool {
-	if allowedNumber, ok := numeric(allowed); ok {
-		if valueNumber, ok := numeric(value); ok {
-			return allowedNumber == valueNumber
+func compareNumbers(left, right any) (int, error) {
+	if isNaN(left) || isNaN(right) {
+		return 0, fmt.Errorf("NaN is unordered")
+	}
+	if leftInteger, ok := left.(int64); ok {
+		if rightInteger, ok := right.(int64); ok {
+			switch {
+			case leftInteger < rightInteger:
+				return -1, nil
+			case leftInteger > rightInteger:
+				return 1, nil
+			default:
+				return 0, nil
+			}
 		}
 	}
-	return fmt.Sprintf("%#v", allowed) == fmt.Sprintf("%#v", value)
+	leftFloat, leftIsFloat := left.(float64)
+	rightFloat, rightIsFloat := right.(float64)
+	if (leftIsFloat && math.IsInf(leftFloat, 0)) || (rightIsFloat && math.IsInf(rightFloat, 0)) {
+		return compareFloat(numberAsFloat(left), numberAsFloat(right)), nil
+	}
+	return numericRat(left).Cmp(numericRat(right)), nil
+}
+
+func numberAsFloat(value any) float64 {
+	if integer, ok := value.(int64); ok {
+		return float64(integer)
+	}
+	return value.(float64)
+}
+
+func numericRat(value any) *big.Rat {
+	if integer, ok := value.(int64); ok {
+		return new(big.Rat).SetInt64(integer)
+	}
+	return new(big.Rat).SetFloat64(value.(float64))
 }
 
 func typeNameOf(value any) string {

--- a/reference-implementations/go/schema_test.go
+++ b/reference-implementations/go/schema_test.go
@@ -1352,6 +1352,115 @@ type = "npm"
 	}
 }
 
+func TestPreservesNumericPrecisionAndDefinesTemporalOrdering(t *testing.T) {
+	dir := t.TempDir()
+	schemaPath := write(t, dir, "value-semantics.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[elements.precise]
+type = "integer"
+allowedvalues = [ 9007199254740992 ]
+
+[elements.mixed]
+type = "integer"
+max = 9007199254740992.0
+
+[elements.nanValue]
+type = "float"
+allowedvalues = [ nan ]
+
+[elements.nanRange]
+type = "float"
+min = 0.0
+
+[elements.zero]
+type = "float"
+allowedvalues = [ -0.0 ]
+
+[elements.instant]
+type = "offset-date-time"
+min = 2024-01-01T00:00:00Z
+max = 2024-01-01T00:00:00Z
+
+[elements.instantMember]
+type = "offset-date-time"
+allowedvalues = [ 2024-01-01T00:00:00Z ]
+
+[elements.localMember]
+type = "local-time"
+allowedvalues = [ 12:00:00.1 ]
+
+[elements.localDateTime]
+type = "local-date-time"
+max = 2024-01-01T00:00:00.100
+
+[elements.localDate]
+type = "local-date"
+max = 2024-01-01
+
+[elements.localTime]
+type = "local-time"
+max = 12:00:00.100
+`)
+	validPath := write(t, dir, "value-semantics-valid.toml", `
+precise = 9007199254740992
+mixed = 9007199254740992
+nanValue = nan
+nanRange = 0.0
+zero = 0.0
+instant = 2023-12-31T19:00:00-05:00
+instantMember = 2024-01-01T00:00:00+00:00
+localMember = 12:00:00.100
+localDateTime = 2024-01-01T00:00:00.100
+localDate = 2024-01-01
+localTime = 12:00:00.100
+`)
+	invalidPath := write(t, dir, "value-semantics-invalid.toml", `
+precise = 9007199254740993
+mixed = 9007199254740993
+nanValue = 0.0
+nanRange = nan
+zero = 1.0
+instant = 2024-01-01T00:00:00.001Z
+instantMember = 2023-12-31T19:00:00-05:00
+localMember = 12:00:00.101
+localDateTime = 2024-01-01T00:00:00.101
+localDate = 2024-01-02
+localTime = 12:00:00.101
+`)
+	schema, err := LoadSchema(schemaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result := schema.ValidateFile(validPath); !result.Valid() {
+		t.Fatalf("expected valid value semantics, got %#v", result.Errors)
+	}
+	invalid := schema.ValidateFile(invalidPath)
+	for _, path := range []string{
+		"$.precise", "$.mixed", "$.nanValue", "$.nanRange", "$.zero",
+		"$.instant", "$.instantMember", "$.localMember",
+		"$.localDateTime", "$.localDate", "$.localTime",
+	} {
+		if !hasPath(invalid, path) {
+			t.Fatalf("expected error at %s, got %#v", path, invalid.Errors)
+		}
+	}
+
+	malformedPath := write(t, dir, "value-semantics-malformed.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "integer"
+allowedvalues = [ 9007199254740993 ]
+max = 9007199254740992.0
+`)
+	if _, err := LoadSchema(malformedPath); err == nil {
+		t.Fatal("expected imprecise allowed value comparison to be rejected at schema load")
+	}
+}
+
 func TestLocatesSchemaFromDocumentMetadata(t *testing.T) {
 	dir := t.TempDir()
 	write(t, dir, "schema.tosd", `

--- a/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
@@ -579,10 +579,10 @@ final class SchemaLoader {
             if ((min != null || max != null) && allowed instanceof Double doubleValue && doubleValue.isNaN()) {
                 throw new SchemaException(entry + " does not satisfy min or max");
             }
-            if (min != null && compare(allowed, min, entry) < 0) {
+            if (min != null && ValueSemantics.compare(allowed, min) < 0) {
                 throw new SchemaException(entry + " is less than min");
             }
-            if (max != null && compare(allowed, max, entry) > 0) {
+            if (max != null && ValueSemantics.compare(allowed, max) > 0) {
                 throw new SchemaException(entry + " is greater than max");
             }
             if (minLength != null || maxLength != null) {
@@ -598,17 +598,6 @@ final class SchemaLoader {
                 }
             }
         }
-    }
-
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    private int compare(Object value, Object boundary, String entry) {
-        if (value instanceof Number valueNumber && boundary instanceof Number boundaryNumber) {
-            return Double.compare(valueNumber.doubleValue(), boundaryNumber.doubleValue());
-        }
-        if (value instanceof Comparable valueComparable && value.getClass().isInstance(boundary)) {
-            return valueComparable.compareTo(boundary);
-        }
-        throw new SchemaException(entry + " cannot be compared with its boundary");
     }
 
     private String normalizeReference(String reference) {

--- a/reference-implementations/java/src/main/java/org/tomlschema/TomlSchemaValidator.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/TomlSchemaValidator.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 final class TomlSchemaValidator {
@@ -240,11 +239,23 @@ final class TomlSchemaValidator {
     private void validateRange(String path, Object value, SchemaDefinition definition) {
         Object min = definition.min();
         Object max = definition.max();
-        if (min != null && compare(value, min) < 0) {
-            add(path, "value is less than min");
+        if (min != null) {
+            try {
+                if (ValueSemantics.compare(value, min) < 0) {
+                    add(path, "value is less than min");
+                }
+            } catch (SchemaException error) {
+                add(path, error.getMessage());
+            }
         }
-        if (max != null && compare(value, max) > 0) {
-            add(path, "value is greater than max");
+        if (max != null) {
+            try {
+                if (ValueSemantics.compare(value, max) > 0) {
+                    add(path, "value is greater than max");
+                }
+            } catch (SchemaException error) {
+                add(path, error.getMessage());
+            }
         }
     }
 
@@ -257,22 +268,8 @@ final class TomlSchemaValidator {
         }
     }
 
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    private int compare(Object value, Object boundary) {
-        if (value instanceof Number valueNumber && boundary instanceof Number boundaryNumber) {
-            return Double.compare(valueNumber.doubleValue(), boundaryNumber.doubleValue());
-        }
-        if (value instanceof Comparable valueComparable && value.getClass().isInstance(boundary)) {
-            return valueComparable.compareTo(boundary);
-        }
-        throw new SchemaException("Cannot compare " + typeName(value) + " with boundary " + typeName(boundary));
-    }
-
     private boolean valuesEqual(Object allowed, Object value) {
-        if (allowed instanceof Number allowedNumber && value instanceof Number valueNumber) {
-            return Double.compare(allowedNumber.doubleValue(), valueNumber.doubleValue()) == 0;
-        }
-        return Objects.equals(allowed, value);
+        return ValueSemantics.valuesEqual(allowed, value);
     }
 
     private SchemaDefinition resolve(SchemaDefinition definition, Set<String> seenReferences) {

--- a/reference-implementations/java/src/main/java/org/tomlschema/ValueSemantics.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/ValueSemantics.java
@@ -1,0 +1,80 @@
+package org.tomlschema;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.Objects;
+
+final class ValueSemantics {
+    private ValueSemantics() {
+    }
+
+    static int compare(Object left, Object right) {
+        if (left instanceof Number leftNumber && right instanceof Number rightNumber) {
+            return compareNumbers(leftNumber, rightNumber);
+        }
+        if (left instanceof OffsetDateTime leftDateTime && right instanceof OffsetDateTime rightDateTime) {
+            return leftDateTime.toInstant().compareTo(rightDateTime.toInstant());
+        }
+        if (left instanceof Comparable<?> comparable && left.getClass().isInstance(right)) {
+            return compareComparable(comparable, right);
+        }
+        throw new SchemaException("Cannot compare " + typeName(left) + " with boundary " + typeName(right));
+    }
+
+    static boolean valuesEqual(Object left, Object right) {
+        if (left instanceof Number leftNumber && right instanceof Number rightNumber) {
+            if (isNaN(leftNumber) || isNaN(rightNumber)) {
+                return isNaN(leftNumber) && isNaN(rightNumber);
+            }
+            return compareNumbers(leftNumber, rightNumber) == 0;
+        }
+        return Objects.equals(left, right);
+    }
+
+    private static int compareNumbers(Number left, Number right) {
+        if (isNaN(left) || isNaN(right)) {
+            throw new SchemaException("NaN is unordered");
+        }
+        if (left instanceof Long leftInteger && right instanceof Long rightInteger) {
+            return Long.compare(leftInteger, rightInteger);
+        }
+        if (isInfinite(left) || isInfinite(right)) {
+            return compareNonFinite(left.doubleValue(), right.doubleValue());
+        }
+        return decimal(left).compareTo(decimal(right));
+    }
+
+    private static BigDecimal decimal(Number number) {
+        if (number instanceof Long integer) {
+            return BigDecimal.valueOf(integer);
+        }
+        return new BigDecimal(number.doubleValue());
+    }
+
+    private static boolean isNaN(Number number) {
+        return number instanceof Double value && value.isNaN();
+    }
+
+    private static boolean isInfinite(Number number) {
+        return number instanceof Double value && value.isInfinite();
+    }
+
+    private static int compareNonFinite(double left, double right) {
+        if (left < right) {
+            return -1;
+        }
+        if (left > right) {
+            return 1;
+        }
+        return 0;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static int compareComparable(Comparable left, Object right) {
+        return left.compareTo(right);
+    }
+
+    private static String typeName(Object value) {
+        return value == null ? "null" : value.getClass().getSimpleName();
+    }
+}

--- a/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
+++ b/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
@@ -1186,6 +1186,110 @@ class TomlSchemaTest {
     }
 
     @Test
+    void preservesNumericPrecisionAndDefinesTemporalOrdering() throws IOException {
+        Path schema = write("value-semantics.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.precise]
+                type = "integer"
+                allowedvalues = [ 9007199254740992 ]
+
+                [elements.mixed]
+                type = "integer"
+                max = 9007199254740992.0
+
+                [elements.nanValue]
+                type = "float"
+                allowedvalues = [ nan ]
+
+                [elements.nanRange]
+                type = "float"
+                min = 0.0
+
+                [elements.zero]
+                type = "float"
+                allowedvalues = [ -0.0 ]
+
+                [elements.instant]
+                type = "offset-date-time"
+                min = 2024-01-01T00:00:00Z
+                max = 2024-01-01T00:00:00Z
+
+                [elements.instantMember]
+                type = "offset-date-time"
+                allowedvalues = [ 2024-01-01T00:00:00Z ]
+
+                [elements.localMember]
+                type = "local-time"
+                allowedvalues = [ 12:00:00.1 ]
+
+                [elements.localDateTime]
+                type = "local-date-time"
+                max = 2024-01-01T00:00:00.100
+
+                [elements.localDate]
+                type = "local-date"
+                max = 2024-01-01
+
+                [elements.localTime]
+                type = "local-time"
+                max = 12:00:00.100
+                """);
+        Path validDocument = write("value-semantics-valid.toml", """
+                precise = 9007199254740992
+                mixed = 9007199254740992
+                nanValue = nan
+                nanRange = 0.0
+                zero = 0.0
+                instant = 2023-12-31T19:00:00-05:00
+                instantMember = 2024-01-01T00:00:00+00:00
+                localMember = 12:00:00.100
+                localDateTime = 2024-01-01T00:00:00.100
+                localDate = 2024-01-01
+                localTime = 12:00:00.100
+                """);
+        Path invalidDocument = write("value-semantics-invalid.toml", """
+                precise = 9007199254740993
+                mixed = 9007199254740993
+                nanValue = 0.0
+                nanRange = nan
+                zero = 1.0
+                instant = 2024-01-01T00:00:00.001Z
+                instantMember = 2023-12-31T19:00:00-05:00
+                localMember = 12:00:00.101
+                localDateTime = 2024-01-01T00:00:00.101
+                localDate = 2024-01-02
+                localTime = 12:00:00.101
+                """);
+        TomlSchema loaded = TomlSchema.load(schema);
+
+        ValidationResult valid = loaded.validate(validDocument);
+        assertTrue(valid.isValid(), () -> valid.errors().toString());
+
+        ValidationResult invalid = loaded.validate(invalidDocument);
+        for (String path : List.of(
+                "$.precise", "$.mixed", "$.nanValue", "$.nanRange", "$.zero",
+                "$.instant", "$.instantMember", "$.localMember",
+                "$.localDateTime", "$.localDate", "$.localTime"
+        )) {
+            assertTrue(invalid.errors().stream().anyMatch(error -> error.path().equals(path)),
+                    () -> "Expected error at " + path + ": " + invalid.errors());
+        }
+
+        Path malformedSchema = write("value-semantics-malformed.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.value]
+                type = "integer"
+                allowedvalues = [ 9007199254740993 ]
+                max = 9007199254740992.0
+                """);
+        assertThrows(SchemaException.class, () -> TomlSchema.load(malformedSchema));
+    }
+
+    @Test
     void appliesArrayRangesAndNamedItemConstraints() throws IOException {
         Path schema = write("array-member-boundaries.tosd", """
                 [toml-schema]

--- a/reference-implementations/rust/src/schema.rs
+++ b/reference-implementations/rust/src/schema.rs
@@ -842,7 +842,9 @@ fn validate_boundary_matches_type(
 
 fn boundary_matches_type(value: &Value, type_name: SchemaType) -> bool {
     match type_name {
-        SchemaType::Integer | SchemaType::Float => numeric(value).is_some(),
+        SchemaType::Integer | SchemaType::Float => {
+            matches!(value, Value::Integer(_) | Value::Float(_))
+        }
         SchemaType::OffsetDateTime
         | SchemaType::LocalDateTime
         | SchemaType::LocalDate
@@ -1328,10 +1330,14 @@ fn type_name_of_value(value: &Value) -> &'static str {
 }
 
 fn compare(value: &Value, boundary: &Value) -> Result<std::cmp::Ordering, String> {
-    if let (Some(value_number), Some(boundary_number)) = (numeric(value), numeric(boundary)) {
-        return Ok(value_number
-            .partial_cmp(&boundary_number)
-            .unwrap_or(std::cmp::Ordering::Equal));
+    match (value, boundary) {
+        (Value::Integer(left), Value::Integer(right)) => return Ok(left.cmp(right)),
+        (Value::Float(left), Value::Float(right)) => return compare_floats(*left, *right),
+        (Value::Integer(left), Value::Float(right)) => return compare_integer_float(*left, *right),
+        (Value::Float(left), Value::Integer(right)) => {
+            return compare_integer_float(*right, *left).map(std::cmp::Ordering::reverse)
+        }
+        _ => {}
     }
     if let (Value::Datetime(left), Value::Datetime(right)) = (value, boundary) {
         if let Some(ordering) = compare_datetimes(left, right) {
@@ -1419,22 +1425,57 @@ fn days_from_civil(year: i64, month: u32, day: u32) -> i64 {
     era * 146_097 + doe - 719_468
 }
 
-fn numeric(value: &Value) -> Option<f64> {
-    match value {
-        Value::Integer(integer) => Some(*integer as f64),
-        Value::Float(float) => Some(*float),
-        _ => None,
+fn compare_floats(left: f64, right: f64) -> Result<std::cmp::Ordering, String> {
+    left.partial_cmp(&right)
+        .ok_or_else(|| "NaN is unordered".to_string())
+}
+
+fn compare_integer_float(integer: i64, float: f64) -> Result<std::cmp::Ordering, String> {
+    if float.is_nan() {
+        return Err("NaN is unordered".to_string());
+    }
+    if float == f64::NEG_INFINITY {
+        return Ok(std::cmp::Ordering::Greater);
+    }
+    if float == f64::INFINITY {
+        return Ok(std::cmp::Ordering::Less);
+    }
+    if float < i64::MIN as f64 {
+        return Ok(std::cmp::Ordering::Greater);
+    }
+    if float >= 9_223_372_036_854_775_808.0 {
+        return Ok(std::cmp::Ordering::Less);
+    }
+    let truncated = float.trunc() as i64;
+    match integer.cmp(&truncated) {
+        std::cmp::Ordering::Equal => {
+            if float.fract() > 0.0 {
+                Ok(std::cmp::Ordering::Less)
+            } else if float.fract() < 0.0 {
+                Ok(std::cmp::Ordering::Greater)
+            } else {
+                Ok(std::cmp::Ordering::Equal)
+            }
+        }
+        ordering => Ok(ordering),
     }
 }
 
 fn values_equal(left: &Value, right: &Value) -> bool {
-    if let (Some(left_number), Some(right_number)) = (numeric(left), numeric(right)) {
-        return left_number == right_number;
+    if let (Value::Float(left_float), Value::Float(right_float)) = (left, right) {
+        if left_float.is_nan() || right_float.is_nan() {
+            return left_float.is_nan() && right_float.is_nan();
+        }
+    }
+    if matches!(left, Value::Integer(_) | Value::Float(_))
+        && matches!(right, Value::Integer(_) | Value::Float(_))
+    {
+        return compare(left, right).is_ok_and(|ordering| ordering == std::cmp::Ordering::Equal);
     }
     match (left, right) {
         (Value::String(left), Value::String(right)) => left == right,
         (Value::Boolean(left), Value::Boolean(right)) => left == right,
-        (Value::Datetime(left), Value::Datetime(right)) => left.to_string() == right.to_string(),
+        (Value::Datetime(left), Value::Datetime(right)) => datetimes_equal(left, right),
         (Value::Array(left), Value::Array(right)) => {
             left.len() == right.len()
                 && left
@@ -1453,6 +1494,19 @@ fn values_equal(left: &Value, right: &Value) -> bool {
         }
         _ => false,
     }
+}
+
+fn datetimes_equal(left: &Datetime, right: &Datetime) -> bool {
+    left.date == right.date
+        && left.time == right.time
+        && numeric_offset(left.offset) == numeric_offset(right.offset)
+}
+
+fn numeric_offset(offset: Option<Offset>) -> Option<i16> {
+    offset.map(|offset| match offset {
+        Offset::Z => 0,
+        Offset::Custom { minutes } => minutes,
+    })
 }
 
 fn matches_pattern(pattern: &Regex, value: &str) -> bool {

--- a/reference-implementations/rust/tests/integration.rs
+++ b/reference-implementations/rust/tests/integration.rs
@@ -1687,6 +1687,142 @@ type = "npm"
 }
 
 #[test]
+fn preserves_numeric_precision_and_defines_temporal_ordering() {
+    let directory = tempfile_dir("value-semantics");
+    let schema_path = write_file(
+        &directory,
+        "schema.tosd",
+        r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.precise]
+type = "integer"
+allowedvalues = [ 9007199254740992 ]
+
+[elements.mixed]
+type = "integer"
+max = 9007199254740992.0
+
+[elements.nanValue]
+type = "float"
+allowedvalues = [ nan ]
+
+[elements.nanRange]
+type = "float"
+min = 0.0
+
+[elements.zero]
+type = "float"
+allowedvalues = [ -0.0 ]
+
+[elements.instant]
+type = "offset-date-time"
+min = 2024-01-01T00:00:00Z
+max = 2024-01-01T00:00:00Z
+
+[elements.instantMember]
+type = "offset-date-time"
+allowedvalues = [ 2024-01-01T00:00:00Z ]
+
+[elements.localMember]
+type = "local-time"
+allowedvalues = [ 12:00:00.1 ]
+
+[elements.localDateTime]
+type = "local-date-time"
+max = 2024-01-01T00:00:00.100
+
+[elements.localDate]
+type = "local-date"
+max = 2024-01-01
+
+[elements.localTime]
+type = "local-time"
+max = 12:00:00.100
+"#,
+    );
+    let valid_path = write_file(
+        &directory,
+        "valid.toml",
+        r#"
+precise = 9007199254740992
+mixed = 9007199254740992
+nanValue = nan
+nanRange = 0.0
+zero = 0.0
+instant = 2023-12-31T19:00:00-05:00
+instantMember = 2024-01-01T00:00:00+00:00
+localMember = 12:00:00.100
+localDateTime = 2024-01-01T00:00:00.100
+localDate = 2024-01-01
+localTime = 12:00:00.100
+"#,
+    );
+    let invalid_path = write_file(
+        &directory,
+        "invalid.toml",
+        r#"
+precise = 9007199254740993
+mixed = 9007199254740993
+nanValue = 0.0
+nanRange = nan
+zero = 1.0
+instant = 2024-01-01T00:00:00.001Z
+instantMember = 2023-12-31T19:00:00-05:00
+localMember = 12:00:00.101
+localDateTime = 2024-01-01T00:00:00.101
+localDate = 2024-01-02
+localTime = 12:00:00.101
+"#,
+    );
+
+    let schema = Schema::load(&schema_path).expect("load schema");
+    let valid = schema.validate_file(&valid_path);
+    assert!(
+        valid.valid(),
+        "expected valid value semantics: {:#?}",
+        valid.errors
+    );
+    let invalid = schema.validate_file(&invalid_path);
+    for path in [
+        "$.precise",
+        "$.mixed",
+        "$.nanValue",
+        "$.nanRange",
+        "$.zero",
+        "$.instant",
+        "$.instantMember",
+        "$.localMember",
+        "$.localDateTime",
+        "$.localDate",
+        "$.localTime",
+    ] {
+        assert!(
+            has_path(&invalid, path),
+            "expected error at {path}: {:#?}",
+            invalid.errors
+        );
+    }
+
+    let malformed_path = write_file(
+        &directory,
+        "malformed.tosd",
+        r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "integer"
+allowedvalues = [ 9007199254740993 ]
+max = 9007199254740992.0
+"#,
+    );
+    Schema::load(&malformed_path)
+        .expect_err("imprecise allowed value comparison must fail at schema load");
+}
+
+#[test]
 fn cli_locates_schema_from_document_metadata() {
     let directory = tempfile_dir("cli-locates-schema");
     write_file(


### PR DESCRIPTION
Numeric and temporal constraints could produce different results across reference implementations because large integers were rounded through binary floats and temporal equality and ordering were not fully specified. This defines portable value semantics and applies them consistently in Java, Go, and Rust.

## Changes

- preserve exact signed 64-bit integer ordering in integer and mixed integer/float comparisons
- define signed-zero equality, NaN membership, unordered NaN ranges, and infinity ordering
- compare offset date-time ranges by instant while comparing `allowedvalues` membership by parsed local fields and numeric UTC offset
- compare local temporal ranges lexicographically by parsed components, including fractional seconds
- centralize Java comparison behavior and align Go and Rust implementations
- add cross-language regression coverage for precision boundaries, malformed schema checks, NaN, equivalent offsets, and equivalent fractional spellings

## Validation

- Java Maven test suite
- Go test suite
- Rust test suite