### PR TITLE
Audit schema coherence and industry coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ A TOML Schema document is itself a valid TOML document. Validators can use it to
 - [Self-schema](toml-schema.tosd) - a structural schema for TOML Schema documents;
   schema loaders enforce property types and conditional applicability.
 - [Example schema](config.tosd) and [example TOML document](config.toml) - a worked example used by the reference implementation tests.
+- [Industry examples](examples/) - representative schemas for Cargo,
+  `pyproject.toml`, Hugo, Netlify, GitLab Runner, and Cloudflare Wrangler.
 - [Reference implementations](REFERENCE_IMPLEMENTATIONS.md) - implementation status, Java CLI/library usage, and conformance expectations.
 
 ## Quick example

--- a/SPEC.md
+++ b/SPEC.md
@@ -51,6 +51,7 @@ command.
   - [Pattern - `pattern`](#pattern---pattern)
   - [Key Pattern - `keypattern`](#key-pattern---keypattern)
 - [Validation and Data Model](#validation-and-data-model)
+  - [Expressiveness and Validation Scope](#expressiveness-and-validation-scope)
 - [Filename Extension](#filename-extension)
 - [MIME Type](#mime-type)
 - [TOML Reference of a TOML Schema](#toml-reference-of-a-toml-schema)
@@ -953,6 +954,52 @@ It is NOT the goal of a TOML Schema to ever modify the data output of a TOML obj
 
 A validator MUST produce the exact same TOML data object as the underlying TOML
 parser would produce without schema validation.
+
+### Expressiveness and Validation Scope
+
+TOML Schema describes the parsed TOML value tree. It can model the structural
+patterns used by major configuration formats, including:
+
+- fixed keys and closed tables;
+- open tables for extension-owned data;
+- dynamic-key maps with uniform values by using `collection`;
+- arrays of tables and arrays of inline tables by using a named table as an
+  array's `itemtype`;
+- scalar-or-table and other alternative representations with `oneof` or
+  `anyof`;
+- fixed-length heterogeneous arrays with `items`; and
+- quoted, empty, or literal dotted keys through normal TOML key syntax.
+
+The checked-in schemas under [`examples/`](examples/) exercise these patterns
+against formats including [Cargo manifests](https://doc.rust-lang.org/cargo/reference/manifest.html),
+Python [`pyproject.toml`](https://packaging.python.org/en/latest/specifications/pyproject-toml/),
+Hugo, Netlify, GitLab Runner, and Cloudflare Wrangler.
+
+Version 1.0 validates each node independently. It does not define keywords for:
+
+- requiring, forbidding, or changing the schema of one key based on another
+  key's value;
+- mutual exclusion, implication, or exactly-one rules between sibling keys;
+- comparisons or references between values at different paths;
+- uniqueness of array items; or
+- merging, extending, or overriding a named definition at a reference site.
+
+For example, a schema can describe both Cargo dependency string and table
+forms, but cannot express every relationship among `git`, `path`, `version`,
+`branch`, `tag`, and `rev`. A `pyproject.toml` schema can describe the
+`project.dynamic` array and optional dynamic fields, but cannot require a field
+to be absent precisely when its name appears in that array. These application
+policies require an additional semantic-validation pass.
+
+Annotations beyond `description`, such as defaults, examples, deprecation
+notices, and editor-specific presentation hints, are also outside the version
+1.0 vocabulary. They do not affect whether a configuration format can be
+structurally validated.
+
+Validation applies to parsed keys and values, not to their lexical spelling.
+A schema cannot require dotted-key notation instead of table headers, an inline
+table instead of a regular table, or a particular quoting, whitespace, or
+comment style when those forms produce the same TOML value tree.
 
 ## Filename Extension
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,10 +9,17 @@ popular tool or project, and is intended as a learning resource and a
 reference for writing your own schemas. The examples are not affiliated
 with or endorsed by the upstream projects.
 
+These schemas are representative snapshots rather than canonical schemas
+published by the upstream projects. When an upstream rule depends on another
+field's presence or value, the example accepts the structurally valid superset
+and leaves that policy to application-level validation. See
+[Expressiveness and Validation Scope](../SPEC.md#expressiveness-and-validation-scope).
+
 ## Available examples
 
 | File | Describes | Based on |
 | --- | --- | --- |
+| [`cargo.tosd`](cargo.tosd) | Rust Cargo manifests (`Cargo.toml`) | <https://doc.rust-lang.org/cargo/reference/manifest.html> |
 | [`gitlab-runner.tosd`](gitlab-runner.tosd) | GitLab Runner advanced configuration | <https://docs.gitlab.com/runner/configuration/advanced-configuration/> |
 | [`hugo.tosd`](hugo.tosd) | Hugo static site generator configuration | <https://gohugo.io/configuration/> |
 | [`netlify.tosd`](netlify.tosd) | Netlify file-based build configuration (`netlify.toml`) | <https://docs.netlify.com/build/configure-builds/file-based-configuration/> |

--- a/examples/cargo.tosd
+++ b/examples/cargo.tosd
@@ -1,4 +1,4 @@
-# Based on https://dirname.github.io/rust-std-doc/cargo/reference/manifest.html
+# Based on https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [toml-schema]
 version = "1.0.0"
@@ -99,7 +99,71 @@ type = "table"
     optional = true
 
 [types.package]
-type = "types.packageBase"
+type = "table"
+
+    [types.package.version]
+    type = "types.stringOrWorkspace"
+    optional = true
+
+    [types.package.authors]
+    type = "types.stringArrayOrWorkspace"
+    optional = true
+
+    [types.package.edition]
+    type = "types.stringOrWorkspace"
+    optional = true
+
+    [types.package.rust-version]
+    type = "types.stringOrWorkspace"
+    optional = true
+
+    [types.package.description]
+    type = "types.stringOrWorkspace"
+    optional = true
+
+    [types.package.documentation]
+    type = "types.stringOrWorkspace"
+    optional = true
+
+    [types.package.readme]
+    type = "types.stringOrBooleanOrWorkspace"
+    optional = true
+
+    [types.package.homepage]
+    type = "types.stringOrWorkspace"
+    optional = true
+
+    [types.package.repository]
+    type = "types.stringOrWorkspace"
+    optional = true
+
+    [types.package.license]
+    type = "types.stringOrWorkspace"
+    optional = true
+
+    [types.package.license-file]
+    type = "types.stringOrWorkspace"
+    optional = true
+
+    [types.package.keywords]
+    type = "types.stringArrayOrWorkspace"
+    optional = true
+
+    [types.package.categories]
+    type = "types.stringArrayOrWorkspace"
+    optional = true
+
+    [types.package.exclude]
+    type = "types.stringArrayOrWorkspace"
+    optional = true
+
+    [types.package.include]
+    type = "types.stringArrayOrWorkspace"
+    optional = true
+
+    [types.package.publish]
+    type = "types.publish"
+    optional = true
 
     [types.package.name]
     type = "string"

--- a/examples/pyproject.tosd
+++ b/examples/pyproject.tosd
@@ -47,6 +47,7 @@ type = "table"
 
     [types.readmeTable."content-type"]
     type = "string"
+    optional = true
 
 [types.readme]
 oneof = [ "string", "types.readmeTable" ]

--- a/reference-implementations/go/schema_test.go
+++ b/reference-implementations/go/schema_test.go
@@ -23,6 +23,7 @@ func TestValidatesCheckedInExample(t *testing.T) {
 
 func TestLoadsCheckedInExamples(t *testing.T) {
 	for _, name := range []string{
+		"cargo.tosd",
 		"gitlab-runner.tosd",
 		"hugo.tosd",
 		"netlify.tosd",
@@ -34,6 +35,18 @@ func TestLoadsCheckedInExamples(t *testing.T) {
 				t.Fatal(err)
 			}
 		})
+	}
+}
+
+func TestValidatesCargoManifestExample(t *testing.T) {
+	schema, err := LoadSchema(filepath.Join(fixture("examples"), "cargo.tosd"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := schema.ValidateFile(fixture("reference-implementations/rust/Cargo.toml"))
+	if !result.Valid() {
+		t.Fatalf("expected valid Cargo.toml, got %#v", result.Errors)
 	}
 }
 

--- a/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
+++ b/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
@@ -33,6 +33,7 @@ class TomlSchemaTest {
     @Test
     void loadsCheckedInExamples() {
         for (String schema : List.of(
+                "examples/cargo.tosd",
                 "examples/gitlab-runner.tosd",
                 "examples/hugo.tosd",
                 "examples/netlify.tosd",
@@ -40,6 +41,14 @@ class TomlSchemaTest {
                 "examples/wrangler.tosd")) {
             assertDoesNotThrow(() -> TomlSchema.load(fixture(schema)), schema);
         }
+    }
+
+    @Test
+    void validatesCargoManifestExample() throws IOException {
+        ValidationResult result = TomlSchema.load(fixture("examples/cargo.tosd"))
+                .validate(fixture("reference-implementations/rust/Cargo.toml"));
+
+        assertTrue(result.isValid(), () -> result.errors().toString());
     }
 
     @Test
@@ -87,6 +96,16 @@ class TomlSchemaTest {
         assertTrue(schemaSchema.validate(fixture("config.tosd")).isValid());
         assertTrue(schemaSchema.validate(fixture("toml-schema.tosd")).isValid());
         assertTrue(schemaSchema.validate(emptyElementsSchema).isValid());
+        for (String schema : List.of(
+                "examples/cargo.tosd",
+                "examples/gitlab-runner.tosd",
+                "examples/hugo.tosd",
+                "examples/netlify.tosd",
+                "examples/pyproject.tosd",
+                "examples/wrangler.tosd")) {
+            ValidationResult result = schemaSchema.validate(fixture(schema));
+            assertTrue(result.isValid(), () -> schema + ": " + result.errors());
+        }
     }
 
     @Test

--- a/reference-implementations/rust/tests/integration.rs
+++ b/reference-implementations/rust/tests/integration.rs
@@ -62,6 +62,7 @@ fn validates_checked_in_example() {
 #[test]
 fn loads_checked_in_examples() {
     for name in [
+        "cargo.tosd",
         "gitlab-runner.tosd",
         "hugo.tosd",
         "netlify.tosd",
@@ -72,6 +73,17 @@ fn loads_checked_in_examples() {
         Schema::load(&path)
             .unwrap_or_else(|error| panic!("failed to load {}: {error}", path.display()));
     }
+}
+
+#[test]
+fn validates_cargo_manifest_example() {
+    let schema = Schema::load(fixture("examples/cargo.tosd")).expect("load cargo.tosd");
+    let result = schema.validate_file(fixture("reference-implementations/rust/Cargo.toml"));
+    assert!(
+        result.valid(),
+        "expected valid Cargo.toml, got {:#?}",
+        result.errors
+    );
 }
 
 #[test]

--- a/toml-schema.abnf
+++ b/toml-schema.abnf
@@ -14,10 +14,12 @@
 ;; reference-implementation parser profile.
 
 toml-schema-document = toml-document
-; A conforming document contains exactly one required [toml-schema] table,
-; zero or one [types] table, and exactly one required [elements] table.
-; No other top-level members are allowed. Their lexical order is governed by
-; TOML rather than by the order of the productions below.
+; The productions below are an unordered semantic inventory layered on the
+; parsed TOML document; they are not a second, order-sensitive serialization
+; grammar. A conforming document contains exactly one required [toml-schema]
+; table, zero or one [types] table, and exactly one required [elements] table.
+; No other top-level members are allowed. Schema loaders enforce those
+; cardinality and membership constraints after TOML parsing.
 
 toml-schema-table = toml-table-header-toml-schema version [ metadata-table ]
 types-table       = toml-table-header-types *schema-definition


### PR DESCRIPTION
Major TOML configuration formats need dynamic maps, arrays of tables, unions, literal dotted keys, and reusable definitions. This audit confirms those structures are covered while making the boundary between structural schema validation and application-specific semantic rules explicit.

## Summary

- Document the supported real-world patterns and version 1.0 limitations, including cross-field constraints, uniqueness, annotations, and lexical TOML representation.
- Promote the Cargo manifest schema into the industry examples and replace its invalid named-type extension with a conforming table definition.
- Correct the `pyproject.toml` readme model so `content-type` is not unconditionally required.
- Clarify that the ABNF is an unordered semantic layer over parsed TOML.
- Exercise Cargo and all checked-in industry schemas across the Java, Go, and Rust reference implementations, including self-schema validation.

## Review note

The industry schemas intentionally accept a structural superset when upstream validity depends on relationships between fields. Examples include Cargo dependency source exclusivity and `pyproject.toml` dynamic metadata rules; those require an additional semantic-validation pass.