### PR TITLE
Publish real-world TOML Schema validation report

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -30,6 +30,7 @@
       </a>
       <nav aria-label="Primary navigation">
         <a href="#why">Why</a>
+        <a href="/validation-report/">Evidence</a>
         <a href="#tour">Tour</a>
         <a href="/spec/">Spec</a>
         <a href="#implementations">Implementations</a>
@@ -48,7 +49,7 @@
           </p>
           <div class="actions">
             <a class="button" href="/spec/">Read the specification</a>
-            <a class="button-secondary" href="https://github.com/brunoborges/toml-schema">View on GitHub</a>
+            <a class="button-secondary" href="/validation-report/">See real-world results</a>
           </div>
         </div>
         <aside class="panel" aria-label="Example TOML Schema document">
@@ -99,6 +100,14 @@ itemtype = "integer"</code></pre>
           </article>
         </div>
       </section>
+
+      <a class="proof-band" href="/validation-report/">
+        <span>
+          <strong>Tested beyond the examples</strong>
+          <span>18 public configuration files from six TOML ecosystems were validated without editing the source files.</span>
+        </span>
+        <span class="proof-result">16 passed unchanged <span aria-hidden="true">→</span></span>
+      </a>
 
       <section class="section" id="tour">
         <h2>A Quick Tour of TOML Schema</h2>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -70,6 +70,10 @@ a {
   text-decoration-thickness: 1px;
   text-underline-offset: 3px;
 }
