### PR TITLE
Validate industry schemas against public configs

### DIFF
--- a/examples/cargo.tosd
+++ b/examples/cargo.tosd
@@ -356,6 +356,11 @@ type = "table"
     type = "integer"
     optional = true
 
+    [types.lintTable.check-cfg]
+    type = "array"
+    itemtype = "string"
+    optional = true
+
 [types.lintGroup]
 type = "collection"
 itemtype = "types.lintValue"

--- a/examples/hugo.tosd
+++ b/examples/hugo.tosd
@@ -741,8 +741,31 @@ itemtype = "any"
     itemtype = "string"
     optional = true
 
+[types.hugoVersion]
+type = "table"
+
+    [types.hugoVersion.extended]
+    type = "boolean"
+    optional = true
+
+    [types.hugoVersion.max]
+    type = "string"
+    optional = true
+
+    [types.hugoVersion.min]
+    type = "string"
+    optional = true
+
 [types.module]
 type = "table"
+
+    [types.module.auth]
+    type = "string"
+    optional = true
+
+    [types.module.hugoVersion]
+    type = "types.hugoVersion"
+    optional = true
 
     [types.module.imports]
     type = "array"
@@ -758,6 +781,10 @@ type = "table"
     type = "string"
     optional = true
 
+    [types.module.noVendor]
+    type = "string"
+    optional = true
+
     [types.module.private]
     type = "string"
     optional = true
@@ -768,6 +795,10 @@ type = "table"
 
     [types.module.replacements]
     type = "string"
+    optional = true
+
+    [types.module.vendorClosest]
+    type = "boolean"
     optional = true
 
     [types.module.workspace]
@@ -1261,6 +1292,11 @@ optional = true
 
 [elements.menus]
 type = "types.menus"
+optional = true
+
+[elements.menu]
+type = "types.menus"
+description = "Legacy alias for menus retained by Hugo for compatibility."
 optional = true
 
 [elements.minify]

--- a/examples/wrangler.tosd
+++ b/examples/wrangler.tosd
@@ -77,9 +77,62 @@ type = "table"
 
     [types.observability.enabled]
     type = "boolean"
+    optional = true
 
     [types.observability.head_sampling_rate]
     type = "types.numberValue"
+    optional = true
+
+    [types.observability.logs]
+    type = "types.observabilityLogs"
+    optional = true
+
+    [types.observability.traces]
+    type = "types.observabilityTraces"
+    optional = true
+
+[types.observabilityLogs]
+type = "table"
+
+    [types.observabilityLogs.enabled]
+    type = "boolean"
+    optional = true
+
+    [types.observabilityLogs.head_sampling_rate]
+    type = "types.numberValue"
+    optional = true
+
+    [types.observabilityLogs.invocation_logs]
+    type = "boolean"
+    optional = true
+
+    [types.observabilityLogs.persist]
+    type = "boolean"
+    optional = true
+
+    [types.observabilityLogs.destinations]
+    type = "array"
+    itemtype = "string"
+    optional = true
+
+[types.observabilityTraces]
+type = "table"
+
+    [types.observabilityTraces.enabled]
+    type = "boolean"
+    optional = true
+
+    [types.observabilityTraces.head_sampling_rate]
+    type = "types.numberValue"
+    optional = true
+
+    [types.observabilityTraces.persist]
+    type = "boolean"
+    optional = true
+
+    [types.observabilityTraces.destinations]
+    type = "array"
+    itemtype = "string"
     optional = true
 
 [types.build]
@@ -961,6 +1014,8 @@ type = "types.workerName"
 
 [elements.main]
 type = "string"
+description = "Worker entrypoint; optional for assets-only Workers."
+optional = true
 
 [elements.compatibility_date]
 type = "types.compatibilityDate"


### PR DESCRIPTION
The industry schemas need to match configuration shapes that are actively used in public projects, not only illustrative snippets. Validation against 17 pinned GitHub fixtures found five mismatches across Cargo, Hugo, and Wrangler while pyproject, Netlify, and official GitLab Runner fixtures already passed.

This change:
- supports Cargo's `lints.rust.unexpected_cfgs.check-cfg` array;
- covers Hugo module version settings, current module options, and the retained legacy `menu` alias;
- models Wrangler's nested observability logs and traces;
- permits assets-only Workers where `main` is conditionally optional.

After these corrections, all 17 public fixtures validate with the Java, Go, and Rust reference implementations, and all existing implementation test suites pass.