### PR TITLE
Align website examples with TOML Schema specification

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -85,7 +85,7 @@ itemtype = "integer"</code></pre>
           <article class="card">
             <span class="badge">Native</span>
             <h3>TOML all the way down</h3>
-            <p>Schemas are valid TOML files, conventionally stored with the required <code>.tosd</code> extension.</p>
+            <p>Schemas are valid TOML documents and use the required <code>.tosd</code> filename extension.</p>
           </article>
           <article class="card">
             <span class="badge">Practical</span>
@@ -103,7 +103,7 @@ itemtype = "integer"</code></pre>
       <section class="section" id="tour">
         <h2>A Quick Tour of TOML Schema</h2>
         <p class="section-intro">
-          A schema starts with versioned metadata, then describes the TOML document
+          A schema includes versioned metadata and describes the TOML document
           under <code>[elements]</code>. Reusable shapes live under <code>[types]</code>.
           The examples below are fragments of one schema, not standalone files.
         </p>
@@ -112,7 +112,7 @@ itemtype = "integer"</code></pre>
             <div>
               <span class="badge">Metadata</span>
               <h3>Declare the schema language version</h3>
-              <p>Every schema document starts with <code>[toml-schema]</code> and a full SemVer version.</p>
+              <p>Every schema document must contain <code>[toml-schema]</code> with a full SemVer version.</p>
             </div>
             <pre><code>[toml-schema]
 version = "1.0.0"</code></pre>
@@ -163,11 +163,11 @@ type = "string"</code></pre>
             <div>
               <span class="badge">Collections</span>
               <h3>Handle dynamic table names</h3>
-              <p>A collection validates user-defined keys, such as named servers or environments.</p>
+              <p>A collection validates values stored under user-defined keys, such as named servers or environments.</p>
             </div>
             <pre><code>[elements.servers]
 type = "collection"
-            itemtype = "types.server"
+itemtype = "types.server"
 minlength = 1</code></pre>
           </article>
           <article class="tour-step">
@@ -196,9 +196,9 @@ max = 10</code></pre>
         </p>
         <div class="spec-list">
           <div class="spec-item"><strong>Versioned metadata</strong><span><code>[toml-schema]</code> declares SemVer language compatibility.</span></div>
-          <div class="spec-item"><strong>Type references</strong><span><code>type</code>, <code>itemtype</code>, <code>items</code>, <code>oneof</code>, and <code>anyof</code> can reference built-in type names or reusable <code>[types]</code>.</span></div>
-          <div class="spec-item"><strong>Dynamic keys</strong><span><code>collection</code> validates user-provided table keys.</span></div>
-          <div class="spec-item"><strong>Union shapes</strong><span><code>oneof</code> and <code>anyof</code> model alternative valid forms.</span></div>
+          <div class="spec-item"><strong>Type references</strong><span>References used by <code>type</code>, <code>itemtype</code>, <code>items</code>, <code>oneof</code>, and <code>anyof</code> select built-in types or reusable <code>[types]</code> definitions.</span></div>
+          <div class="spec-item"><strong>Dynamic entries</strong><span><code>collection</code> validates dynamically named values; <code>keypattern</code> can constrain their keys.</span></div>
+          <div class="spec-item"><strong>Alternative types</strong><span><code>oneof</code> requires exactly one matching type; <code>anyof</code> requires at least one.</span></div>
           <div class="spec-item"><strong>Containers and tuples</strong><span><code>itemtype</code> validates homogeneous array and collection members; <code>items</code> defines positional arrays.</span></div>
           <div class="spec-item"><strong>Media type</strong><span>TOML Schema files use <code>.tosd</code> and <code>application/tosd</code>.</span></div>
         </div>
@@ -221,7 +221,7 @@ max = 10</code></pre>
           </article>
           <article class="card">
             <span class="badge">Go</span>
-            <h3>CLI</h3>
+            <h3>Library and CLI</h3>
             <p>Uses go-toml and supports explicit schema validation and schema-location lookup.</p>
           </article>
           <article class="card">

--- a/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
+++ b/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
@@ -10,6 +10,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -1803,6 +1805,57 @@ class TomlSchemaTest {
 
         ValidationResult validationResult = TomlSchema.load(extractedSchema).validate(document);
         assertTrue(validationResult.isValid(), () -> validationResult.errors().toString());
+    }
+
+    @Test
+    void validatesWebsiteExamples() throws IOException {
+        String page = Files.readString(fixture("docs/index.html"), StandardCharsets.UTF_8);
+        Pattern codeBlock = Pattern.compile("<pre><code>(.*?)</code></pre>", Pattern.DOTALL);
+
+        Matcher hero = Pattern.compile("<aside class=\"panel\".*?</aside>", Pattern.DOTALL).matcher(page);
+        assertTrue(hero.find(), "Website hero example is missing");
+        Matcher heroCode = codeBlock.matcher(hero.group());
+        assertTrue(heroCode.find(), "Website hero schema is missing");
+
+        Path heroSchema = write("website-hero.tosd", heroCode.group(1));
+        Path heroDocument = write("website-hero.toml", """
+                title = "Example"
+
+                [database]
+                enabled = true
+                ports = [8000, 8001]
+                """);
+        ValidationResult heroResult = TomlSchema.load(heroSchema).validate(heroDocument);
+        assertTrue(heroResult.isValid(), () -> heroResult.errors().toString());
+
+        Matcher tour = Pattern.compile(
+                "<section class=\"section\" id=\"tour\">(.*?)</section>",
+                Pattern.DOTALL
+        ).matcher(page);
+        assertTrue(tour.find(), "Website tour is missing");
+
+        Matcher tourCode = codeBlock.matcher(tour.group(1));
+        StringBuilder assembledSchema = new StringBuilder();
+        while (tourCode.find()) {
+            assembledSchema.append(tourCode.group(1)).append(System.lineSeparator()).append(System.lineSeparator());
+        }
+
+        Path tourSchema = write("website-tour.tosd", assembledSchema.toString());
+        Path tourDocument = write("website-tour.toml", """
+                title = "Example"
+                environment = "prod"
+                retries = 3
+
+                [database]
+                enabled = true
+                ports = [8000, 8001]
+
+                [servers.primary]
+                ip = "10.0.0.1"
+                role = "frontend"
+                """);
+        ValidationResult tourResult = TomlSchema.load(tourSchema).validate(tourDocument);
+        assertTrue(tourResult.isValid(), () -> tourResult.errors().toString());
     }
 
     private Path write(String fileName, String content) throws IOException {


### PR DESCRIPTION
The landing page contained several statements that were looser than the normative specification, and its embedded schemas could drift without automated validation.

This change tightens the language around schema metadata, collections, type references, alternatives, filename requirements, and Go implementation support. It also fixes the malformed collection snippet indentation and adds a Java regression test that extracts the hero schema and assembles the tour fragments directly from `docs/index.html`, then validates representative TOML documents against both.

**Test**

`mvn -f reference-implementations/java/pom.xml -Dtest=TomlSchemaTest#validatesWebsiteExamples test`