### PR TITLE
Recover remaining schema conformance fixes

### DIFF
--- a/REFERENCE_IMPLEMENTATIONS.md
+++ b/REFERENCE_IMPLEMENTATIONS.md
@@ -45,7 +45,12 @@ Validate using `[toml-schema].location` from the TOML document:
 java -jar reference-implementations/java/target/toml-schema-1.0.0-rc.2.jar validate config.toml
 ```
 
-For document-driven lookup, the Java CLI resolves a relative `[toml-schema].location` from the TOML document's directory. The document's `[toml-schema].version` is optional; when present, the CLI rejects a major-version mismatch with the resolved schema and warns about other unequal versions.
+For document-driven lookup, each reference CLI resolves a relative
+`[toml-schema].location` from the TOML document's directory. The document's
+`[toml-schema].version` is optional; when present, the CLI rejects a major-version
+mismatch with the resolved schema and warns about other unequal versions.
+Reference CLIs currently support local files and reject unsupported URI schemes
+explicitly.
 
 Validate the example schema against the TOML Schema self-schema:
 
@@ -207,6 +212,7 @@ Every reference implementation should:
 1. Require a schema document's `[toml-schema].version` to be a SemVer string compatible with the implementation's supported TOML Schema version.
 1. Validate the checked-in `config.toml` document against `config.tosd`.
 1. Support schema lookup through `[toml-schema].location`.
+1. Enforce the document schema-reference URI and optional language-version compatibility rules from `SPEC.md`.
 1. Validate `config.tosd` against `toml-schema.tosd`.
 1. Validate `toml-schema.tosd` against itself.
 1. Keep supported schema vocabulary aligned with `toml-schema.abnf` and `toml-schema.tosd`.

--- a/SPEC.md
+++ b/SPEC.md
@@ -980,6 +980,13 @@ An absolute `location` MUST be used unchanged. A relative `location` MUST be res
 
 A validator that receives a TOML document without a base location, for example through standard input, cannot resolve a relative `location`. It MUST either obtain an explicit base URI from the caller or report that schema discovery failed. An absolute `location` does not require a document base. Implementations MAY limit the URI schemes they can retrieve, but MUST report an unsupported scheme rather than reinterpret its value as a relative local path.
 
+An implementation that supports the `file` scheme MUST require a hierarchical
+file URI that can be converted to a local path, such as
+`file:///schemas/config.tosd`. It MUST reject an opaque URI such as
+`file:schema.tosd` rather than reinterpret it as a path relative to the TOML
+document. A file URI with a query or fragment MUST also be rejected because
+those components are not part of the local filesystem path.
+
 `version` is OPTIONAL. When present, it denotes the expected TOML Schema **language version** in the resolved schema document's `[toml-schema].version`; it is not an application version or an author-defined revision of that schema. Its value MUST be a string containing a full SemVer version in `MAJOR.MINOR.PATCH` form, with the same syntax defined by [Schema Versioning](#schema-versioning).
 
 After resolving and loading the schema, a validator MUST compare these two language versions when the referencing document provides `version`. A different major version is incompatible and schema discovery MUST fail. Any other unequal version, including a minor, patch, pre-release, or build metadata difference, MUST produce a warning but MUST NOT by itself cause validation to fail. Compatibility between the resolved schema and the validator remains governed by [Schema Versioning](#schema-versioning).

--- a/examples/wrangler.tosd
+++ b/examples/wrangler.tosd
@@ -154,7 +154,6 @@ type = "table"
     optional = true
 
 [types.moduleRule]
-type = "table"
 
     [types.moduleRule.type]
     type = "string"
@@ -292,44 +291,58 @@ type = "table"
     type = "string"
 
 [types.idBinding]
-type = "types.simpleBinding"
+
+    [types.idBinding.binding]
+    type = "string"
 
     [types.idBinding.id]
     type = "string"
 
 [types.nameBinding]
-type = "types.simpleBinding"
+
+    [types.nameBinding.binding]
+    type = "string"
 
     [types.nameBinding.name]
     type = "string"
 
 [types.namespaceBinding]
-type = "types.simpleBinding"
+
+    [types.namespaceBinding.binding]
+    type = "string"
 
     [types.namespaceBinding.namespace]
     type = "string"
 
 [types.aiSearchInstance]
-type = "types.simpleBinding"
+
+    [types.aiSearchInstance.binding]
+    type = "string"
 
     [types.aiSearchInstance.instance_name]
     type = "string"
 
 [types.indexBinding]
-type = "types.simpleBinding"
+
+    [types.indexBinding.binding]
+    type = "string"
 
     [types.indexBinding.index_name]
     type = "string"
 
 [types.datasetBinding]
-type = "types.simpleBinding"
+
+    [types.datasetBinding.binding]
+    type = "string"
 
     [types.datasetBinding.dataset]
     type = "string"
     optional = true
 
 [types.serviceBinding]
-type = "types.simpleBinding"
+
+    [types.serviceBinding.binding]
+    type = "string"
 
     [types.serviceBinding.service]
     type = "string"
@@ -339,13 +352,17 @@ type = "types.simpleBinding"
     optional = true
 
 [types.certificateBinding]
-type = "types.simpleBinding"
+
+    [types.certificateBinding.binding]
+    type = "string"
 
     [types.certificateBinding.certificate_id]
     type = "string"
 
 [types.workflowBinding]
-type = "types.simpleBinding"
+
+    [types.workflowBinding.binding]
+    type = "string"
 
     [types.workflowBinding.class_name]
     type = "string"
@@ -369,7 +386,12 @@ type = "table"
     optional = true
 
 [types.dispatchNamespace]
-type = "types.namespaceBinding"
+
+    [types.dispatchNamespace.binding]
+    type = "string"
+
+    [types.dispatchNamespace.namespace]
+    type = "string"
 
     [types.dispatchNamespace.outbound]
     type = "types.dispatchOutbound"
@@ -460,7 +482,9 @@ type = "table"
     optional = true
 
 [types.queueProducer]
-type = "types.simpleBinding"
+
+    [types.queueProducer.binding]
+    type = "string"
 
     [types.queueProducer.delivery_delay]
     type = "types.numberValue"
@@ -521,7 +545,9 @@ type = "table"
     optional = true
 
 [types.secretsStoreSecret]
-type = "types.simpleBinding"
+
+    [types.secretsStoreSecret.binding]
+    type = "string"
 
     [types.secretsStoreSecret.store_id]
     type = "string"

--- a/reference-implementations/go/cmd/toml-schema/main_test.go
+++ b/reference-implementations/go/cmd/toml-schema/main_test.go
@@ -76,6 +76,18 @@ type = "string"
 			wantExitCode: 2,
 			wantError:    "unsupported schema location URI scheme: https",
 		},
