### PR TITLE
Clarify industry schema patterns

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -665,6 +665,13 @@ When collection values may have alternative types, define those alternatives in 
 
 A `collection` may additionally constrain the **keys** (entry names) of its dynamic children with `keypattern`. See [Key Pattern - `keypattern`](#key-pattern---keypattern).
 
+Fixed child definitions take precedence over the collection's dynamic-entry
+rule. This permits a collection to validate known keys precisely while applying
+`itemtype` only to all other keys. For example, `itemtype = "any"` makes unknown
+keys forward-compatible while fixed children still receive their declared
+validation. Authors choosing this pattern trade typo detection on unknown keys
+for extensibility; use a plain `table` when undeclared keys must be rejected.
+
 
 **Example:**
 The below example shows a table `servers` that is a `collection`.
@@ -855,6 +862,25 @@ type = "collection"
 itemtype = "types.dnsValue"
 ```
 
+A named container definition can also be an alternative. This models formats
+that accept either one table or an array of the same table shape:
+
+```toml
+[types.cascadeEntry]
+type = "table"
+
+    [types.cascadeEntry.params]
+    type = "table"
+    optional = true
+
+[types.cascadeEntries]
+type = "array"
+itemtype = "types.cascadeEntry"
+
+[elements.cascade]
+oneof = [ "types.cascadeEntry", "types.cascadeEntries" ]
+```
+
 ### Description - `description`
 
 `description` is an optional human-readable string that documents a schema definition. It may be used on reusable types, elements, and nested definitions. Implementations and tooling MAY use it for documentation, suggestions, and autocompletion; it does not affect validation.
@@ -967,6 +993,8 @@ patterns used by major configuration formats, including:
   array's `itemtype`;
 - scalar-or-table and other alternative representations with `oneof` or
   `anyof`;
+- single-table-or-array-of-table representations through named container
+  alternatives;
 - fixed-length heterogeneous arrays with `items`; and
 - quoted, empty, or literal dotted keys through normal TOML key syntax.
 
@@ -990,6 +1018,12 @@ forms, but cannot express every relationship among `git`, `path`, `version`,
 `project.dynamic` array and optional dynamic fields, but cannot require a field
 to be absent precisely when its name appears in that array. These application
 policies require an additional semantic-validation pass.
+
+Some configuration sections intentionally combine known fields with arbitrary
+future or extension-owned fields. A `collection` with fixed child definitions
+and `itemtype = "any"` models that forward-compatible shape, but unknown keys
+cannot then be distinguished from misspellings. Schema authors SHOULD prefer a
+closed `table` when the upstream format defines a stable, exhaustive key set.
 
 Annotations beyond `description`, such as defaults, examples, deprecation
 notices, and editor-specific presentation hints, are also outside the version

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,7 @@ published by the upstream projects. When an upstream rule depends on another
 field's presence or value, the example accepts the structurally valid superset
 and leaves that policy to application-level validation. See
 [Expressiveness and Validation Scope](../SPEC.md#expressiveness-and-validation-scope).
+The upstream sources in the table below were reviewed on 2026-08-18.
 
 ## Available examples
 
@@ -25,6 +26,14 @@ and leaves that policy to application-level validation. See
 | [`netlify.tosd`](netlify.tosd) | Netlify file-based build configuration (`netlify.toml`) | <https://docs.netlify.com/build/configure-builds/file-based-configuration/> |
 | [`pyproject.tosd`](pyproject.tosd) | Python `pyproject.toml` (PEP 621 + dependency groups) | <https://packaging.python.org/en/latest/specifications/pyproject-toml/> |
 | [`wrangler.tosd`](wrangler.tosd) | Cloudflare Workers `wrangler.toml` | <https://developers.cloudflare.com/workers/wrangler/configuration/> |
+
+Together these examples exercise dynamic-key maps, arrays of tables, open
+extension namespaces, constrained scalar values, map values, fixed and dynamic
+children in one collection, and alternative representations such as scalar
+versus table or one table versus an array of tables. They also expose the
+intentional version 1.0 boundary: cross-field requirements, merge and
+inheritance behavior, sibling mutual exclusion, array uniqueness, and
+deprecation metadata require application-level handling.
 
 ## Using the examples
 

--- a/examples/hugo.tosd
+++ b/examples/hugo.tosd
@@ -7,10 +7,6 @@ version = "1.0.0"
 type = "array"
 itemtype = "string"
 
-[types.anyArray]
-type = "array"
-itemtype = "any"
-
 [types.numberValue]
 oneof = [ "integer", "float" ]
 
@@ -96,8 +92,47 @@ type = "table"
 type = "collection"
 itemtype = "types.cache"
 
+[types.cascadeTarget]
+type = "table"
+
+    [types.cascadeTarget.environment]
+    type = "string"
+    optional = true
+
+    [types.cascadeTarget.kind]
+    type = "string"
+    optional = true
+
+    [types.cascadeTarget.lang]
+    type = "string"
+    optional = true
+
+    [types.cascadeTarget.path]
+    type = "string"
+    optional = true
+
+    [types.cascadeTarget.sites]
+    type = "types.anyMap"
+    optional = true
+
+[types.cascadeEntry]
+type = "collection"
+itemtype = "any"
+
+    [types.cascadeEntry.params]
+    type = "types.anyMap"
+    optional = true
+
+    [types.cascadeEntry.target]
+    type = "types.cascadeTarget"
+    optional = true
+
+[types.cascadeEntries]
+type = "array"
+itemtype = "types.cascadeEntry"
+
 [types.cascade]
-oneof = [ "types.anyMap", "types.anyArray" ]
+oneof = [ "types.cascadeEntry", "types.cascadeEntries" ]
 
 [types.frontmatter]
 type = "table"


### PR DESCRIPTION
TOML Schema already covers the dominant structures used by major TOML configuration formats, but the specification did not clearly explain the forward-compatibility trade-off for mixed fixed and dynamic collections, and several industry examples underrepresented current real-world shapes.

This change:
- documents how fixed collection children take precedence over the dynamic `itemtype` rule and explains the typo-detection trade-off of `itemtype = "any"`;
- demonstrates a typed single-table-or-array-of-tables alternative using named container definitions;
- tightens Hugo's `cascade` model and covers current module settings plus the retained legacy `menu` alias;
- covers Cargo's `lints.rust.unexpected_cfgs.check-cfg` option;
- updates Wrangler observability for nested logs and traces and permits assets-only Workers without `main`;
- records the industry examples' coverage and the intentional 1.0 boundary around cross-field rules, inheritance, uniqueness, and deprecation metadata.

The schemas were exercised against 17 public GitHub configurations: three each for Cargo, pyproject, Hugo, Netlify, and Wrangler, plus two official GitLab Runner fixtures. All 17 validate with the Java, Go, and Rust reference implementations. The language vocabulary is unchanged; these updates clarify existing semantics and improve example precision.