+a:focus-visible {
+  outline: 3px solid var(--cp-link);
+  outline-offset: 3px;
+}
 code,
 pre {
   font-family: Consolas, "Courier New", Courier, monospace;
@@ -143,6 +147,11 @@ nav a,
 nav a:hover,
 .button-secondary:hover {
   background: var(--cp-surface-soft);
+}
+nav a[aria-current="page"] {
+  background: var(--cp-accent-soft);
+  border-color: var(--cp-accent);
+  color: var(--cp-accent);
 }
 .button {
   background: var(--cp-accent);
@@ -315,6 +324,32 @@ pre {
   font-weight: 700;
   padding: 4px 8px;
 }
+.proof-band {
+  align-items: center;
+  border-bottom: 1px solid var(--cp-border-strong);
+  border-top: 1px solid var(--cp-border-strong);
+  color: var(--cp-text);
+  display: flex;
+  gap: 24px;
+  justify-content: space-between;
+  padding: 24px 4px;
+  text-decoration: none;
+}
+.proof-band > span:first-child {
+  display: grid;
+  gap: 4px;
+}
+.proof-band > span:first-child > span {
+  color: var(--cp-text-muted);
+}
+.proof-band:hover .proof-result {
+  color: var(--cp-accent-hover);
+}
+.proof-result {
+  color: var(--cp-accent);
+  flex: 0 0 auto;
+  font-weight: 700;
+}
 footer {
   border-top: 1px solid var(--cp-border);
   color: var(--cp-text-muted);
@@ -323,6 +358,193 @@ footer {
   gap: 12px;
   justify-content: space-between;
   padding: 28px 0 0;
+}
+
+/* Real-world validation report */
+.report {
+  margin: 0 auto;
+  max-width: 960px;
+}
+.report-hero {
+  padding: 72px 0 48px;
+}
+.report-hero h1 {
+  font-size: clamp(42px, 7vw, 72px);
+  letter-spacing: -0.04em;
+  max-width: 13ch;
+}
+.evidence-line {
+  border-bottom: 1px solid var(--cp-border-strong);
+  border-top: 1px solid var(--cp-border-strong);
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+}
+.evidence-line span {
+  color: var(--cp-text-muted);
+  padding: 18px 16px;
+}
+.evidence-line span + span {
+  border-left: 1px solid var(--cp-border);
+}
+.evidence-line strong {
+  color: var(--cp-text);
+  display: block;
+  font-size: 24px;
+}
+.report-section {
+  padding: 64px 0;
+}
+.report-section + .report-section {
+  border-top: 1px solid var(--cp-border);
+}
+.report-intro h2 {
+  max-width: 18ch;
+}
+.report-columns {
+  column-gap: 48px;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  margin-top: 28px;
+}
+.report-columns p,
+.diagnosis p,
+.limits p,
+.report-cta p {
+  color: var(--cp-text-muted);
+  font-size: 18px;
+  margin: 0;
+}
+.report-columns p + p,
+.limits p + p {
+  margin-top: 0;
+}
+.result-groups {
+  border-top: 1px solid var(--cp-border);
+  margin-top: 32px;
+}
+.result-group {
+  border-bottom: 1px solid var(--cp-border);
+  padding: 28px 0;
+}
+.result-heading {
+  align-items: start;
+  display: flex;
+  gap: 24px;
+  justify-content: space-between;
+}
+.result-heading p {
+  color: var(--cp-text-muted);
+  margin: 8px 0 0;
+}
+.status {
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  flex: 0 0 auto;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 5px 10px;
+}
+.status-pass {
+  color: var(--cp-success);
+}
+.status-mixed {
+  color: var(--cp-warning);
+}
+.source-list {
+  display: grid;
+  gap: 0;
+  list-style: none;
+  margin: 20px 0 0;
+  padding: 0;
+}
+.source-list li {
+  align-items: center;
+  display: flex;
+  gap: 16px;
+  justify-content: space-between;
+  padding: 9px 0;
+}
+.source-list li + li {
+  border-top: 1px solid var(--cp-border);
+}
+.source-list code,
+.inline-result {
+  color: var(--cp-text-muted);
+  font-size: 13px;
+}
+.diagnosis {
+  display: grid;
+  gap: 28px;
+  grid-template-columns: minmax(0, 0.9fr) minmax(320px, 1.1fr);
+}
+.diagnosis h2 {
+  max-width: 16ch;
+}
+.diagnosis > div > p {
+  margin-top: 16px;
+}
+.diagnostic-output {
+  background: var(--cp-surface);
+  border: 1px solid var(--cp-border);
+  border-radius: 12px;
+  display: grid;
+  gap: 10px;
+  padding: 20px;
+}
+.diagnostic-output code {
+  overflow-wrap: anywhere;
+}
+.diagnosis .diagnosis-note {
+  grid-column: 1 / -1;
+}
+.method-list {
+  counter-reset: method;
+  list-style: none;
+  margin: 32px 0;
+  padding: 0;
+}
+.method-list li {
+  align-items: baseline;
+  border-top: 1px solid var(--cp-border);
+  counter-increment: method;
+  display: grid;
+  gap: 16px;
+  grid-template-columns: 24px minmax(220px, 0.8fr) minmax(0, 1.2fr);
+  padding: 18px 0;
+}
+.method-list li::before {
+  color: var(--cp-accent);
+  content: counter(method) ".";
+  font-weight: 700;
+}
+.method-list span {
+  color: var(--cp-text-muted);
+}
+.command-block {
+  background: var(--cp-surface);
+  border: 1px solid var(--cp-border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+.limits {
+  display: grid;
+  gap: 32px 48px;
+  grid-template-columns: 1fr 1fr;
+}
+.limits h2 {
+  grid-column: 1 / -1;
+  max-width: 18ch;
+}
+.report-cta {
+  border-top: 1px solid var(--cp-border-strong);
+  padding: 64px 0 72px;
+}
+.report-cta h2 {
+  max-width: 20ch;
+}
+.report-cta p {
+  margin-top: 16px;
+  max-width: 64ch;
 }
 @media (max-width: 840px) {
   header,
@@ -344,6 +566,41 @@ footer {
   .implementations,
   .spec-list {
     grid-template-columns: 1fr;
+  }
+  .proof-band,
+  .result-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+  .evidence-line {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .evidence-line span:nth-child(3) {
+    border-left: 0;
+    border-top: 1px solid var(--cp-border);
+  }
+  .evidence-line span:nth-child(4) {
+    border-top: 1px solid var(--cp-border);
+  }
+  .report-columns,
+  .diagnosis,
+  .limits {
+    grid-template-columns: 1fr;
+  }
+  .method-list li {
+    grid-template-columns: 24px 1fr;
+  }
+  .method-list span {
+    grid-column: 2;
+  }
+  .report-columns p + p,
+  .limits p + p {
+    margin-top: 20px;
+  }
+  .source-list li {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 4px;
   }
 }
 
@@ -446,7 +703,7 @@ footer {
   padding: 0;
 }
 .markdown blockquote {
-  border-left: 3px solid var(--cp-accent);
+  border-left: 1px solid var(--cp-accent);
   color: var(--cp-text-muted);
   margin: 0 0 1em;
   padding: 0.2em 0 0.2em 1em;

--- a/docs/validation-report/index.html
+++ b/docs/validation-report/index.html
@@ -1,0 +1,235 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="A field report validating 18 real-world Cargo, pyproject, Hugo, Netlify, Wrangler, and GitLab Runner files with TOML Schema.">
+  <link rel="canonical" href="https://toml-schema.org/validation-report/">
+  <title>Real-world validation report · TOML Schema</title>
+  <script>
+    (() => {
+      const param = new URLSearchParams(window.location.search).get("clawpilotTheme");
+      const theme =
+        param || (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+      document.documentElement.setAttribute("data-theme", theme);
+    })();
+  </script>
+  <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+  <div class="page">
+    <header>
+      <a class="brand" href="/" aria-label="TOML Schema home">
+        <svg class="brand-logo" viewBox="0 0 420 128" preserveAspectRatio="xMinYMid meet" aria-hidden="true" focusable="false">
+          <polygon class="logo-bracket" points="0 0 34 0 34 14 18 14 18 114 34 114 34 128 0 128" />
+          <polygon class="logo-t" points="42 26 104 26 104 42 80 42 80 110 66 110 66 42 42 42" />
+          <polygon class="logo-bracket" points="112 0 146 0 146 128 112 128 112 114 128 114 128 14 112 14" />
+          <text class="logo-schema" x="160" y="110">Schema</text>
+        </svg>
+        <span class="visually-hidden">TOML Schema</span>
+      </a>
+      <nav aria-label="Primary navigation">
+        <a href="/">Home</a>
+        <a href="/validation-report/" aria-current="page">Evidence</a>
+        <a href="/spec/">Spec</a>
+        <a href="https://github.com/brunoborges/toml-schema">GitHub</a>
+      </nav>
+    </header>
+
+    <main class="report">
+      <section class="report-hero">
+        <h1>16 of 18 real-world TOML files validated unchanged.</h1>
+        <p class="lead">
+          We took public configuration files from six established TOML ecosystems,
+          downloaded them directly from GitHub, and ran the Java reference validator.
+          No source file was rewritten to fit the schema.
+        </p>
+        <div class="actions">
+          <a class="button" href="#results">Inspect every result</a>
+          <a class="button-secondary" href="#method">Review the method</a>
+        </div>
+      </section>
+
+      <div class="evidence-line" aria-label="Report summary">
+        <span><strong>18</strong> public files</span>
+        <span><strong>6</strong> ecosystems</span>
+        <span><strong>5</strong> schemas at 100%</span>
+        <span><strong>2</strong> precise diagnostics</span>
+      </div>
+
+      <section class="report-section report-intro">
+        <h2>A useful schema has to survive contact with existing files.</h2>
+        <div class="report-columns">
+          <p>
+            A specification can look complete while only validating its own examples.
+            This field test deliberately moved outside the repository: package manifests,
+            deployment settings, site configuration, worker bindings, and CI runner files
+            from unrelated public projects.
+          </p>
+          <p>
+            The result is evidence that TOML Schema can describe mature, varied formats
+            without translating them into another language. It also shows the value of
+            strict validation: the two failures identified exact compatibility differences
+            instead of silently accepting unknown keys.
+          </p>
+        </div>
+      </section>
+
+      <section class="report-section" id="results">
+        <h2>Results by ecosystem</h2>
+        <p class="section-intro">
+          Each source link is pinned to the revision used where available. “Valid” means
+          the downloaded TOML document passed the proposed schema with no modifications.
+        </p>
+        <div class="result-groups">
+          <article class="result-group">
+            <div class="result-heading">
+              <div><h3>Cargo</h3><p>Packages, workspaces, target dependencies, profiles, and metadata.</p></div>
+              <span class="status status-pass">3 / 3 valid</span>
+            </div>
+            <ul class="source-list">
+              <li><a href="https://github.com/BurntSushi/ripgrep/blob/8372866810a1f2a647d11d7780984d4402a5c1e9/Cargo.toml">BurntSushi/ripgrep</a><code>Cargo.toml</code></li>
+              <li><a href="https://github.com/sharkdp/bat/blob/1cf12d49bda67f3f26ee0e26d1ab72ccc2e844a7/Cargo.toml">sharkdp/bat</a><code>Cargo.toml</code></li>
+              <li><a href="https://github.com/tokio-rs/tokio/blob/dd1196d36930bf23d5ba32402f5dadef861546fa/Cargo.toml">tokio-rs/tokio</a><code>Cargo.toml</code></li>
+            </ul>
+          </article>
+
+          <article class="result-group">
+            <div class="result-heading">
+              <div><h3>pyproject</h3><p>PEP 621 metadata, dependency groups, build systems, and open tool namespaces.</p></div>
+              <span class="status status-pass">3 / 3 valid</span>
+            </div>
+            <ul class="source-list">
+              <li><a href="https://github.com/fastapi/fastapi/blob/b35a7c39447d6953c8791172068146baad702590/pyproject.toml">fastapi/fastapi</a><code>pyproject.toml</code></li>
+              <li><a href="https://github.com/encode/httpx/blob/767cf6baa608a56d03f8fe438a39c2013904f0ae/pyproject.toml">encode/httpx</a><code>pyproject.toml</code></li>
+              <li><a href="https://github.com/pydantic/pydantic/blob/f7e30afbd959b3cf6401ebec3ed2a239aa1eaae8/pyproject.toml">pydantic/pydantic</a><code>pyproject.toml</code></li>
+            </ul>
+          </article>
+
+          <article class="result-group result-group-attention">
+            <div class="result-heading">
+              <div><h3>Hugo</h3><p>Site settings, modules, theme parameters, languages, and pagination.</p></div>
+              <span class="status status-mixed">1 / 3 valid</span>
+            </div>
+            <ul class="source-list">
+              <li><a href="https://github.com/dillonzq/LoveIt/blob/23bc60506c5632547bdc7b56b927ae154a321c27/hugo.toml">dillonzq/LoveIt</a><span class="inline-result">Valid</span></li>
+              <li><a href="https://github.com/neoforged/websites/blob/4d38126b8b02c7aeb668bb26b2c01a25d1521728/hugo.toml">neoforged/websites</a><code>$.Params</code></li>
+              <li><a href="https://github.com/pyrevitlabs/pyrevitlabs/blob/334a730ae531be55987d6fb758236fafdcf61c39/hugo.toml">pyrevitlabs/pyrevitlabs</a><code>3 legacy names</code></li>
+            </ul>
+          </article>
+
+          <article class="result-group">
+            <div class="result-heading">
+              <div><h3>Netlify</h3><p>Build contexts, redirects, headers, environment values, and deployment behavior.</p></div>
+              <span class="status status-pass">3 / 3 valid</span>
+            </div>
+            <ul class="source-list">
+              <li><a href="https://github.com/rstacruz/cheatsheets/blob/5fc5cef0ca5d16f7959ffe0bad7b440c7ac9fbe7/netlify.toml">rstacruz/cheatsheets</a><code>netlify.toml</code></li>
+              <li><a href="https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/67de5c25543b2ec9c76897670fc928309473fbe1/netlify.toml">cluster-api-provider-aws</a><code>netlify.toml</code></li>
+              <li><a href="https://github.com/ajitid/fzf-for-js/blob/cf3903255b6bba6143bfbed5a387f3cadfd6938a/netlify.toml">ajitid/fzf-for-js</a><code>netlify.toml</code></li>
+            </ul>
+          </article>
+
+          <article class="result-group">
+            <div class="result-heading">
+              <div><h3>Cloudflare Wrangler</h3><p>Worker entry points, bindings, routes, variables, and compatibility settings.</p></div>
+              <span class="status status-pass">3 / 3 valid</span>
+            </div>
+            <ul class="source-list">
+              <li><a href="https://github.com/justlovemaki/CloudFlare-AI-Insight-Daily/blob/287cde1f1614e90e6c2f5e39ce6621dd9f7b8d83/wrangler.toml">CloudFlare-AI-Insight-Daily</a><code>wrangler.toml</code></li>
+              <li><a href="https://github.com/ling-drag0n/CloudPaste-old/blob/de8ca6a4ebd31cc5e224480b5528b0348e8b75a7/wrangler.toml">ling-drag0n/CloudPaste-old</a><code>wrangler.toml</code></li>
+              <li><a href="https://github.com/philipwalton/blog/blob/cb68580dae3e7c329a5f257a71f25f034f805f41/wrangler.toml">philipwalton/blog</a><code>wrangler.toml</code></li>
+            </ul>
+          </article>
+
+          <article class="result-group">
+            <div class="result-heading">
+              <div><h3>GitLab Runner</h3><p>Global settings, runner arrays, executors, and service configuration.</p></div>
+              <span class="status status-pass">3 / 3 valid</span>
+            </div>
+            <ul class="source-list">
+              <li><a href="https://github.com/gitlabhq/gitlab-runner/blob/92c053a68de5adba40c32546c52bde5373c13b8a/config.toml.example">gitlabhq/gitlab-runner</a><code>config.toml.example</code></li>
+              <li><a href="https://github.com/tomMoulard/make-my-server/blob/4db27e3358b9df240722013b4532ce559a642d2c/gitlab/runner/config.toml">tomMoulard/make-my-server</a><code>config.toml</code></li>
+              <li><a href="https://github.com/cavo789/blog/blob/474cd8660f017cc74294950652375fed9a9d576f/blog/2025/06/15/gitlab-docker-out-of-docker/files/config.toml">cavo789/blog</a><code>config.toml</code></li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
+      <section class="report-section diagnosis">
+        <div>
+          <h2>The two failures made the case for validation.</h2>
+          <p>
+            They were not parser crashes or vague incompatibilities. The validator returned
+            exact paths for keys outside the current Hugo configuration vocabulary.
+          </p>
+        </div>
+        <div class="diagnostic-output">
+          <code>$.Params: unexpected key</code>
+          <code>$.pagination.paginate: unexpected key</code>
+          <code>$.languagecode: unexpected key</code>
+          <code>$.defaultcontentlanguage: unexpected key</code>
+        </div>
+        <p class="diagnosis-note">
+          The proposed schema follows Hugo’s current documented names:
+          <code>params</code>, <code>pagination.pagerSize</code>,
+          <code>languageCode</code>, and <code>defaultContentLanguage</code>.
+          A compatibility schema could choose to admit historical aliases; the current
+          schema instead reports them visibly.
+        </p>
+      </section>
+
+      <section class="report-section" id="method">
+        <h2>Method</h2>
+        <ol class="method-list">
+          <li><strong>Search public GitHub repositories.</strong><span>Prefer project configuration over vendor documentation and template-only examples.</span></li>
+          <li><strong>Pin and download the source.</strong><span>Use repository content directly; do not normalize casing, remove unknown keys, or otherwise prepare it for the schema.</span></li>
+          <li><strong>Validate with the reference CLI.</strong><span>Pair each file with the corresponding proposed <code>.tosd</code> schema.</span></li>
+          <li><strong>Record every outcome.</strong><span>Count strict validation failures as failures and retain the diagnostic paths.</span></li>
+        </ol>
+        <div class="command-block">
+          <div class="panel-header"><strong>Reproduce a validation</strong></div>
+          <pre><code>java -jar toml-schema-1.0.0-rc.2.jar \
+  validate examples/cargo.tosd path/to/Cargo.toml</code></pre>
+        </div>
+      </section>
+
+      <section class="report-section limits">
+        <h2>What this report does—and does not—show</h2>
+        <p>
+          Eighteen files are a field test, not a statistical benchmark or a claim of
+          universal format coverage. The sample spans simple and complex documents but
+          cannot exercise every key or cross-field policy. GitLab Runner files also
+          require care because production copies commonly contain tokens; the selected
+          public files used placeholders or empty values.
+        </p>
+        <p>
+          What the test does show is concrete: one small, TOML-native vocabulary described
+          six independently evolved configuration families, accepted every selected file
+          in five of them, and produced actionable paths for the remaining differences.
+        </p>
+      </section>
+
+      <section class="report-cta">
+        <h2>Make TOML configuration discoverable, validatable, and toolable.</h2>
+        <p>Read the language proposal, try a reference implementation, or bring a real configuration format to the examples.</p>
+        <div class="actions">
+          <a class="button" href="/spec/">Read the specification</a>
+          <a class="button-secondary" href="https://github.com/brunoborges/toml-schema/tree/main/examples">Explore the schemas</a>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <span>TOML Schema is licensed under MIT.</span>
+      <span>
+        <a href="/">Home</a>
+        <span class="muted"> / </span>
+        <a href="/spec/">Spec</a>
+        <span class="muted"> / </span>
+        <a href="https://github.com/brunoborges/toml-schema/issues">Feedback</a>
+      </span>
+    </footer>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
TOML Schema needs evidence beyond its own examples to make a credible adoption case. This adds a public field report showing how the proposed schemas perform against 18 unmodified configuration files from six established TOML ecosystems.

## What changed

- Publishes `/validation-report/` with pinned GitHub sources, the full 16-of-18 result set, methodology, limitations, and exact diagnostics for the two Hugo compatibility differences.
- Explains why strict failures are useful rather than hiding them: the Hugo schema follows current documented names while the sampled files use capitalization or legacy aliases.
- Adds prominent Evidence links from the homepage navigation, hero, and a dedicated proof band.
- Extends the existing visual language with responsive report layouts, dark-mode support, visible focus states, and mobile-safe result lists.

The report is intentionally framed as a field test, not a statistical benchmark. It keeps the adoption argument persuasive while making the sample size and coverage limits explicit.