### PR TITLE
Clarify TOML schema industry coverage

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -652,7 +652,9 @@ Semantics:
 
 One can set an element of type `collection` when there is a need to have multiple children with dynamic, user-provided keys or table headers.
 
-A `collection` is also a `table` and, therefore, it may have nested, schema-restricted key-value pairs of simple types.
+A `collection` is also a `table` and, therefore, it may have fixed child
+definitions in addition to dynamically named entries. Fixed children may use
+any schema definition, including nested tables, arrays, and named types.
 
 A `collection` requires `itemtype` to define the type of its dynamic child values. Each dynamic child must be given a unique key in the TOML document. `itemtype` may reference a built-in type or a named reusable definition.
 
@@ -671,6 +673,12 @@ rule. This permits a collection to validate known keys precisely while applying
 keys forward-compatible while fixed children still receive their declared
 validation. Authors choosing this pattern trade typo detection on unknown keys
 for extensibility; use a plain `table` when undeclared keys must be rejected.
+
+This precedence also supports open extension namespaces with typed well-known
+entries. For example, a `pyproject.toml` schema can define `[tool]` as a
+collection of open tables, then add fixed `[tool.ruff]` and `[tool.uv]` child
+definitions with their respective schemas. Other tool names continue to use the
+collection's general `itemtype`.
 
 
 **Example:**
@@ -989,6 +997,8 @@ patterns used by major configuration formats, including:
 - fixed keys and closed tables;
 - open tables for extension-owned data;
 - dynamic-key maps with uniform values by using `collection`;
+- open namespaces with specially typed well-known keys by combining a
+  `collection` with fixed child definitions;
 - arrays of tables and arrays of inline tables by using a named table as an
   array's `itemtype`;
 - scalar-or-table and other alternative representations with `oneof` or

--- a/examples/README.md
+++ b/examples/README.md
@@ -35,6 +35,33 @@ intentional version 1.0 boundary: cross-field requirements, merge and
 inheritance behavior, sibling mutual exclusion, array uniqueness, and
 deprecation metadata require application-level handling.
 
+## Industry format coverage
+
+The version 1.0 vocabulary is sufficient to describe the parsed structure of
+the major formats reviewed:
+
+| Format | Structural coverage | Remaining application-level rules |
+| --- | --- | --- |
+| [Cargo](https://doc.rust-lang.org/cargo/reference/manifest.html) | Dependencies, target-specific maps, workspace inheritance, profiles, arrays of targets | Relationships among dependency source fields, unstable-feature gates |
+| [`pyproject.toml`](https://packaging.python.org/en/latest/specifications/pyproject-toml/) | Project metadata, build systems, dependency groups, open `[tool]` namespaces | Static-versus-dynamic metadata rules, mutually exclusive table fields |
+| [uv](https://docs.astral.sh/uv/reference/settings/) and [Ruff](https://docs.astral.sh/ruff/settings/) | Fixed settings, enums, unions, nested tables, typed maps | Merge behavior, sibling dependencies, defaults and deprecations |
+| [Taplo](https://github.com/tamasfe/taplo/blob/master/crates/taplo-common/src/config.rs) | Closed option tables, arrays of rules, plugin maps | URL/path precedence and embedded glob semantics |
+| [Starship](https://starship.rs/config/) | Fixed modules, custom-module maps, nested palette maps | Reusable base-module extension, defaults, embedded format-string syntax |
+| [Wrangler](https://developers.cloudflare.com/workers/wrangler/configuration/) | Routes, bindings, module rules, environment maps | Inheritance and override semantics, embedded cron syntax |
+
+A collection may combine fixed children with a general `itemtype`, so an open
+namespace can still give well-known keys specialized schemas. For example,
+`[tool.ruff]` and `[tool.uv]` can be fixed children of a `[tool]` collection
+while unknown tool names remain open. The generic `pyproject.tosd` example
+intentionally leaves every `[tool.*]` entry open because it does not bundle
+third-party tool schemas.
+
+Across these formats, the main practical limitation is semantic rather than
+structural: version 1.0 does not express relationships between sibling or
+cross-path values. Defaults, examples, and deprecation notices are also not
+machine-readable annotations. These boundaries are detailed in
+[Expressiveness and Validation Scope](../SPEC.md#expressiveness-and-validation-scope).
+
 ## Using the examples
 
 You can validate a TOML file against any of these schemas using one of the

--- a/examples/pyproject.tosd
+++ b/examples/pyproject.tosd
@@ -36,6 +36,7 @@ type = "table"
 
 [types.readmeTable]
 type = "table"
+description = "Exactly one of file or text is required; sibling mutual exclusion requires application-level validation."
 
     [types.readmeTable.file]
     type = "string"
@@ -47,7 +48,6 @@ type = "table"
 
     [types.readmeTable."content-type"]
     type = "string"
-    optional = true
 
 [types.readme]
 oneof = [ "string", "types.readmeTable" ]
@@ -87,11 +87,11 @@ pattern = '^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$'
 
 [types.pythonImportName]
 type = "string"
-pattern = '^([A-Za-z_][A-Za-z0-9_]*)(\.[A-Za-z_][A-Za-z0-9_]*)*(\s*;\s*private)?$'
+pattern = '^([A-Za-z_][A-Za-z0-9_]*)(\.[A-Za-z_][A-Za-z0-9_]*)*([ \t]*;[ \t]*private)?$'
 
 [types.pythonImportNameOrEmpty]
 type = "string"
-pattern = '^$|^([A-Za-z_][A-Za-z0-9_]*)(\.[A-Za-z_][A-Za-z0-9_]*)*(\s*;\s*private)?$'
+pattern = '^$|^([A-Za-z_][A-Za-z0-9_]*)(\.[A-Za-z_][A-Za-z0-9_]*)*([ \t]*;[ \t]*private)?$'
 
 [types.importNames]
 type = "array"


### PR DESCRIPTION
TOML Schema's real-world applicability was documented only broadly, and the `pyproject.toml` example contained two details that did not fully match the specification and upstream metadata rules.

This change:
- clarifies that collections can combine dynamic entries with fully typed fixed children, including specialized schemas for well-known entries in open namespaces;
- documents structural coverage and semantic limitations across Cargo, `pyproject.toml`, uv, Ruff, Taplo, Starship, and Wrangler;
- makes `readme.content-type` required for table-form project metadata; and
- replaces non-portable `\s` regex shorthand with the specification's portable character-class form.

The ABNF and self-schema remain unchanged because their vocabulary and structural responsibilities already align with the normative specification.