+		{
+			name:         "opaque-file-uri",
+			location:     "file:schema.tosd",
+			wantExitCode: 2,
+			wantError:    "invalid file schema location",
+		},
+		{
+			name:         "file-uri-query",
+			location:     fileURI + "?version=1",
+			wantExitCode: 2,
+			wantError:    "invalid file schema location",
+		},
 	}
 
 	for _, test := range tests {

--- a/reference-implementations/go/schema.go
+++ b/reference-implementations/go/schema.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -1104,23 +1105,68 @@ func isSchemaReferenceScalar(value any) bool {
 }
 
 func resolveSchemaLocation(documentPath, location string) (string, error) {
+	if filepath.IsAbs(location) {
+		return filepath.Clean(location), nil
+	}
+	if hasInvalidURIReferenceCharacter(location) {
+		return "", fmt.Errorf("invalid [toml-schema].location URI: %s", location)
+	}
+	reference, err := url.Parse(location)
+	if err != nil {
+		return "", fmt.Errorf("invalid [toml-schema].location URI: %s: %w", location, err)
+	}
 	absoluteDocumentPath, err := filepath.Abs(documentPath)
 	if err != nil {
 		return "", fmt.Errorf("invalid document path: %w", err)
 	}
 	base := &url.URL{Scheme: "file", Path: filepath.ToSlash(absoluteDocumentPath)}
-	reference, err := url.Parse(location)
-	if err != nil {
-		return "", fmt.Errorf("invalid [toml-schema].location URI: %s: %w", location, err)
-	}
 	resolved := base.ResolveReference(reference)
 	if !strings.EqualFold(resolved.Scheme, "file") {
 		return "", fmt.Errorf("unsupported schema location URI scheme: %s", resolved.Scheme)
 	}
-	if resolved.Host != "" && !strings.EqualFold(resolved.Host, "localhost") {
-		return "", fmt.Errorf("unsupported file schema location host: %s", resolved.Host)
+	path, err := localPathFromFileURI(resolved)
+	if err != nil {
+		return "", fmt.Errorf("invalid file schema location: %s: %w", location, err)
 	}
-	return filepath.Clean(filepath.FromSlash(resolved.Path)), nil
+	return filepath.Clean(path), nil
+}
+
+func hasInvalidURIReferenceCharacter(reference string) bool {
+	for _, character := range reference {
+		if character <= ' ' || character == 0x7f {
+			return true
+		}
+		switch character {
+		case '\\', '"', '<', '>', '^', '`', '{', '|', '}':
+			return true
+		}
+	}
+	return false
+}
+
+func localPathFromFileURI(uri *url.URL) (string, error) {
+	if uri.Opaque != "" || uri.User != nil || uri.RawQuery != "" || uri.ForceQuery || uri.Fragment != "" {
+		return "", fmt.Errorf("file URI contains unsupported components")
+	}
+	if uri.Host != "" && !strings.EqualFold(uri.Host, "localhost") {
+		return "", fmt.Errorf("file URI has a non-local host")
+	}
+	escapedPath := strings.ToLower(uri.EscapedPath())
+	if strings.Contains(escapedPath, "%2f") || strings.Contains(escapedPath, "%5c") {
+		return "", fmt.Errorf("file URI contains an encoded path separator")
+	}
+	path := uri.Path
+	if path == "" || strings.ContainsRune(path, 0) {
+		return "", fmt.Errorf("file URI does not contain a safe path")
+	}
+	if runtime.GOOS == "windows" && len(path) >= 3 && path[0] == '/' && path[2] == ':' {
+		path = path[1:]
+	}
+	path = filepath.FromSlash(path)
+	if !filepath.IsAbs(path) {
+		return "", fmt.Errorf("file URI path is not absolute")
+	}
+	return path, nil
 }
 
 func compareDocumentSchemaVersion(value any, actual string) (string, error) {

--- a/reference-implementations/go/schema_test.go
+++ b/reference-implementations/go/schema_test.go
@@ -21,8 +21,14 @@ func TestValidatesCheckedInExample(t *testing.T) {
 	}
 }
 
-func TestLoadsExamplesMigratedFromReferenceSpecialization(t *testing.T) {
-	for _, name := range []string{"hugo.tosd", "netlify.tosd"} {
+func TestLoadsCheckedInExamples(t *testing.T) {
+	for _, name := range []string{
+		"gitlab-runner.tosd",
+		"hugo.tosd",
+		"netlify.tosd",
+		"pyproject.tosd",
+		"wrangler.tosd",
+	} {
 		t.Run(name, func(t *testing.T) {
 			if _, err := LoadSchema(filepath.Join(fixture("examples"), name)); err != nil {
 				t.Fatal(err)

--- a/reference-implementations/java/src/main/java/org/tomlschema/TomlSchemaCli.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/TomlSchemaCli.java
@@ -127,6 +127,9 @@ public final class TomlSchemaCli {
         } catch (IllegalArgumentException e) {
             throw new SchemaException("Invalid [toml-schema].location URI: " + location, e);
         }
+        if (reference.isOpaque() && "file".equalsIgnoreCase(reference.getScheme())) {
+            throw new SchemaException("Invalid file schema location: " + location);
+        }
         URI resolved = tomlPath.toAbsolutePath().toUri().resolve(reference);
         if (!"file".equalsIgnoreCase(resolved.getScheme())) {
             throw new SchemaException("Unsupported schema location URI scheme: " + resolved.getScheme());

--- a/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
+++ b/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
@@ -31,8 +31,13 @@ class TomlSchemaTest {
     }
 
     @Test
-    void loadsExamplesMigratedFromReferenceSpecialization() {
-        for (String schema : List.of("examples/hugo.tosd", "examples/netlify.tosd")) {
+    void loadsCheckedInExamples() {
+        for (String schema : List.of(
+                "examples/gitlab-runner.tosd",
+                "examples/hugo.tosd",
+                "examples/netlify.tosd",
+                "examples/pyproject.tosd",
+                "examples/wrangler.tosd")) {
             assertDoesNotThrow(() -> TomlSchema.load(fixture(schema)), schema);
         }
     }
@@ -1809,6 +1814,30 @@ class TomlSchemaTest {
         assertEquals(2, exitCode);
         assertTrue(err.toString(StandardCharsets.UTF_8).contains(
                 "Unsupported schema location URI scheme: https"));
+    }
+
+    @Test
+    void cliRejectsOpaqueFileSchemaLocationUri() throws IOException {
+        for (String location : List.of(
+                "file:schema.tosd",
+                tempDir.resolve("schema.tosd").toUri() + "?version=1")) {
+            Path document = write("invalid-file-uri.toml", """
+                    title = "Example"
+
+                    [toml-schema]
+                    location = "%s"
+                    """.formatted(location));
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+            int exitCode = TomlSchemaCli.run(
+                    new String[]{"validate", document.toString()},
+                    new PrintStream(out, true, StandardCharsets.UTF_8),
+                    new PrintStream(err, true, StandardCharsets.UTF_8));
+
+            assertEquals(2, exitCode);
+            assertTrue(err.toString(StandardCharsets.UTF_8).contains("Invalid file schema location"));
+        }
     }
 
     @Test

--- a/reference-implementations/rust/src/schema.rs
+++ b/reference-implementations/rust/src/schema.rs
@@ -472,6 +472,9 @@ pub fn schema_from_document<P: AsRef<Path>>(document_path: P) -> Result<(Schema,
 }
 
 fn resolve_schema_location(document_path: &Path, location: &str) -> Result<PathBuf, String> {
+    if has_non_hierarchical_file_scheme(location) {
+        return Err(format!("invalid file schema location: {location}"));
+    }
     let absolute_document_path = if document_path.is_absolute() {
         document_path.to_path_buf()
     } else {
@@ -490,9 +493,37 @@ fn resolve_schema_location(document_path: &Path, location: &str) -> Result<PathB
             resolved.scheme()
         ));
     }
+    if resolved.query().is_some()
+        || resolved.fragment().is_some()
+        || contains_percent_encoded_separator(resolved.path())
+    {
+        return Err(format!("invalid file schema location: {location}"));
+    }
     resolved
         .to_file_path()
         .map_err(|_| format!("invalid file schema location: {location}"))
+}
+
+fn has_non_hierarchical_file_scheme(reference: &str) -> bool {
+    match Url::parse(reference) {
+        Ok(url) if url.scheme().eq_ignore_ascii_case("file") => {
+            !reference[url.scheme().len() + 1..].starts_with('/')
+        }
+        _ => false,
+    }
+}
+
+fn contains_percent_encoded_separator(path: &str) -> bool {
+    path.as_bytes().windows(3).any(|window| {
+        window[0] == b'%'
+            && matches!(
+                (
+                    window[1].to_ascii_lowercase(),
+                    window[2].to_ascii_lowercase()
+                ),
+                (b'2', b'f') | (b'5', b'c')
+            )
+    })
 }
 
 fn compare_document_schema_version(value: &Value, actual: &str) -> Result<Option<String>, String> {

--- a/reference-implementations/rust/tests/integration.rs
+++ b/reference-implementations/rust/tests/integration.rs
@@ -60,8 +60,14 @@ fn validates_checked_in_example() {
 }
 
 #[test]
-fn loads_examples_migrated_from_reference_specialization() {
-    for name in ["hugo.tosd", "netlify.tosd"] {
+fn loads_checked_in_examples() {
+    for name in [
+        "gitlab-runner.tosd",
+        "hugo.tosd",
+        "netlify.tosd",
+        "pyproject.tosd",
+        "wrangler.tosd",
+    ] {
         let path = fixture("examples").join(name);
         Schema::load(&path)
             .unwrap_or_else(|error| panic!("failed to load {}: {error}", path.display()));
@@ -1948,6 +1954,20 @@ type = "string"
             2,
             "unsupported schema location URI scheme: https",
         ),
+        (
+            "opaque-file-uri",
+            "",
+            "file:schema.tosd",
+            2,
+            "invalid file schema location",
+        ),
+        (
+            "file-uri-query",
+            "",
+            "file:///schema.tosd?version=1",
+            2,
+            "invalid file schema location",
+        ),
     ];
 
     for (name, version, location, expected_code, expected_error) in cases {
@@ -1966,7 +1986,7 @@ location = {location:?}
         );
         let (exit_code, _stdout, stderr) = capture(&["validate", document_path.to_str().unwrap()]);
 
-        assert_eq!(exit_code, expected_code, "{stderr}");
+        assert_eq!(exit_code, expected_code, "{name}: {stderr}");
         assert!(
             stderr.contains(expected_error),
             "expected {expected_error:?}, got {stderr:?}"


### PR DESCRIPTION
A review of closed PR 90 found two useful fixes that were not superseded by later work: the checked-in Wrangler schema remained invalid TOML, and file URI handling still diverged across the reference implementations.

## Summary

- repair Wrangler definitions that collided with schema-property names or attempted unsupported named-reference specialization
- load every checked-in schema example in the Java, Go, and Rust suites so future drift is caught
- require hierarchical local `file:` URIs and reject opaque URIs, queries, fragments, unsafe encoded separators, and non-local hosts
- align schema-discovery behavior and regression coverage across Java, Go, and Rust
- correct reference documentation that described document-driven lookup as Java-only

## Scope note

This intentionally does not restore PR 90's advisory `default` property, which PR 91 removed as undocumented and inert. It also avoids adding redundant resolution-result APIs because existing warning accessors already cover that need.

## Validation

- `mvn -q -f reference-implementations/java/pom.xml test`
- `go -C reference-implementations/go test ./...`
- `cargo test --quiet --manifest-path reference-implementations/rust/Cargo.toml`