### PR TITLE
Align TOML Schema Editor with current specification

### DIFF
--- a/.github/extensions/tosd-editor/client.js
+++ b/.github/extensions/tosd-editor/client.js
@@ -46,6 +46,8 @@ const state = {
     lastIssues: [],
     view: "elements",
     zoom: 1,
+    showLegend: false,
+    kbFocus: false,
 };
 
 function resolvedKinds(ref, seen = new Set()) {
@@ -67,6 +69,10 @@ function resolvedKinds(ref, seen = new Set()) {
 }
 
 const $ = (sel, root = document) => root.querySelector(sel);
+
+let uidCounter = 0;
+const uid = (prefix = "f") => `tosd-${prefix}-${++uidCounter}`;
+
 function el(tag, attrs = {}, ...kids) {
     const node = document.createElement(tag);
     for (const [k, v] of Object.entries(attrs)) {
@@ -90,6 +96,7 @@ async function load() {
     state.model = data.model;
     state.dirty = false;
     state.selected = (state.model.elements[0] || state.model.types[0]) ?? null;
+    resetHistory();
     renderAll();
     schedulePreview();
 }
@@ -129,6 +136,7 @@ async function save() {
         const data = await res.json();
         if (data.ok) {
             state.dirty = false;
+            history.saved = snapshot();
             updateStatus("saved", "Saved");
         } else {
             updateStatus("dirty", "Save failed: " + (data.error || "unknown"));
@@ -143,7 +151,124 @@ async function save() {
 function markDirty() {
     state.dirty = true;
     updateStatus("dirty", "Unsaved changes");
+    scheduleHistory();
     schedulePreview();
+}
+
+// --- Undo / redo history ------------------------------------------------
+// Snapshots capture only persistent schema shape. Rapid edits (e.g. typing in
+// a field) are coalesced into a single history entry via a short timer so undo
+// steps map to meaningful user actions rather than individual keystrokes.
+const history = { undo: [], redo: [], base: null, saved: null, timer: null, pending: false };
+
+function snapshot() {
+    return JSON.stringify(
+        { version: state.model.version, meta: state.model.meta, types: state.model.types, elements: state.model.elements },
+        (k, v) => (k.startsWith("__") && k !== "__collapsed" ? undefined : v),
+    );
+}
+
+function resetHistory() {
+    history.undo = [];
+    history.redo = [];
+    history.base = snapshot();
+    history.saved = history.base;
+    history.pending = false;
+    clearTimeout(history.timer);
+    updateHistoryButtons();
+}
+
+function scheduleHistory() {
+    history.pending = true;
+    clearTimeout(history.timer);
+    history.timer = setTimeout(commitHistory, 400);
+    updateHistoryButtons();
+}
+
+function commitHistory() {
+    clearTimeout(history.timer);
+    if (!history.pending) return;
+    history.pending = false;
+    const current = snapshot();
+    if (current === history.base) return;
+    history.undo.push(history.base);
+    if (history.undo.length > 100) history.undo.shift();
+    history.redo = [];
+    history.base = current;
+    updateHistoryButtons();
+}
+
+function findPath(list, target, acc) {
+    for (const n of list || []) {
+        const p = [...acc, n.name];
+        if (n === target) return p;
+        if (n.children) {
+            const r = findPath(n.children, target, p);
+            if (r) return r;
+        }
+    }
+    return null;
+}
+
+function selectionRef() {
+    if (state.selected === "__meta__") return { meta: true };
+    if (!state.selected || typeof state.selected !== "object") return null;
+    for (const view of ["elements", "types"]) {
+        const p = findPath(state.model[view], state.selected, []);
+        if (p) return { view, path: p };
+    }
+    return null;
+}
+
+function resolveSelection(ref) {
+    if (!ref) return null;
+    if (ref.meta) return "__meta__";
+    let list = state.model[ref.view];
+    let node = null;
+    for (const name of ref.path) {
+        node = (list || []).find((n) => n.name === name);
+        if (!node) return null;
+        list = node.children;
+    }
+    if (node) state.view = ref.view;
+    return node;
+}
+
+function applySnapshot(str) {
+    const ref = selectionRef();
+    const d = JSON.parse(str);
+    state.model.version = d.version;
+    state.model.meta = d.meta;
+    state.model.types = d.types;
+    state.model.elements = d.elements;
+    state.selected = resolveSelection(ref);
+    history.base = str;
+    state.dirty = str !== history.saved;
+    renderAll();
+    schedulePreview();
+}
+
+function undo() {
+    commitHistory();
+    if (!history.undo.length) return;
+    history.redo.push(snapshot());
+    applySnapshot(history.undo.pop());
+    updateHistoryButtons();
+}
+
+function redo() {
+    commitHistory();
+    if (!history.redo.length) return;
+    history.undo.push(snapshot());
+    applySnapshot(history.redo.pop());
+    updateHistoryButtons();
+}
+
+function updateHistoryButtons() {
+    const u = $("#undo");
+    const r = $("#redo");
+    if (u) u.disabled = history.undo.length === 0 && !history.pending;
+    if (r) r.disabled = history.redo.length === 0;
 }
 
 // --- Status / header ----------------------------------------------------
@@ -222,12 +347,34 @@ function cardinality(node) {
     return p.optional ? "0\u20261" : "1";
 }
 
+function cardinalityLabel(node) {
+    const p = node.props || {};
+    const many = p.type === "array" || p.type === "collection";
+    if (many) {
+        const lo = p.minlength != null ? p.minlength : (p.optional ? 0 : 1);
+        const hi = p.maxlength != null ? p.maxlength : "unlimited";
+        return `Repeats ${lo} to ${hi}`;
+    }
+    return p.optional ? "Optional (0 or 1)" : "Required (exactly 1)";
+}
+
 function compositor(node) {
     const p = node.props || {};
-    if (p.type === "array" || p.type === "collection") return { glyph: "\u21bb", cls: "repeat", title: "repeating items" };
-    if (p.oneof) return { glyph: "\u25c8", cls: "choice", title: "one of" };
-    if (p.anyof) return { glyph: "\u25c6", cls: "choice", title: "any of" };
-    return { glyph: "\u2630", cls: "sequence", title: "sequence" };
+    if (p.type === "array" || p.type === "collection") return { glyph: "\u21bb", cls: "repeat", title: "Repeating items" };
+    if (p.oneof) return { glyph: "\u25c8", cls: "choice", title: "One of \u2014 exactly one alternative" };
+    if (p.anyof) return { glyph: "\u25c6", cls: "choice", title: "Any of \u2014 at least one alternative" };
+    return { glyph: "\u2630", cls: "sequence", title: "All child fields (sequence)" };
+}
+
+// Type references on this node that don't resolve to a builtin or defined type.
+function unresolvedRefs(node) {
+    const p = node.props || {};
+    const refs = [];
+    if (p.typeof) refs.push(p.typeof);
+    if (p.itemtype) refs.push(p.itemtype);
+    for (const r of p.oneof || []) refs.push(r);
+    for (const r of p.anyof || []) refs.push(r);
+    return refs.filter((r) => r && !isKnownRef(r));
 }
 
 function visKids(n) {
@@ -241,7 +388,11 @@ function renderDiagram() {
     host.textContent = "";
 
     const view = state.view || "elements";
-    document.querySelectorAll(".vtab").forEach((b) => b.classList.toggle("active", b.dataset.view === view));
+    document.querySelectorAll(".vtab").forEach((b) => {
+        const on = b.dataset.view === view;
+        b.classList.toggle("active", on);
+        b.setAttribute("aria-selected", on ? "true" : "false");
+    });
 
     const roots = state.model[view] || [];
     const root = { __root: true, name: view, children: roots, props: {} };
@@ -279,7 +430,7 @@ function renderDiagram() {
     state.__totalW = totalW;
     state.__totalH = totalH;
 
-    const inner = el("div", { class: "diagram-inner" });
+    const inner = el("div", { class: "diagram-inner", role: "tree", "aria-label": "Schema " + view });
     inner.style.width = totalW + "px";
     inner.style.height = totalH + "px";
     inner.style.transform = "scale(" + (state.zoom || 1) + ")";
@@ -306,14 +457,14 @@ function renderDiagram() {
         const kids = visKids(node);
         if (node.__root || !kids.length) continue;
         const c = compositor(node);
-        const chip = el("div", { class: "dg-comp " + c.cls, title: c.title, text: c.glyph });
+        const chip = el("div", { class: "dg-comp " + c.cls, title: c.title, role: "img", "aria-label": c.title, text: c.glyph });
         chip.style.left = (node.__x + DG.BOX_W + DG.H_GAP / 2 - 11) + "px";
         chip.style.top = (node.__cy - 11) + "px";
         inner.appendChild(chip);
     }
 
-    for (const { node } of placed) {
-        inner.appendChild(node.__root ? rootBox(node) : diagramBox(node));
+    for (const { node, depth } of placed) {
+        inner.appendChild(node.__root ? rootBox(node) : diagramBox(node, depth));
     }
 
     host.appendChild(inner);
@@ -332,10 +483,21 @@ function renderDiagram() {
     const zl = $("#zoom-label");
     if (zl) zl.textContent = Math.round((state.zoom || 1) * 100) + "%";
     refreshTypeRefs();
+
+    // Roving tabindex: ensure exactly one box is tab-reachable.
+    if (!inner.querySelector('.dg-box[tabindex="0"]')) {
+        const first = inner.querySelector(".dg-box");
+        if (first) first.setAttribute("tabindex", "0");
+    }
+    if (state.kbFocus) {
+        const sel = inner.querySelector(".dg-box.selected");
+        if (sel) sel.focus();
+        state.kbFocus = false;
+    }
 }
 
 function rootBox(node) {
-    const box = el("div", { class: "dg-root" });
+    const box = el("div", { class: "dg-root", role: "treeitem", "aria-level": "1" });
     box.style.left = node.__x + "px";
     box.style.top = (node.__cy - DG.BOX_H / 2) + "px";
     box.style.width = DG.BOX_W + "px";
@@ -343,15 +505,28 @@ function rootBox(node) {
     box.append(el("span", { class: "dg-root-label", text: "[" + node.name + "]" }));
     const n = node.children.length;
     box.append(el("span", { class: "dg-root-sub", text: n + " " + (n === 1 ? "entry" : "entries") }));
+    box.setAttribute("aria-label", "[" + node.name + "], " + n + (n === 1 ? " entry" : " entries"));
     return box;
 }
 
-function diagramBox(node) {
+function diagramBox(node, depth = 1) {
     const p = node.props || {};
+    const kids = node.children || [];
+    const selected = state.selected === node;
+    const unresolved = unresolvedRefs(node);
     const box = el("div", {
-        class: "dg-box" + (state.selected === node ? " selected" : "") + (p.optional ? " optional" : ""),
+        class: "dg-box" + (selected ? " selected" : "") + (p.optional ? " optional" : "") + (unresolved.length ? " has-error" : ""),
         "data-cat": typeCategory(node),
+        role: "treeitem",
+        "aria-level": String(depth),
+        "aria-selected": selected ? "true" : "false",
+        tabindex: selected ? "0" : "-1",
     });
+    if (kids.length) box.setAttribute("aria-expanded", node.__collapsed ? "false" : "true");
+    const ariaParts = [node.name, typeBadge(node), cardinalityLabel(node)];
+    if (p.optional) ariaParts.push("optional");
+    if (unresolved.length) ariaParts.push("unresolved reference " + unresolved.join(", "));
+    box.setAttribute("aria-label", ariaParts.join(", "));
     box.style.left = node.__x + "px";
     box.style.top = (node.__cy - DG.BOX_H / 2) + "px";
     box.style.width = DG.BOX_W + "px";
@@ -360,11 +535,15 @@ function diagramBox(node) {
         if (e.target.closest("button")) return;
         selectNode(node);
     });
+    box.addEventListener("keydown", (e) => onBoxKeydown(e, node));
 
     const top = el("div", { class: "dg-top" });
     top.append(el("span", { class: "dg-accent" }));
     top.append(el("span", { class: "dg-name", text: node.name }));
-    top.append(el("span", { class: "dg-card", title: "cardinality", text: cardinality(node) }));
+    if (unresolved.length) {
+        top.append(el("span", { class: "dg-warn", role: "img", title: "Unresolved type reference: " + unresolved.join(", "), "aria-label": "Unresolved reference", text: "\u26a0" }));
+    }
+    top.append(el("span", { class: "dg-card", title: cardinalityLabel(node), "aria-hidden": "true", text: cardinality(node) }));
     box.append(top);
 
     const typeLine = el("div", { class: "dg-typeline" });
@@ -382,28 +561,93 @@ function diagramBox(node) {
     }
     box.append(typeLine);
 
-    const kids = node.children || [];
     if (kids.length) {
         box.append(el("button", {
             class: "dg-expander",
             text: node.__collapsed ? "+" : "\u2013",
             title: node.__collapsed ? "Expand" : "Collapse",
+            "aria-label": (node.__collapsed ? "Expand " : "Collapse ") + node.name + " (" + kids.length + " field" + (kids.length > 1 ? "s" : "") + ")",
             onclick: (e) => { e.stopPropagation(); node.__collapsed = !node.__collapsed; renderDiagram(); },
         }));
     }
 
     const acts = el("div", { class: "dg-actions" });
-    acts.append(el("button", { class: "icon", title: "Add child field", text: "+", onclick: (e) => { e.stopPropagation(); addChild(node); } }));
-    acts.append(el("button", { class: "icon", title: "Move up", text: "\u2191", onclick: (e) => { e.stopPropagation(); moveNode(node, -1); } }));
-    acts.append(el("button", { class: "icon", title: "Move down", text: "\u2193", onclick: (e) => { e.stopPropagation(); moveNode(node, 1); } }));
-    acts.append(el("button", { class: "icon danger", title: "Delete " + node.name, text: "\u2715", onclick: (e) => { e.stopPropagation(); deleteNode(node); } }));
+    acts.append(el("button", { class: "icon", title: "Add child field", "aria-label": "Add child field to " + node.name, text: "+", onclick: (e) => { e.stopPropagation(); addChild(node); } }));
+    acts.append(el("button", { class: "icon", title: "Move up", "aria-label": "Move " + node.name + " up", text: "\u2191", onclick: (e) => { e.stopPropagation(); moveNode(node, -1); } }));
+    acts.append(el("button", { class: "icon", title: "Move down", "aria-label": "Move " + node.name + " down", text: "\u2193", onclick: (e) => { e.stopPropagation(); moveNode(node, 1); } }));
+    acts.append(el("button", { class: "icon danger", title: "Delete " + node.name, "aria-label": "Delete " + node.name, text: "\u2715", onclick: (e) => { e.stopPropagation(); deleteNode(node); } }));
     box.append(acts);
 
     return box;
 }
 
-function selectNode(node) {
+// Flatten currently-visible nodes in top-to-bottom order for keyboard nav.
+function flatVisible() {
+    const out = [];
+    const walk = (list) => {
+        for (const n of list || []) {
+            out.push(n);
+            if (!n.__collapsed && n.children && n.children.length) walk(n.children);
+        }
+    };
+    walk(state.model[state.view || "elements"] || []);
+    return out;
+}
+
+function parentOf(node) {
+    const search = (list, parent) => {
+        for (const n of list || []) {
+            if (n === node) return parent;
+            if (n.children) {
+                const r = search(n.children, n);
+                if (r !== undefined) return r;
+            }
+        }
+        return undefined;
+    };
+    const r = search(state.model[state.view] || [], null);
+    return r === undefined ? null : r;
+}
+
+function onBoxKeydown(e, node) {
+    const flat = flatVisible();
+    const idx = flat.indexOf(node);
+    const kids = node.children || [];
+    switch (e.key) {
+        case "ArrowDown":
+            e.preventDefault();
+            if (idx < flat.length - 1) selectNode(flat[idx + 1], true);
+            break;
+        case "ArrowUp":
+            e.preventDefault();
+            if (idx > 0) selectNode(flat[idx - 1], true);
+            break;
+        case "ArrowRight":
+            e.preventDefault();
+            if (kids.length && node.__collapsed) { node.__collapsed = false; state.kbFocus = true; renderDiagram(); }
+            else if (kids.length) selectNode(kids[0], true);
+            break;
+        case "ArrowLeft":
+            e.preventDefault();
+            if (kids.length && !node.__collapsed) { node.__collapsed = true; state.kbFocus = true; renderDiagram(); }
+            else { const par = parentOf(node); if (par) selectNode(par, true); }
+            break;
+        case "Enter":
+        case " ":
+            e.preventDefault();
+            selectNode(node, true);
+            break;
+        case "Delete":
+        case "Backspace":
+            e.preventDefault();
+            deleteNode(node);
+            break;
+    }
+}
+
+function selectNode(node, kb = false) {
     state.selected = node;
+    state.kbFocus = kb;
     renderDiagram();
     renderEditor();
 }
@@ -492,6 +736,9 @@ function addChild(node) {
 }
 
 function deleteNode(node) {
+    const kidCount = (node.children || []).length;
+    const detail = kidCount ? ` and its ${kidCount} child field${kidCount > 1 ? "s" : ""}` : "";
+    if (!confirm(`Delete "${node.name}"${detail}? You can undo this with Ctrl/Cmd+Z.`)) return;
     const removeFrom = (list) => {
         const idx = list.indexOf(node);
         if (idx >= 0) {
@@ -524,10 +771,12 @@ function renderEditor() {
     const p = (node.props = node.props || {});
 
     // Header: name + actions
+    const nameId = uid("name");
     const header = el("div", { class: "field" });
-    header.append(el("label", { text: "Name" }));
+    header.append(el("label", { for: nameId, text: "Name" }));
     const nameInput = el("input", {
         type: "text",
+        id: nameId,
         class: "mono",
         value: node.name,
         oninput: (e) => {
@@ -668,11 +917,33 @@ function setListProp(p, key, arr) {
 }
 
 // --- Field builders -----------------------------------------------------
+function knownTypeNames() {
+    return new Set((state.model.types || []).map((t) => t.name));
+}
+
+function isKnownRef(v) {
+    const val = String(v || "").trim();
+    if (!val) return true;
+    if (BUILTIN_TYPES.includes(val)) return true;
+    const names = knownTypeNames();
+    if (val.startsWith("types.")) return names.has(val.slice(6));
+    return names.has(val);
+}
+
+function markRefValidity(input, msgEl) {
+    const ok = isKnownRef(input.value);
+    input.classList.toggle("invalid", !ok);
+    input.setAttribute("aria-invalid", ok ? "false" : "true");
+    if (msgEl) msgEl.textContent = ok ? "" : "Unknown type reference \u2014 define it under Types first.";
+}
+
 function textField(name, label, value, onchange, mono = false, hint) {
+    const id = uid("in");
     const f = el("div", { class: "field" });
-    f.append(labelEl(label, hint));
+    f.append(labelEl(label, hint, id));
     f.append(el("input", {
         type: "text",
+        id,
         class: mono ? "mono" : "",
         value,
         placeholder: name,
@@ -682,10 +953,12 @@ function textField(name, label, value, onchange, mono = false, hint) {
 }
 
 function numField(name, label, value, onchange) {
+    const id = uid("num");
     const f = el("div", { class: "field" });
-    f.append(labelEl(label));
+    f.append(labelEl(label, null, id));
     f.append(el("input", {
         type: "number",
+        id,
         value: value != null ? value : "",
         placeholder: name,
         oninput: (e) => onchange(e.target.value === "" ? "" : Number(e.target.value)),
@@ -694,9 +967,10 @@ function numField(name, label, value, onchange) {
 }
 
 function selectField(label, value, options, onchange, hint) {
+    const id = uid("sel");
     const f = el("div", { class: "field" });
-    f.append(labelEl(label, hint));
-    const sel = el("select", { onchange: (e) => onchange(e.target.value) });
+    f.append(labelEl(label, hint, id));
+    const sel = el("select", { id, onchange: (e) => onchange(e.target.value) });
     for (const opt of options) {
         const o = el("option", { value: opt, text: opt === "" ? "(none)" : opt });
         if (opt === value) o.selected = true;
@@ -707,51 +981,66 @@ function selectField(label, value, options, onchange, hint) {
 }
 
 function checkboxField(name, label, checked, onchange) {
+    const id = uid("chk");
     const f = el("div", { class: "field inline" });
-    const cb = el("input", { type: "checkbox", onchange: (e) => onchange(e.target.checked) });
+    const cb = el("input", { type: "checkbox", id, onchange: (e) => onchange(e.target.checked) });
     cb.checked = checked;
     f.append(cb);
-    f.append(el("label", { text: label }));
+    f.append(el("label", { for: id, text: label }));
     return f;
 }
 
 function refField(name, label, value, onchange, hint) {
+    const id = uid("ref");
+    const errId = uid("err");
     const f = el("div", { class: "field" });
-    f.append(labelEl(label, hint));
+    f.append(labelEl(label, hint, id));
+    const msg = el("div", { class: "field-err", id: errId, role: "alert" });
     const input = el("input", {
         type: "text",
+        id,
         class: "mono",
         value,
         placeholder: name,
         list: "type-refs",
-        oninput: (e) => onchange(e.target.value),
+        "aria-describedby": errId,
+        oninput: (e) => { onchange(e.target.value); markRefValidity(input, msg); },
     });
     f.append(input);
+    f.append(msg);
+    markRefValidity(input, msg);
     return f;
 }
 
 function listField(name, label, values, onchange, isRef, hint) {
     const f = el("div", { class: "field" });
-    f.append(labelEl(label, hint));
+    const groupId = uid("list");
+    f.append(labelEl(label, hint, null, groupId));
     const arr = [...values];
-    const container = el("div");
+    const container = el("div", { role: "group", "aria-labelledby": groupId });
     const rerender = () => {
         container.textContent = "";
         arr.forEach((val, idx) => {
             const row = el("div", { class: "list-row" });
-            row.append(el("input", {
+            const input = el("input", {
                 type: "text",
                 class: "mono",
                 value: val,
+                "aria-label": `${label} item ${idx + 1}`,
                 list: isRef ? "type-refs" : null,
                 oninput: (e) => {
                     arr[idx] = e.target.value;
                     onchange([...arr]);
+                    if (isRef) input.classList.toggle("invalid", !isKnownRef(e.target.value));
                 },
-            }));
+            });
+            if (isRef) input.classList.toggle("invalid", !isKnownRef(val));
+            row.append(input);
             row.append(el("button", {
                 class: "icon danger",
-                text: "✕",
+                text: "\u2715",
+                "aria-label": `Remove ${label} item ${idx + 1}`,
+                title: "Remove",
                 onclick: () => {
                     arr.splice(idx, 1);
                     onchange([...arr]);
@@ -764,19 +1053,25 @@ function listField(name, label, values, onchange, isRef, hint) {
     rerender();
     f.append(container);
     f.append(el("button", {
-        class: "icon",
+        class: "icon add-row",
         text: "+ add",
+        "aria-label": "Add " + label + " item",
         onclick: () => {
             arr.push("");
             onchange([...arr]);
             rerender();
+            const inputs = container.querySelectorAll("input");
+            if (inputs.length) inputs[inputs.length - 1].focus();
         },
     }));
     return f;
 }
 
-function labelEl(text, hint) {
-    const l = el("label", {}, text);
+function labelEl(text, hint, forId, id) {
+    const attrs = {};
+    if (forId) attrs.for = forId;
+    if (id) attrs.id = id;
+    const l = el("label", attrs, text);
     if (hint) l.append(el("span", { class: "hint", text: hint }));
     return l;
 }
@@ -814,11 +1109,11 @@ function renderMetaEditor(box) {
         container.textContent = "";
         arr.forEach((pair, idx) => {
             const row = el("div", { class: "list-row" });
-            row.append(el("input", { type: "text", class: "mono", value: pair[0], placeholder: "key",
+            row.append(el("input", { type: "text", class: "mono", value: pair[0], placeholder: "key", "aria-label": "Metadata key " + (idx + 1),
                 oninput: (e) => { arr[idx][0] = e.target.value; commit(); } }));
-            row.append(el("input", { type: "text", class: "mono", value: pair[1], placeholder: "value",
+            row.append(el("input", { type: "text", class: "mono", value: pair[1], placeholder: "value", "aria-label": "Metadata value " + (idx + 1),
                 oninput: (e) => { arr[idx][1] = e.target.value; commit(); } }));
-            row.append(el("button", { class: "icon danger", text: "✕",
+            row.append(el("button", { class: "icon danger", text: "\u2715", "aria-label": "Remove metadata " + (idx + 1), title: "Remove",
                 onclick: () => { arr.splice(idx, 1); commit(); rerender(); } }));
             container.append(row);
         });
@@ -834,7 +1129,7 @@ function renderIssues() {
     const box = $("#issues");
     box.textContent = "";
     for (const issue of state.lastIssues) {
-        const row = el("div", { class: "issue " + issue.level });
+        const row = el("div", { class: "issue " + issue.level, role: "listitem" });
         row.append(el("span", { class: "lvl", text: issue.level === "error" ? "ERROR" : "WARN" }));
         row.append(el("span", { text: issue.message }));
         row.append(el("span", { class: "where mono", text: issue.path }));
@@ -853,9 +1148,9 @@ function boot() {
         </div>
         <span class="tb-sep"></span>
         <div class="tb-info">
-          <input class="path-field mono" id="path" readonly title="" placeholder="(new schema)" />
-          <span class="pill" id="validity"></span>
-          <span class="status" id="status"></span>
+          <input class="path-field mono" id="path" readonly title="" placeholder="(new schema)" aria-label="Schema file path" />
+          <span class="pill" id="validity" role="status" aria-live="polite"></span>
+          <span class="status" id="status" role="status" aria-live="polite"></span>
         </div>
       </div>
       <div class="tb-row tb-row-actions">
@@ -863,6 +1158,11 @@ function boot() {
           <div class="tb-group">
             <button id="add-element" class="btn"><span class="bi">+</span>Element</button>
             <button id="add-type" class="btn"><span class="bi">+</span>Type</button>
+          </div>
+          <span class="tb-sep"></span>
+          <div class="tb-group">
+            <button id="undo" class="btn icon-btn" title="Undo (Ctrl/Cmd+Z)" aria-label="Undo" disabled><span class="bi">&#8630;</span></button>
+            <button id="redo" class="btn icon-btn" title="Redo (Ctrl/Cmd+Shift+Z)" aria-label="Redo" disabled><span class="bi">&#8631;</span></button>
           </div>
           <span class="tb-sep"></span>
           <div class="tb-group">
@@ -877,7 +1177,7 @@ function boot() {
           <span class="spacer"></span>
           <div class="tb-group">
             <button id="revert" class="btn ghost" title="Discard changes and reload from disk">Revert</button>
-            <button id="save" class="btn primary" title="Save to disk">Save</button>
+            <button id="save" class="btn primary" title="Save to disk (Ctrl/Cmd+S)">Save</button>
           </div>
         </div>
       </div>
@@ -885,32 +1185,34 @@ function boot() {
     <div class="workspace">
       <div class="diagram-pane">
         <div class="diagram-bar">
-          <div class="view-tabs">
-            <button class="vtab active" data-view="elements">Elements</button>
-            <button class="vtab" data-view="types">Types</button>
+          <div class="view-tabs" role="tablist" aria-label="Schema view">
+            <button class="vtab active" data-view="elements" role="tab" aria-selected="true">Elements</button>
+            <button class="vtab" data-view="types" role="tab" aria-selected="false">Types</button>
           </div>
           <button id="dg-add" class="icon" title="Add a top-level entry to this view">+ Add</button>
           <button id="dg-meta" class="icon" title="Edit [toml-schema] metadata">&#9881; Metadata</button>
           <span class="spacer"></span>
+          <button id="legend-toggle" class="icon" title="Show notation legend" aria-expanded="false" aria-controls="legend">&#9432; Legend</button>
           <div class="zoom">
-            <button id="zoom-out" class="icon" title="Zoom out">&#8722;</button>
-            <span id="zoom-label" class="zoom-label">100%</span>
-            <button id="zoom-in" class="icon" title="Zoom in">+</button>
+            <button id="zoom-out" class="icon" title="Zoom out" aria-label="Zoom out">&#8722;</button>
+            <span id="zoom-label" class="zoom-label" aria-hidden="true">100%</span>
+            <button id="zoom-in" class="icon" title="Zoom in" aria-label="Zoom in">+</button>
             <button id="zoom-fit" class="icon" title="Fit to view">Fit</button>
           </div>
         </div>
-        <div class="diagram-scroll" id="diagram"></div>
+        <div class="diagram-scroll" id="diagram" role="region" aria-label="Schema diagram" tabindex="0"></div>
+        <div class="legend" id="legend" hidden></div>
       </div>
       <div class="side">
         <div class="panel side-panel">
-          <div class="panel-head"><h2>Properties</h2><span class="spacer"></span><button id="prop-close" class="icon" title="Close / deselect" hidden>&#10005;</button></div>
+          <div class="panel-head"><h2>Properties</h2><span class="spacer"></span><button id="prop-close" class="icon" title="Close / deselect" aria-label="Close properties" hidden>&#10005;</button></div>
           <div class="editor" id="editor"></div>
         </div>
         <div class="panel side-panel preview-panel">
           <div class="panel-head"><h2>TOML Preview</h2><span class="spacer"></span></div>
           <div class="preview-wrap">
-            <pre class="preview mono" id="preview"></pre>
-            <div class="issues" id="issues"></div>
+            <pre class="preview mono" id="preview" tabindex="0" aria-label="Generated TOML preview"></pre>
+            <div class="issues" id="issues" role="list" aria-label="Validation issues"></div>
           </div>
         </div>
       </div>
@@ -923,6 +1225,8 @@ function boot() {
     $("#open").addEventListener("click", openSchema);
     $("#generate").addEventListener("click", openGenerateModal);
     $("#infer").addEventListener("click", openInferModal);
+    $("#undo").addEventListener("click", undo);
+    $("#redo").addEventListener("click", redo);
     $("#add-type").addEventListener("click", () => { state.view = "types"; addNode(state.model.types, ["types"]); });
     $("#add-element").addEventListener("click", () => { state.view = "elements"; addNode(state.model.elements, ["elements"]); });
 
@@ -934,18 +1238,106 @@ function boot() {
     $("#zoom-out").addEventListener("click", () => setZoom((state.zoom || 1) - 0.1));
     $("#zoom-fit").addEventListener("click", fitZoom);
     $("#prop-close").addEventListener("click", clearSelection);
+    $("#legend-toggle").addEventListener("click", toggleLegend);
+    renderLegend();
 
     $("#diagram").addEventListener("click", (e) => {
         if (suppressDiagramClick) { suppressDiagramClick = false; return; }
         if (e.target.closest(".dg-box, .dg-root, .dg-comp, button")) return;
         if (state.selected) clearSelection();
     });
-    document.addEventListener("keydown", (e) => {
-        if (e.key === "Escape" && state.selected && !document.querySelector(".modal-overlay")) clearSelection();
-    });
+    document.addEventListener("keydown", onGlobalKeydown);
     setupPanning();
 
     load();
+}
+
+function onGlobalKeydown(e) {
+    const mod = e.metaKey || e.ctrlKey;
+    if (mod && (e.key === "s" || e.key === "S")) {
+        e.preventDefault();
+        if (state.dirty) save();
+        return;
+    }
+    if (mod && (e.key === "z" || e.key === "Z")) {
+        e.preventDefault();
+        if (e.shiftKey) redo(); else undo();
+        return;
+    }
+    if (mod && (e.key === "y" || e.key === "Y")) {
+        e.preventDefault();
+        redo();
+        return;
+    }
+    if (e.key === "Escape") {
+        const overlay = document.querySelector(".modal-overlay");
+        if (overlay) { closeModal(overlay); return; }
+        if (state.selected) clearSelection();
+    }
+}
+
+// --- Legend -------------------------------------------------------------
+function toggleLegend() {
+    state.showLegend = !state.showLegend;
+    renderLegend();
+}
+
+function renderLegend() {
+    const box = $("#legend");
+    const btn = $("#legend-toggle");
+    if (!box) return;
+    box.hidden = !state.showLegend;
+    if (btn) {
+        btn.setAttribute("aria-expanded", state.showLegend ? "true" : "false");
+        btn.classList.toggle("active", !!state.showLegend);
+    }
+    if (!state.showLegend) { box.textContent = ""; return; }
+    box.textContent = "";
+
+    const group = (title, items) => {
+        const g = el("div", { class: "legend-group" });
+        g.append(el("div", { class: "legend-title", text: title }));
+        for (const [glyph, label, cls] of items) {
+            const row = el("div", { class: "legend-item" });
+            row.append(el("span", { class: "legend-glyph " + (cls || ""), text: glyph }));
+            row.append(el("span", { class: "legend-label", text: label }));
+            g.append(row);
+        }
+        return g;
+    };
+
+    box.append(group("Cardinality", [
+        ["1", "Required (exactly one)"],
+        ["0\u20261", "Optional (zero or one)"],
+        ["1\u2026\u221e", "One or more"],
+        ["0\u2026\u221e", "Any number"],
+    ]));
+    box.append(group("Composition", [
+        ["\u2630", "Sequence \u2014 all child fields", "sequence"],
+        ["\u21bb", "Repeating array / collection", "repeat"],
+        ["\u25c8", "One of \u2014 exactly one alternative", "choice"],
+        ["\u25c6", "Any of \u2014 at least one alternative", "choice"],
+    ]));
+    box.append(group("Actions", [
+        ["\u2197", "Jump to type definition"],
+        ["+ / \u2013", "Expand / collapse children"],
+        ["\u26a0", "Unresolved type reference", "warn"],
+    ]));
+
+    const cats = [
+        ["string", "string"], ["number", "number"], ["boolean", "boolean"],
+        ["date", "date/time"], ["table", "table"], ["array", "array"],
+        ["ref", "type reference"], ["choice", "one/any of"],
+    ];
+    const cg = el("div", { class: "legend-group" });
+    cg.append(el("div", { class: "legend-title", text: "Type colors" }));
+    for (const [cat, label] of cats) {
+        const row = el("div", { class: "legend-item" });
+        row.append(el("span", { class: "legend-dot", "data-cat": cat }));
+        row.append(el("span", { class: "legend-label", text: label }));
+        cg.append(row);
+    }
+    box.append(cg);
 }
 
 // --- Pan / hand tool ----------------------------------------------------
@@ -978,8 +1370,35 @@ function setupPanning() {
 
 function clearSelection() {
     state.selected = null;
+    state.kbFocus = false;
     renderEditor();
     renderDiagram();
+}
+
+// --- Modal helpers (focus trap + restore) -------------------------------
+function installModal(overlay) {
+    overlay.__restoreFocus = document.activeElement;
+    overlay.__trap = (e) => {
+        if (e.key !== "Tab") return;
+        const f = [...overlay.querySelectorAll('button, input, select, textarea, [href], [tabindex]:not([tabindex="-1"])')]
+            .filter((x) => !x.disabled && x.offsetParent !== null);
+        if (!f.length) return;
+        const first = f[0];
+        const last = f[f.length - 1];
+        if (e.shiftKey && document.activeElement === first) { e.preventDefault(); last.focus(); }
+        else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); first.focus(); }
+    };
+    document.addEventListener("keydown", overlay.__trap, true);
+    overlay.setAttribute("role", "dialog");
+    overlay.setAttribute("aria-modal", "true");
+}
+
+function closeModal(overlay) {
+    if (!overlay) return;
+    if (overlay.__trap) document.removeEventListener("keydown", overlay.__trap, true);
+    const restore = overlay.__restoreFocus;
+    overlay.remove();
+    if (restore && document.contains(restore) && typeof restore.focus === "function") restore.focus();
 }
 
 // --- New (empty) schema -------------------------------------------------
@@ -987,6 +1406,7 @@ function newSchema() {
     if (state.dirty && !confirm("Discard unsaved changes and start a new schema?")) return;
     state.model = { version: "1.0.0", meta: null, types: [], elements: [] };
     state.selected = "__meta__";
+    resetHistory();
     markDirty();
     renderAll();
 }
@@ -994,28 +1414,30 @@ function newSchema() {
 // --- Generate-with-Copilot modal ---------------------------------------
 function openGenerateModal() {
     const existing = $("#generate-modal");
-    if (existing) existing.remove();
+    if (existing) closeModal(existing);
 
-    const overlay = el("div", { class: "modal-overlay", id: "generate-modal" });
+    const titleId = uid("mt");
+    const overlay = el("div", { class: "modal-overlay", id: "generate-modal", "aria-labelledby": titleId });
     const dialog = el("div", { class: "modal" });
-    dialog.append(el("h3", { text: "\u2728 Generate schema with Copilot" }));
+    dialog.append(el("h3", { id: titleId, text: "\u2728 Generate schema with Copilot" }));
     dialog.append(el("p", { class: "hint", text: "Describe the configuration file you want a schema for \u2014 its sections, fields, and any constraints. Copilot will draft the TOML Schema. The result replaces the current schema (not saved until you click Save)." }));
 
     const ta = el("textarea", {
         class: "modal-textarea",
+        "aria-label": "Configuration description",
         placeholder: "e.g. A web service config with a [server] section (host string, port integer 1-65535), a [database] table with url and pool_size, an optional [logging] section with level one of debug/info/warn/error, and a list of [[routes]] each having path and handler.",
     });
     dialog.append(ta);
 
-    const errBox = el("div", { class: "modal-err" });
+    const errBox = el("div", { class: "modal-err", role: "alert" });
     dialog.append(errBox);
 
     const actions = el("div", { class: "modal-actions" });
-    const cancelBtn = el("button", { text: "Cancel", onclick: () => overlay.remove() });
+    const cancelBtn = el("button", { text: "Cancel", onclick: () => closeModal(overlay) });
     const genBtn = el("button", { class: "primary", text: "Generate" });
     genBtn.addEventListener("click", async () => {
         const description = ta.value.trim();
-        if (!description) { errBox.textContent = "Describe the configuration first."; return; }
+        if (!description) { errBox.className = "modal-err"; errBox.textContent = "Describe the configuration first."; ta.focus(); return; }
         genBtn.disabled = true;
         cancelBtn.disabled = true;
         ta.disabled = true;
@@ -1039,9 +1461,10 @@ function openGenerateModal() {
             state.model = data.model;
             state.view = "elements";
             state.selected = (state.model.elements[0] || state.model.types[0]) ?? null;
+            resetHistory();
             markDirty();
             renderAll();
-            overlay.remove();
+            closeModal(overlay);
         } catch (e) {
             errBox.className = "modal-err";
             errBox.textContent = e.message;
@@ -1054,26 +1477,29 @@ function openGenerateModal() {
     dialog.append(actions);
 
     overlay.append(dialog);
-    overlay.addEventListener("click", (e) => { if (e.target === overlay) overlay.remove(); });
+    overlay.addEventListener("click", (e) => { if (e.target === overlay) closeModal(overlay); });
     document.body.append(overlay);
+    installModal(overlay);
     ta.focus();
 }
 
 // --- Open existing schema modal ----------------------------------------
 function openSchema() {
     const existing = $("#open-modal");
-    if (existing) existing.remove();
+    if (existing) closeModal(existing);
 
-    const overlay = el("div", { class: "modal-overlay", id: "open-modal" });
+    const titleId = uid("mt");
+    const overlay = el("div", { class: "modal-overlay", id: "open-modal", "aria-labelledby": titleId });
     const dialog = el("div", { class: "modal" });
-    dialog.append(el("h3", { text: "\u{1F4C1} Open schema file" }));
+    dialog.append(el("h3", { id: titleId, text: "\u{1F4C1} Open schema file" }));
     dialog.append(el("p", { class: "hint", text: "Enter the path to an existing .tosd schema file (absolute or workspace-relative). It will be loaded into the editor, replacing the current schema." }));
 
-    const errBox = el("div", { class: "modal-err" });
+    const errBox = el("div", { class: "modal-err", role: "alert" });
 
     const doOpen = async (input, openBtn) => {
         const p = input.value.trim();
-        if (!p) { errBox.textContent = "Enter a file path."; return; }
+        if (!p) { errBox.className = "modal-err"; errBox.textContent = "Enter a file path."; input.focus(); return; }
+        errBox.className = "modal-err working";
         errBox.textContent = "Opening\u2026";
         if (openBtn) openBtn.disabled = true;
         try {
@@ -1083,76 +1509,84 @@ function openSchema() {
                 body: JSON.stringify({ path: p }),
             });
             const data = await res.json();
-            if (data.error) { errBox.textContent = data.error; if (openBtn) openBtn.disabled = false; return; }
+            if (data.error) { errBox.className = "modal-err"; errBox.textContent = data.error; if (openBtn) openBtn.disabled = false; return; }
             state.path = data.path;
             state.model = data.model;
             state.dirty = false;
             state.selected = (state.model.elements[0] || state.model.types[0]) ?? null;
+            resetHistory();
             renderAll();
             schedulePreview();
-            overlay.remove();
-        } catch (e) { errBox.textContent = e.message; if (openBtn) openBtn.disabled = false; }
+            closeModal(overlay);
+        } catch (e) { errBox.className = "modal-err"; errBox.textContent = e.message; if (openBtn) openBtn.disabled = false; }
     };
 
     const pathRow = el("div", { class: "list-row" });
-    const pathInput = el("input", { type: "text", class: "mono", placeholder: "path/to/schema.tosd" });
+    const pathInput = el("input", { type: "text", class: "mono", "aria-label": "Schema file path", placeholder: "path/to/schema.tosd" });
     pathInput.addEventListener("keydown", (e) => { if (e.key === "Enter") { e.preventDefault(); doOpen(pathInput, openBtn); } });
     pathRow.append(pathInput);
     dialog.append(pathRow);
     dialog.append(errBox);
 
     const actions = el("div", { class: "modal-actions" });
-    actions.append(el("button", { text: "Cancel", onclick: () => overlay.remove() }));
+    actions.append(el("button", { text: "Cancel", onclick: () => closeModal(overlay) }));
     const openBtn = el("button", { class: "primary", text: "Open" });
     openBtn.addEventListener("click", () => doOpen(pathInput, openBtn));
     actions.append(openBtn);
     dialog.append(actions);
 
     overlay.append(dialog);
-    overlay.addEventListener("click", (e) => { if (e.target === overlay) overlay.remove(); });
+    overlay.addEventListener("click", (e) => { if (e.target === overlay) closeModal(overlay); });
     document.body.append(overlay);
+    installModal(overlay);
     pathInput.focus();
 }
 
 // --- Infer-from-TOML modal ---------------------------------------------
 function openInferModal() {
     const existing = $("#infer-modal");
-    if (existing) existing.remove();
+    if (existing) closeModal(existing);
 
-    const overlay = el("div", { class: "modal-overlay", id: "infer-modal" });
+    const titleId = uid("mt");
+    const overlay = el("div", { class: "modal-overlay", id: "infer-modal", "aria-labelledby": titleId });
     const dialog = el("div", { class: "modal" });
-    dialog.append(el("h3", { text: "Infer schema from a reference TOML document" }));
+    dialog.append(el("h3", { id: titleId, text: "Infer schema from a reference TOML document" }));
     dialog.append(el("p", { class: "hint", text: "Paste a sample TOML document, or load one from a file path. The generated schema replaces the current one (it is not saved until you click Save)." }));
 
     const pathRow = el("div", { class: "list-row" });
-    const pathInput = el("input", { type: "text", class: "mono", placeholder: "path/to/sample.toml (absolute or workspace-relative)" });
+    const pathInput = el("input", { type: "text", class: "mono", "aria-label": "Reference TOML file path", placeholder: "path/to/sample.toml (absolute or workspace-relative)" });
     const loadBtn = el("button", { text: "Load file", onclick: async () => {
         const p = pathInput.value.trim();
-        if (!p) return;
-        errBox.textContent = "Loading…";
+        if (!p) { pathInput.focus(); return; }
+        errBox.className = "modal-err working";
+        errBox.textContent = "Loading\u2026";
         try {
             const res = await fetch("readfile?path=" + encodeURIComponent(p));
             const data = await res.json();
-            if (data.error) { errBox.textContent = data.error; return; }
+            if (data.error) { errBox.className = "modal-err"; errBox.textContent = data.error; return; }
             ta.value = data.content;
+            errBox.className = "modal-err";
             errBox.textContent = "";
-        } catch (e) { errBox.textContent = e.message; }
+        } catch (e) { errBox.className = "modal-err"; errBox.textContent = e.message; }
     } });
     pathRow.append(pathInput, loadBtn);
     dialog.append(pathRow);
 
-    const ta = el("textarea", { class: "mono modal-textarea", placeholder: "# paste TOML here\ntitle = \"Example\"\n[owner]\nname = \"…\"" });
+    const ta = el("textarea", { class: "mono modal-textarea", "aria-label": "TOML content to infer from", placeholder: "# paste TOML here\ntitle = \"Example\"\n[owner]\nname = \"…\"" });
     dialog.append(ta);
 
-    const errBox = el("div", { class: "modal-err" });
+    const errBox = el("div", { class: "modal-err", role: "alert" });
     dialog.append(errBox);
 
     const actions = el("div", { class: "modal-actions" });
-    actions.append(el("button", { text: "Cancel", onclick: () => overlay.remove() }));
-    actions.append(el("button", { class: "primary", text: "Infer schema", onclick: async () => {
+    actions.append(el("button", { text: "Cancel", onclick: () => closeModal(overlay) }));
+    const inferBtn = el("button", { class: "primary", text: "Infer schema" });
+    inferBtn.addEventListener("click", async () => {
         const toml = ta.value;
-        if (!toml.trim()) { errBox.textContent = "Provide some TOML to infer from."; return; }
-        errBox.textContent = "Inferring…";
+        if (!toml.trim()) { errBox.className = "modal-err"; errBox.textContent = "Provide some TOML to infer from."; ta.focus(); return; }
+        inferBtn.disabled = true;
+        errBox.className = "modal-err working";
+        errBox.textContent = "Inferring\u2026";
         try {
             const res = await fetch("infer", {
                 method: "POST",
@@ -1160,19 +1594,22 @@ function openInferModal() {
                 body: JSON.stringify({ toml }),
             });
             const data = await res.json();
-            if (data.error) { errBox.textContent = data.error; return; }
+            if (data.error) { errBox.className = "modal-err"; errBox.textContent = data.error; inferBtn.disabled = false; return; }
             state.model = data.model;
             state.selected = (state.model.elements[0] || state.model.types[0]) ?? null;
+            resetHistory();
             markDirty();
             renderAll();
-            overlay.remove();
-        } catch (e) { errBox.textContent = e.message; }
-    } }));
+            closeModal(overlay);
+        } catch (e) { errBox.className = "modal-err"; errBox.textContent = e.message; inferBtn.disabled = false; }
+    });
+    actions.append(inferBtn);
     dialog.append(actions);
 
     overlay.append(dialog);
-    overlay.addEventListener("click", (e) => { if (e.target === overlay) overlay.remove(); });
+    overlay.addEventListener("click", (e) => { if (e.target === overlay) closeModal(overlay); });
     document.body.append(overlay);
+    installModal(overlay);
     ta.focus();
 }
 

--- a/.github/extensions/tosd-editor/client.js
+++ b/.github/extensions/tosd-editor/client.js
@@ -162,9 +162,21 @@ function markDirty() {
 const history = { undo: [], redo: [], base: null, saved: null, timer: null, pending: false };
 
 function snapshot() {
+    const transientKeys = new Set(["__x", "__cy", "__root"]);
+    const schemaNodes = new WeakSet();
+    const collect = (nodes) => {
+        for (const node of nodes || []) {
+            schemaNodes.add(node);
+            collect(node.children);
+        }
+    };
+    collect(state.model.types);
+    collect(state.model.elements);
     return JSON.stringify(
         { version: state.model.version, meta: state.model.meta, types: state.model.types, elements: state.model.elements },
-        (k, v) => (k.startsWith("__") && k !== "__collapsed" ? undefined : v),
+        function replacer(k, v) {
+            return schemaNodes.has(this) && transientKeys.has(k) ? undefined : v;
+        },
     );
 }
 
@@ -797,6 +809,9 @@ function renderEditor() {
     actions.append(el("button", { class: "danger", text: "Delete", onclick: () => deleteNode(node) }));
     box.append(actions);
 
+    box.append(textField("description", "Description", p.description || "", (v) => setProp(p, "description", v),
+        false, "Human-readable documentation for this schema definition."));
+
     // Current-node type selector
     box.append(
         refField("type", "Type", p.type || "", (v) => setProp(p, "type", v),
@@ -912,7 +927,7 @@ function setNumProp(p, key, v) {
 }
 function setListProp(p, key, arr) {
     const clean = arr.filter((s) => s !== "");
-    if (clean.length === 0) delete p[key];
+    if (clean.length === 0 && key !== "allowedvalues") delete p[key];
     else p[key] = clean;
     markDirty();
     renderTree();
@@ -1095,11 +1110,32 @@ function renderMetaEditor(box) {
 
     box.append(el("div", { class: "section-title", text: "[toml-schema.meta] (custom metadata)" }));
     const meta = state.model.meta || {};
-    const entries = Object.entries(meta).filter(([, v]) => typeof v !== "object" || v.__datetime || v.__inline || Array.isArray(v));
+    const entries = Object.entries(meta).filter(([, v]) => typeof v === "string");
+    const preserved = Object.fromEntries(Object.entries(meta).filter(([, v]) => typeof v !== "string"));
     const container = el("div");
-    const arr = entries.map(([k, v]) => [k, typeof v === "string" ? v : JSON.stringify(v)]);
+    const conflictMessage = el("div", { class: "field-err", role: "alert" });
+    const arr = entries.map(([k, v]) => [k, v]);
+    const keyConflict = (key, index) => !!key && (
+        Object.prototype.hasOwnProperty.call(preserved, key)
+        || arr.some((pair, otherIndex) => otherIndex !== index && pair[0] === key)
+    );
+    const validateKeys = () => {
+        let hasConflict = false;
+        [...container.querySelectorAll(".meta-key")].forEach((input, index) => {
+            const conflict = keyConflict(arr[index][0], index);
+            hasConflict ||= conflict;
+            input.classList.toggle("invalid", conflict);
+            input.setAttribute("aria-invalid", conflict ? "true" : "false");
+            input.title = conflict ? "Metadata keys must be unique and cannot replace preserved typed metadata." : "";
+        });
+        conflictMessage.textContent = hasConflict
+            ? "Metadata keys must be unique and cannot replace preserved typed metadata."
+            : "";
+        return !hasConflict;
+    };
     const commit = () => {
-        const obj = {};
+        if (!validateKeys()) return;
+        const obj = { ...preserved };
         for (const [k, v] of arr) {
             if (k === "") continue;
             obj[k] = v;
@@ -1111,19 +1147,27 @@ function renderMetaEditor(box) {
         container.textContent = "";
         arr.forEach((pair, idx) => {
             const row = el("div", { class: "list-row" });
-            row.append(el("input", { type: "text", class: "mono", value: pair[0], placeholder: "key", "aria-label": "Metadata key " + (idx + 1),
-                oninput: (e) => { arr[idx][0] = e.target.value; commit(); } }));
+            row.append(el("input", { type: "text", class: "mono meta-key", value: pair[0], placeholder: "key", "aria-label": "Metadata key " + (idx + 1),
+                oninput: (e) => { arr[idx][0] = e.target.value; validateKeys(); commit(); } }));
             row.append(el("input", { type: "text", class: "mono", value: pair[1], placeholder: "value", "aria-label": "Metadata value " + (idx + 1),
                 oninput: (e) => { arr[idx][1] = e.target.value; commit(); } }));
             row.append(el("button", { class: "icon danger", text: "\u2715", "aria-label": "Remove metadata " + (idx + 1), title: "Remove",
                 onclick: () => { arr.splice(idx, 1); commit(); rerender(); } }));
             container.append(row);
         });
+        validateKeys();
     };
     rerender();
     box.append(container);
+    box.append(conflictMessage);
     box.append(el("button", { class: "icon", text: "+ add metadata", onclick: () => { arr.push(["", ""]); rerender(); } }));
-    box.append(el("div", { class: "field hint", text: "Values are stored as strings. Use the preview to confirm output." }));
+    const preservedCount = Object.keys(preserved).length;
+    box.append(el("div", {
+        class: "field hint",
+        text: preservedCount
+            ? `${preservedCount} typed or nested metadata entr${preservedCount === 1 ? "y is" : "ies are"} preserved read-only. New values are stored as strings.`
+            : "New values are stored as strings. Use the preview to confirm output.",
+    }));
 }
 
 // --- Issues -------------------------------------------------------------

--- a/.github/extensions/tosd-editor/client.js
+++ b/.github/extensions/tosd-editor/client.js
@@ -168,11 +168,11 @@ function snapshot() {
     );
 }
 
-function resetHistory() {
+function resetHistory(markSaved = true) {
     history.undo = [];
     history.redo = [];
     history.base = snapshot();
-    history.saved = history.base;
+    if (markSaved) history.saved = history.base;
     history.pending = false;
     clearTimeout(history.timer);
     updateHistoryButtons();
@@ -370,8 +370,9 @@ function compositor(node) {
 function unresolvedRefs(node) {
     const p = node.props || {};
     const refs = [];
-    if (p.typeof) refs.push(p.typeof);
+    if (p.type) refs.push(p.type);
     if (p.itemtype) refs.push(p.itemtype);
+    for (const r of p.items || []) refs.push(r);
     for (const r of p.oneof || []) refs.push(r);
     for (const r of p.anyof || []) refs.push(r);
     return refs.filter((r) => r && !isKnownRef(r));
@@ -497,7 +498,7 @@ function renderDiagram() {
 }
 
 function rootBox(node) {
-    const box = el("div", { class: "dg-root", role: "treeitem", "aria-level": "1" });
+    const box = el("div", { class: "dg-root", role: "presentation", "aria-hidden": "true" });
     box.style.left = node.__x + "px";
     box.style.top = (node.__cy - DG.BOX_H / 2) + "px";
     box.style.width = DG.BOX_W + "px";
@@ -610,6 +611,7 @@ function parentOf(node) {
 }
 
 function onBoxKeydown(e, node) {
+    if (e.target.closest("button, input, select, textarea, a[href]")) return;
     const flat = flatVisible();
     const idx = flat.indexOf(node);
     const kids = node.children || [];
@@ -1378,6 +1380,8 @@ function clearSelection() {
 // --- Modal helpers (focus trap + restore) -------------------------------
 function installModal(overlay) {
     overlay.__restoreFocus = document.activeElement;
+    overlay.__closed = false;
+    overlay.__requests = new Set();
     overlay.__trap = (e) => {
         if (e.key !== "Tab") return;
         const f = [...overlay.querySelectorAll('button, input, select, textarea, [href], [tabindex]:not([tabindex="-1"])')]
@@ -1393,8 +1397,31 @@ function installModal(overlay) {
     overlay.setAttribute("aria-modal", "true");
 }
 
+function modalIsActive(overlay) {
+    return !overlay.__closed && overlay.isConnected;
+}
+
+async function modalJson(overlay, url, options = {}) {
+    const controller = new AbortController();
+    overlay.__requests.add(controller);
+    try {
+        const res = await fetch(url, { ...options, signal: controller.signal });
+        const data = await res.json();
+        return modalIsActive(overlay) ? data : null;
+    } finally {
+        overlay.__requests.delete(controller);
+    }
+}
+
+function modalRequestCancelled(error, overlay) {
+    return error?.name === "AbortError" || !modalIsActive(overlay);
+}
+
 function closeModal(overlay) {
-    if (!overlay) return;
+    if (!overlay || overlay.__closed) return;
+    overlay.__closed = true;
+    for (const controller of overlay.__requests || []) controller.abort();
+    overlay.__requests?.clear();
     if (overlay.__trap) document.removeEventListener("keydown", overlay.__trap, true);
     const restore = overlay.__restoreFocus;
     overlay.remove();
@@ -1406,7 +1433,7 @@ function newSchema() {
     if (state.dirty && !confirm("Discard unsaved changes and start a new schema?")) return;
     state.model = { version: "1.0.0", meta: null, types: [], elements: [] };
     state.selected = "__meta__";
-    resetHistory();
+    resetHistory(false);
     markDirty();
     renderAll();
 }
@@ -1439,37 +1466,35 @@ function openGenerateModal() {
         const description = ta.value.trim();
         if (!description) { errBox.className = "modal-err"; errBox.textContent = "Describe the configuration first."; ta.focus(); return; }
         genBtn.disabled = true;
-        cancelBtn.disabled = true;
         ta.disabled = true;
         errBox.className = "modal-err working";
         errBox.textContent = "Asking Copilot\u2026 this runs a Copilot turn and may take a moment.";
         try {
-            const res = await fetch("generate", {
+            const data = await modalJson(overlay, "generate", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({ description }),
             });
-            const data = await res.json();
+            if (!data) return;
             if (data.error) {
                 errBox.className = "modal-err";
                 errBox.textContent = data.error;
                 genBtn.disabled = false;
-                cancelBtn.disabled = false;
                 ta.disabled = false;
                 return;
             }
             state.model = data.model;
             state.view = "elements";
             state.selected = (state.model.elements[0] || state.model.types[0]) ?? null;
-            resetHistory();
+            resetHistory(false);
             markDirty();
             renderAll();
             closeModal(overlay);
         } catch (e) {
+            if (modalRequestCancelled(e, overlay)) return;
             errBox.className = "modal-err";
             errBox.textContent = e.message;
             genBtn.disabled = false;
-            cancelBtn.disabled = false;
             ta.disabled = false;
         }
     });
@@ -1503,12 +1528,12 @@ function openSchema() {
         errBox.textContent = "Opening\u2026";
         if (openBtn) openBtn.disabled = true;
         try {
-            const res = await fetch("open", {
+            const data = await modalJson(overlay, "open", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({ path: p }),
             });
-            const data = await res.json();
+            if (!data) return;
             if (data.error) { errBox.className = "modal-err"; errBox.textContent = data.error; if (openBtn) openBtn.disabled = false; return; }
             state.path = data.path;
             state.model = data.model;
@@ -1518,7 +1543,12 @@ function openSchema() {
             renderAll();
             schedulePreview();
             closeModal(overlay);
-        } catch (e) { errBox.className = "modal-err"; errBox.textContent = e.message; if (openBtn) openBtn.disabled = false; }
+        } catch (e) {
+            if (modalRequestCancelled(e, overlay)) return;
+            errBox.className = "modal-err";
+            errBox.textContent = e.message;
+            if (openBtn) openBtn.disabled = false;
+        }
     };
 
     const pathRow = el("div", { class: "list-row" });
@@ -1561,13 +1591,17 @@ function openInferModal() {
         errBox.className = "modal-err working";
         errBox.textContent = "Loading\u2026";
         try {
-            const res = await fetch("readfile?path=" + encodeURIComponent(p));
-            const data = await res.json();
+            const data = await modalJson(overlay, "readfile?path=" + encodeURIComponent(p));
+            if (!data) return;
             if (data.error) { errBox.className = "modal-err"; errBox.textContent = data.error; return; }
             ta.value = data.content;
             errBox.className = "modal-err";
             errBox.textContent = "";
-        } catch (e) { errBox.className = "modal-err"; errBox.textContent = e.message; }
+        } catch (e) {
+            if (modalRequestCancelled(e, overlay)) return;
+            errBox.className = "modal-err";
+            errBox.textContent = e.message;
+        }
     } });
     pathRow.append(pathInput, loadBtn);
     dialog.append(pathRow);
@@ -1588,20 +1622,25 @@ function openInferModal() {
         errBox.className = "modal-err working";
         errBox.textContent = "Inferring\u2026";
         try {
-            const res = await fetch("infer", {
+            const data = await modalJson(overlay, "infer", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({ toml }),
             });
-            const data = await res.json();
+            if (!data) return;
             if (data.error) { errBox.className = "modal-err"; errBox.textContent = data.error; inferBtn.disabled = false; return; }
             state.model = data.model;
             state.selected = (state.model.elements[0] || state.model.types[0]) ?? null;
-            resetHistory();
+            resetHistory(false);
             markDirty();
             renderAll();
             closeModal(overlay);
-        } catch (e) { errBox.className = "modal-err"; errBox.textContent = e.message; inferBtn.disabled = false; }
+        } catch (e) {
+            if (modalRequestCancelled(e, overlay)) return;
+            errBox.className = "modal-err";
+            errBox.textContent = e.message;
+            inferBtn.disabled = false;
+        }
     });
     actions.append(inferBtn);
     dialog.append(actions);

--- a/.github/extensions/tosd-editor/extension.mjs
+++ b/.github/extensions/tosd-editor/extension.mjs
@@ -69,14 +69,10 @@ async function findDefaultTosd() {
     return join(base, "untitled.tosd");
 }
 
-async function loadModelForPath(filePath) {    if (filePath && existsSync(filePath)) {
+async function loadModelForPath(filePath) {
+    if (filePath && existsSync(filePath)) {
         const text = await readFile(filePath, "utf8");
-        try {
-            return parseDocument(text);
-        } catch (e) {
-            // Surface a parse failure as a blank model rather than crashing.
-            return blankModel();
-        }
+        return parseDocument(text);
     }
     return blankModel();
 }
@@ -252,6 +248,13 @@ async function startServer(instanceId, entry) {
                 entry.model = model;
                 if (!entry.path) return sendJson(res, 200, { ok: false, error: "no file path for this schema" });
                 try {
+                    const errors = validateModel(model).filter((issue) => issue.level === "error");
+                    if (errors.length) {
+                        return sendJson(res, 200, {
+                            ok: false,
+                            error: `Schema has ${errors.length} validation error${errors.length === 1 ? "" : "s"}. Resolve them before saving.`,
+                        });
+                    }
                     const toml = serializeDocument(model);
                     await writeFile(entry.path, toml, "utf8");
                     return sendJson(res, 200, { ok: true, path: entry.path });

--- a/.github/extensions/tosd-editor/infer.mjs
+++ b/.github/extensions/tosd-editor/infer.mjs
@@ -151,6 +151,8 @@ function representativeScalarType(values) {
 function scalarType(value) {
     if (typeof value === "boolean") return "boolean";
     if (typeof value === "number") return Number.isInteger(value) ? "integer" : "float";
+    if (value && value.__integer) return "integer";
+    if (value && value.__float) return "float";
     if (value && value.__datetime) return value.__datetime;
     return "string";
 }

--- a/.github/extensions/tosd-editor/model.mjs
+++ b/.github/extensions/tosd-editor/model.mjs
@@ -19,11 +19,13 @@
 //   min/max                                : string    (TOML value token)
 
 import {
+    TomlError,
     parseToml,
     formatValue,
     formatKeyPath,
     parseValue,
     isPlainTable,
+    tableCollisions,
 } from "./toml.mjs";
 
 export const PROP_ORDER = [
@@ -72,70 +74,101 @@ export const BUILTIN_TYPES = [
 // ---------------------------------------------------------------------------
 
 export function parseDocument(text) {
-    const root = parseToml(text || "");
-    const meta = root["toml-schema"] || {};
-    const version = typeof meta.version === "string" ? meta.version : "1.0.0";
+    const root = parseToml(text || "", { allowTableValueCollisions: true });
+    const allowedTopLevel = new Set(["toml-schema", "types", "elements"]);
+    for (const key of Object.keys(root)) {
+        if (!allowedTopLevel.has(key)) {
+            throw new TomlError(`Unsupported top-level key or table: ${key}`);
+        }
+    }
+
+    const meta = root["toml-schema"];
+    if (!isPlainTable(meta)) throw new TomlError("Missing required [toml-schema] table.");
+    if (!Object.prototype.hasOwnProperty.call(meta, "version")) {
+        throw new TomlError("Missing required [toml-schema].version.");
+    }
+    if (typeof meta.version !== "string") {
+        throw new TomlError("[toml-schema].version must be a string.");
+    }
+    for (const key of [...Object.keys(meta), ...Object.keys(tableCollisions(meta))]) {
+        if (!["version", "meta"].includes(key)) {
+            throw new TomlError(`Unsupported key or table under [toml-schema]: ${key}`);
+        }
+    }
+    if (Object.prototype.hasOwnProperty.call(meta, "meta") && !isPlainTable(meta.meta)) {
+        throw new TomlError("[toml-schema].meta must be a table.");
+    }
+    if (!isPlainTable(root.elements)) throw new TomlError("Missing required [elements] table.");
+    if (root.types !== undefined && !isPlainTable(root.types)) {
+        throw new TomlError("[types] must be a table.");
+    }
+
     const metaTable = isPlainTable(meta.meta) ? meta.meta : null;
 
     return {
-        version,
+        version: meta.version,
         meta: metaTable,
-        types: tableToNodes(root["types"]),
-        elements: tableToNodes(root["elements"]),
+        types: tableToNodes(root.types, "types"),
+        elements: tableToNodes(root.elements, "elements"),
     };
 }
 
-function tableToNodes(table) {
+function tableToNodes(table, basePath) {
     if (!isPlainTable(table)) return [];
     const nodes = [];
     for (const [name, value] of Object.entries(table)) {
-        if (isPlainTable(value)) {
-            nodes.push(tableToNode(name, value));
+        if (!isPlainTable(value)) {
+            throw new TomlError(`${basePath}.${name} must be a schema definition table.`);
         }
-        // Non-table top-level entries under [types]/[elements] are not valid
-        // schema definitions; ignore them defensively.
+        nodes.push(tableToNode(name, value, `${basePath}.${name}`));
     }
     return nodes;
 }
 
-function tableToNode(name, table) {
+function tableToNode(name, table, path) {
     const node = { name, props: {}, children: [] };
     for (const [key, value] of Object.entries(table)) {
         if (isPlainTable(value)) {
-            node.children.push(tableToNode(key, value));
+            node.children.push(tableToNode(key, value, `${path}.${key}`));
         } else if (ALL_PROPS.has(key)) {
-            node.props[key] = decodeProp(key, value);
+            node.props[key] = decodeProp(key, value, path);
         } else if (key === "arraytype" || key === "default") {
             // Preserve removed syntax long enough for validation to report it.
             node.props[key] = String(value);
         } else {
-            // A target document key that collides with nothing schema-specific
-            // but holds a scalar - treat it as a child definition placeholder so
-            // the information is not lost. Wrap as a node with a single prop.
-            node.children.push({ name: key, props: scalarToProps(value), children: [] });
+            throw new TomlError(`Unsupported schema property at ${path}: ${key}`);
         }
+    }
+    for (const [key, value] of Object.entries(tableCollisions(table))) {
+        node.children.push(tableToNode(key, value, `${path}.${key}`));
     }
     return node;
 }
 
-function scalarToProps(value) {
-    // Best-effort: represent a stray scalar child as an implicit string-ish node.
-    return { type: typeofToken(value) };
-}
-
-function typeofToken(value) {
-    if (typeof value === "boolean") return "boolean";
-    if (typeof value === "number") return Number.isInteger(value) ? "integer" : "float";
-    if (value && value.__datetime) return value.__datetime;
-    return "string";
-}
-
-function decodeProp(key, value) {
-    if (STRING_PROPS.has(key)) return typeof value === "string" ? value : String(value);
-    if (BOOL_PROPS.has(key)) return Boolean(value);
-    if (INT_PROPS.has(key)) return Number(value);
-    if (REFLIST_PROPS.has(key)) return Array.isArray(value) ? value.map(String) : [];
-    if (VALUELIST_PROPS.has(key)) return Array.isArray(value) ? value.map(formatValue) : [];
+function decodeProp(key, value, path) {
+    if (STRING_PROPS.has(key)) {
+        if (typeof value !== "string") throw new TomlError(`${path}.${key} must be a string.`);
+        return value;
+    }
+    if (BOOL_PROPS.has(key)) {
+        if (typeof value !== "boolean") throw new TomlError(`${path}.${key} must be a boolean.`);
+        return value;
+    }
+    if (INT_PROPS.has(key)) {
+        if (typeof value === "number" && Number.isInteger(value)) return value;
+        if (value?.__integer) return value.value;
+        throw new TomlError(`${path}.${key} must be an integer.`);
+    }
+    if (REFLIST_PROPS.has(key)) {
+        if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
+            throw new TomlError(`${path}.${key} must be an array of type-reference strings.`);
+        }
+        return value;
+    }
+    if (VALUELIST_PROPS.has(key)) {
+        if (!Array.isArray(value)) throw new TomlError(`${path}.${key} must be an array.`);
+        return value.map(formatValue);
+    }
     if (VALUE_PROPS.has(key)) return formatValue(value);
     return formatValue(value);
 }
@@ -197,7 +230,10 @@ function emitNode(node, parentPath, depth, lines) {
 function encodeProp(key, raw) {
     if (STRING_PROPS.has(key)) return String(raw);
     if (BOOL_PROPS.has(key)) return Boolean(raw);
-    if (INT_PROPS.has(key)) return Math.trunc(Number(raw));
+    if (INT_PROPS.has(key)) {
+        const details = tokenDetails(raw);
+        return details?.kind === "integer" ? details.value : undefined;
+    }
     if (REFLIST_PROPS.has(key)) {
         const arr = (Array.isArray(raw) ? raw : []).map(String).filter((s) => s !== "");
         return arr;
@@ -206,7 +242,7 @@ function encodeProp(key, raw) {
         const arr = (Array.isArray(raw) ? raw : [])
             .map((tok) => safeParseToken(tok))
             .filter((v) => v !== undefined);
-        return arr.length ? arr : undefined;
+        return arr;
     }
     if (VALUE_PROPS.has(key)) return safeParseToken(raw);
     return safeParseToken(raw);
@@ -242,7 +278,7 @@ function emitRawTable(pathParts, table, lines) {
 }
 
 function formatKeyMeta(key) {
-    return /^[A-Za-z0-9_-]+$/.test(key) ? key : `'${key}'`;
+    return formatKeyPath([key]);
 }
 
 // ---------------------------------------------------------------------------
@@ -258,23 +294,226 @@ const NUMERIC_OR_TEMPORAL = new Set([
     "local-time",
 ]);
 
+const SIMPLE_TYPES = new Set([
+    "any",
+    "string",
+    "integer",
+    "float",
+    "boolean",
+    "offset-date-time",
+    "local-date-time",
+    "local-date",
+    "local-time",
+]);
+
+const SEMVER_RE =
+    /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+function parseSemVer(version) {
+    const match = SEMVER_RE.exec(version || "");
+    return match ? { major: Number(match[1]), minor: Number(match[2]) } : null;
+}
+
+function tokenDetails(token) {
+    const raw = String(token ?? "").trim();
+    try {
+        const value = parseValue(raw);
+        let kind;
+        if (typeof value === "string") kind = "string";
+        else if (typeof value === "boolean") kind = "boolean";
+        else if (value?.__integer) kind = "integer";
+        else if (value?.__float) kind = "float";
+        else if (value?.__datetime) kind = value.__datetime;
+        else if (typeof value === "number") {
+            kind = /[.eE]|inf|nan/i.test(raw) ? "float" : "integer";
+        }
+        return { raw, value, kind };
+    } catch {
+        return null;
+    }
+}
+
+function numericComparable(details) {
+    if (!details || !["integer", "float"].includes(details.kind)) return false;
+    if (details.value?.__float) return !details.value.value.toLowerCase().includes("nan");
+    return !Number.isNaN(details.value);
+}
+
+function integerBigInt(details) {
+    if (!details || details.kind !== "integer") return null;
+    if (details.value?.__integer) return parseIntegerBigInt(details.value.value);
+    return BigInt(details.value);
+}
+
+function parseIntegerBigInt(token) {
+    const raw = String(token).replace(/_/g, "");
+    const sign = raw.startsWith("-") ? -1n : 1n;
+    const unsigned = raw.replace(/^[+-]/, "");
+    return sign * BigInt(unsigned);
+}
+
+function patternIssue(pattern) {
+    try {
+        new RegExp(pattern, "u");
+    } catch (error) {
+        return { level: "error", message: `is not a valid regular expression: ${error.message}` };
+    }
+    if (/\\[dDsSwW]/.test(pattern) || /\\[1-9]/.test(pattern) || /\(\?(?:[=!]|<[=!])/.test(pattern)) {
+        return { level: "warning", message: "uses syntax outside the portable RE2 profile" };
+    }
+    return null;
+}
+
+function numericValue(details) {
+    if (!numericComparable(details)) return null;
+    if (details.kind === "integer") return { numerator: integerBigInt(details), denominator: 1n };
+    const token = details.value?.__float ? details.value.value.replace(/_/g, "") : String(details.value);
+    const number = token.endsWith("inf")
+        ? (token.startsWith("-") ? -Infinity : Infinity)
+        : Number(token);
+    if (number === Infinity) return { infinity: 1 };
+    if (number === -Infinity) return { infinity: -1 };
+
+    const buffer = new ArrayBuffer(8);
+    const view = new DataView(buffer);
+    view.setFloat64(0, number, false);
+    const bits = view.getBigUint64(0, false);
+    const sign = bits >> 63n ? -1n : 1n;
+    const exponentBits = Number((bits >> 52n) & 0x7ffn);
+    const fractionBits = bits & ((1n << 52n) - 1n);
+    const mantissa = exponentBits === 0 ? fractionBits : (1n << 52n) + fractionBits;
+    const exponent = exponentBits === 0 ? -1074 : exponentBits - 1023 - 52;
+    return exponent >= 0
+        ? { numerator: sign * (mantissa << BigInt(exponent)), denominator: 1n }
+        : { numerator: sign * mantissa, denominator: 1n << BigInt(-exponent) };
+}
+
+function compareNumeric(left, right) {
+    const a = numericValue(left);
+    const b = numericValue(right);
+    if (!a || !b) return null;
+    if (a.infinity || b.infinity) {
+        const av = a.infinity || 0;
+        const bv = b.infinity || 0;
+        return av === bv ? 0 : av < bv ? -1 : 1;
+    }
+    const difference = a.numerator * b.denominator - b.numerator * a.denominator;
+    return difference === 0n ? 0 : difference < 0n ? -1 : 1;
+}
+
+function daysFromCivil(year, month, day) {
+    const adjustedYear = year - (month <= 2 ? 1 : 0);
+    const era = Math.floor(adjustedYear / 400);
+    const yearOfEra = adjustedYear - era * 400;
+    const shiftedMonth = month + (month > 2 ? -3 : 9);
+    const dayOfYear = Math.floor((153 * shiftedMonth + 2) / 5) + day - 1;
+    const dayOfEra = yearOfEra * 365 + Math.floor(yearOfEra / 4) - Math.floor(yearOfEra / 100) + dayOfYear;
+    return BigInt(era * 146097 + dayOfEra);
+}
+
+function parseTime(raw) {
+    const match = /^(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?$/.exec(raw);
+    if (!match) return null;
+    return {
+        seconds: BigInt(Number(match[1]) * 3600 + Number(match[2]) * 60 + Number(match[3])),
+        fraction: match[4] || "",
+    };
+}
+
+function temporalValue(details) {
+    if (!details?.value?.__datetime) return null;
+    const raw = details.value.value;
+    if (details.kind === "local-date") {
+        const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(raw);
+        return match ? { whole: daysFromCivil(Number(match[1]), Number(match[2]), Number(match[3])), fraction: "" } : null;
+    }
+    if (details.kind === "local-time") {
+        const time = parseTime(raw);
+        return time ? { whole: time.seconds, fraction: time.fraction } : null;
+    }
+    const match = /^(\d{4})-(\d{2})-(\d{2})[Tt ](.+)$/.exec(raw);
+    if (!match) return null;
+    let timeText = match[4];
+    let offsetSeconds = 0;
+    if (details.kind === "offset-date-time") {
+        const offset = /(Z|[+-]\d{2}:\d{2})$/i.exec(timeText);
+        if (!offset) return null;
+        timeText = timeText.slice(0, -offset[1].length);
+        if (offset[1].toUpperCase() !== "Z") {
+            const sign = offset[1][0] === "-" ? -1 : 1;
+            offsetSeconds = sign * (Number(offset[1].slice(1, 3)) * 3600 + Number(offset[1].slice(4, 6)) * 60);
+        }
+    }
+    const time = parseTime(timeText);
+    if (!time) return null;
+    const days = daysFromCivil(Number(match[1]), Number(match[2]), Number(match[3]));
+    return { whole: days * 86400n + time.seconds - BigInt(offsetSeconds), fraction: time.fraction };
+}
+
+function compareTemporal(left, right) {
+    const a = temporalValue(left);
+    const b = temporalValue(right);
+    if (!a || !b) return null;
+    if (a.whole !== b.whole) return a.whole < b.whole ? -1 : 1;
+    const width = Math.max(a.fraction.length, b.fraction.length);
+    const af = (a.fraction || "").padEnd(width, "0");
+    const bf = (b.fraction || "").padEnd(width, "0");
+    return af === bf ? 0 : af < bf ? -1 : 1;
+}
+
+function valueSatisfiesRange(details, boundary, direction) {
+    if (!details || !boundary) return false;
+    if (numericComparable(details) && numericComparable(boundary)) {
+        const comparison = compareNumeric(details, boundary);
+        return comparison != null && (direction === "min" ? comparison >= 0 : comparison <= 0);
+    }
+    if (details.kind !== boundary.kind || !details.value?.__datetime || !boundary.value?.__datetime) return false;
+    const comparison = compareTemporal(details, boundary);
+    return comparison != null && (direction === "min" ? comparison >= 0 : comparison <= 0);
+}
+
 export function validateModel(model) {
     const issues = [];
-    const typeNames = new Set((model.types || []).map((t) => t.name));
+    const checkSiblingNames = (nodes, path) => {
+        const names = new Set();
+        for (const node of nodes || []) {
+            if (!node.name) {
+                issues.push({ level: "error", path, message: "Schema definition names must not be blank." });
+            } else if (names.has(node.name)) {
+                issues.push({ level: "error", path: `${path}.${node.name}`, message: `Duplicate schema definition name: ${node.name}.` });
+            }
+            names.add(node.name);
+        }
+    };
+    checkSiblingNames(model.elements, "elements");
+
+    const typeNames = new Set();
+    for (const type of model.types || []) {
+        if (!type.name) {
+            issues.push({ level: "error", path: "types", message: "Reusable type names must not be blank." });
+        } else if (BUILTIN_TYPES.includes(type.name)) {
+            issues.push({ level: "error", path: `types.${type.name}`, message: `Built-in type name \`${type.name}\` is reserved.` });
+        } else if (typeNames.has(type.name)) {
+            issues.push({ level: "error", path: `types.${type.name}`, message: `Duplicate reusable type name: ${type.name}.` });
+        }
+        typeNames.add(type.name);
+    }
     const typesByName = new Map((model.types || []).map((t) => [t.name, t]));
 
     const refExists = (ref) => {
         if (!ref) return true;
-        const name = ref.startsWith("types.") ? ref.slice(6) : ref;
-        if (BUILTIN_TYPES.includes(name)) return true;
+        const qualified = ref.startsWith("types.");
+        const name = qualified ? ref.slice(6) : ref;
+        if (!qualified && BUILTIN_TYPES.includes(name)) return true;
         return typeNames.has(name);
     };
     const normalizeRef = (ref) => ref?.startsWith("types.") ? ref.slice(6) : ref;
+    const bareBuiltin = (ref) => !!ref && !ref.startsWith("types.") && BUILTIN_TYPES.includes(ref);
 
     const resolvedKinds = (ref, seen = new Set()) => {
         if (!ref) return new Set();
-        const name = ref.startsWith("types.") ? ref.slice(6) : ref;
-        if (BUILTIN_TYPES.includes(name)) return new Set([name]);
+        const name = normalizeRef(ref);
+        if (bareBuiltin(ref)) return new Set([name]);
         if (seen.has(name)) return new Set();
         const definition = typesByName.get(name);
         if (!definition) return new Set();
@@ -292,6 +531,7 @@ export function validateModel(model) {
     const walk = (node, pathLabel) => {
         const p = node.props || {};
         const label = pathLabel;
+        let compiledPattern = null;
 
         if (p.arraytype != null) {
             issues.push({ level: "error", path: label, message: "`arraytype` is not supported; use `itemtype`." });
@@ -325,12 +565,23 @@ export function validateModel(model) {
                 }
             }
         }
+        if (p.type && !bareBuiltin(p.type) && refExists(p.type)) {
+            const allowed = new Set(["type", "description", "optional"]);
+            for (const key of Object.keys(p)) {
+                if (!allowed.has(key)) {
+                    issues.push({ level: "error", path: label, message: `A named type reference cannot define \`${key}\`.` });
+                }
+            }
+        }
         if ((node.children || []).length > 0 && !["table", "collection"].includes(p.type) && exclusivity.length > 0) {
             issues.push({ level: "error", path: label, message: "Child definitions require the built-in type `table` or `collection`." });
         }
 
         if (p.items && p.itemtype) {
             issues.push({ level: "error", path: label, message: "`items` is mutually exclusive with `itemtype`." });
+        }
+        if (p.items && p.type !== "array") {
+            issues.push({ level: "error", path: label, message: "`items` requires `type = \"array\"`." });
         }
         if (p.itemtype && !["array", "collection"].includes(p.type)) {
             issues.push({ level: "error", path: label, message: "`itemtype` requires `type = \"array\"` or `type = \"collection\"`." });
@@ -341,9 +592,27 @@ export function validateModel(model) {
         if (p.items && (p.minlength != null || p.maxlength != null)) {
             issues.push({ level: "error", path: label, message: "`items` is mutually exclusive with `minlength`/`maxlength`." });
         }
+        if (p.items && p.allowedvalues) {
+            issues.push({ level: "error", path: label, message: "`items` is mutually exclusive with `allowedvalues`." });
+        }
+        const minLength = p.minlength != null ? integerBigInt(tokenDetails(p.minlength)) : null;
+        const maxLength = p.maxlength != null ? integerBigInt(tokenDetails(p.maxlength)) : null;
+        if (p.minlength != null && (minLength == null || minLength < 0n)) {
+            issues.push({ level: "error", path: label, message: "`minlength` must be an integer greater than or equal to zero." });
+        }
+        if (p.maxlength != null && (maxLength == null || maxLength < 0n)) {
+            issues.push({ level: "error", path: label, message: "`maxlength` must be an integer greater than or equal to zero." });
+        }
+        if (minLength != null && maxLength != null && minLength > maxLength) {
+            issues.push({ level: "error", path: label, message: "`minlength` must be less than or equal to `maxlength`." });
+        }
 
         const hasMin = p.min != null && p.min !== "";
         const hasMax = p.max != null && p.max !== "";
+        const rangeKind = p.type === "array"
+            ? (resolvedKinds(p.itemtype).size === 1 ? [...resolvedKinds(p.itemtype)][0] : null)
+            : p.type;
+        const boundaries = {};
         if (hasMin || hasMax) {
             const t = p.type;
             const itemKinds = t === "array" ? resolvedKinds(p.itemtype) : new Set();
@@ -353,6 +622,18 @@ export function validateModel(model) {
                 issues.push({ level: "error", path: label, message: "`min`/`max` cannot be applied to type `any`." });
             } else if (!ok) {
                 issues.push({ level: "error", path: label, message: "`min`/`max` only apply to numeric/temporal types, or arrays of them." });
+            }
+            for (const key of ["min", "max"]) {
+                if (p[key] == null || p[key] === "") continue;
+                const details = tokenDetails(p[key]);
+                boundaries[key] = details;
+                const valid = NUMERIC_OR_TEMPORAL.has(rangeKind)
+                    && (["integer", "float"].includes(rangeKind)
+                        ? numericComparable(details)
+                        : details?.kind === rangeKind);
+                if (!valid) {
+                    issues.push({ level: "error", path: label, message: `\`${key}\` must be a comparable TOML value for ${rangeKind || "the selected type"}.` });
+                }
             }
         }
 
@@ -365,10 +646,17 @@ export function validateModel(model) {
 
         if (Object.prototype.hasOwnProperty.call(p, "pattern") && p.type !== "string") {
             issues.push({ level: "error", path: label, message: "`pattern` requires the built-in type `string`." });
+        } else if (p.pattern) {
+            const issue = patternIssue(p.pattern);
+            if (issue) issues.push({ level: issue.level, path: label, message: `\`pattern\` ${issue.message}.` });
+            if (issue?.level !== "error") compiledPattern = new RegExp(p.pattern, "u");
         }
 
         if (Object.prototype.hasOwnProperty.call(p, "keypattern") && p.type !== "collection") {
             issues.push({ level: "error", path: label, message: "`keypattern` requires the built-in type `collection`." });
+        } else if (p.keypattern) {
+            const issue = patternIssue(p.keypattern);
+            if (issue) issues.push({ level: issue.level, path: label, message: `\`keypattern\` ${issue.message}.` });
         }
 
         for (const ref of [p.type, p.itemtype]) {
@@ -383,12 +671,67 @@ export function validateModel(model) {
                 } else if (!refExists(ref)) {
                     issues.push({ level: "error", path: label, message: `Unknown type reference in ${listKey}: "${ref}".` });
                 }
+                const builtin = bareBuiltin(ref) ? ref : null;
+                if (builtin === "collection") {
+                    issues.push({ level: "error", path: label, message: `Bare \`collection\` is not valid in ${listKey}.` });
+                }
+                if (["oneof", "anyof"].includes(listKey) && builtin === "any") {
+                    issues.push({ level: "error", path: label, message: `Bare \`any\` is not valid in ${listKey}.` });
+                }
+            }
+        }
+        if (bareBuiltin(p.itemtype) && p.itemtype === "collection") {
+            issues.push({ level: "error", path: label, message: "Bare `collection` is not valid as an `itemtype`." });
+        }
+
+        if (p.allowedvalues != null) {
+            if (!Array.isArray(p.allowedvalues)) {
+                issues.push({ level: "error", path: label, message: "`allowedvalues` must be an array of TOML values." });
+            }
+            if (p.type && !SIMPLE_TYPES.has(p.type) && p.type !== "array") {
+                issues.push({ level: "error", path: label, message: "`allowedvalues` requires a simple type or `array`." });
+            }
+            const expectedKind = p.type === "array"
+                ? (resolvedKinds(p.itemtype).size === 1 ? [...resolvedKinds(p.itemtype)][0] : null)
+                : p.type;
+            for (const token of p.allowedvalues || []) {
+                const details = tokenDetails(token);
+                if (!details) {
+                    issues.push({ level: "error", path: label, message: `Invalid TOML value in \`allowedvalues\`: ${token}.` });
+                    continue;
+                }
+                if (expectedKind && expectedKind !== "any") {
+                    const sameKind = details.kind === expectedKind
+                        || (["integer", "float"].includes(details.kind) && ["integer", "float"].includes(expectedKind));
+                    if (!sameKind) {
+                        issues.push({ level: "error", path: label, message: `\`allowedvalues\` entry ${token} does not match ${expectedKind}.` });
+                        continue;
+                    }
+                }
+                if (compiledPattern && details.kind === "string" && !compiledPattern.test(details.value)) {
+                    issues.push({ level: "error", path: label, message: `\`allowedvalues\` entry ${token} does not satisfy \`pattern\`.` });
+                }
+                if (p.type === "string" && details.kind === "string") {
+                    const length = [...details.value].length;
+                    if (p.minlength != null && length < p.minlength) {
+                        issues.push({ level: "error", path: label, message: `\`allowedvalues\` entry ${token} is shorter than \`minlength\`.` });
+                    }
+                    if (p.maxlength != null && length > p.maxlength) {
+                        issues.push({ level: "error", path: label, message: `\`allowedvalues\` entry ${token} is longer than \`maxlength\`.` });
+                    }
+                }
+                for (const key of ["min", "max"]) {
+                    if (boundaries[key] && !valueSatisfiesRange(details, boundaries[key], key)) {
+                        issues.push({ level: "error", path: label, message: `\`allowedvalues\` entry ${token} violates \`${key}\`.` });
+                    }
+                }
             }
         }
 
         for (const child of node.children || []) {
             walk(child, `${label}.${child.name}`);
         }
+        checkSiblingNames(node.children, label);
     };
 
     for (const t of model.types || []) walk(t, `types.${t.name}`);
@@ -396,8 +739,9 @@ export function validateModel(model) {
 
     const visited = new Set();
     const visitSelector = (name, visiting = new Set()) => {
+        if (!name || bareBuiltin(name)) return;
         name = normalizeRef(name);
-        if (!name || BUILTIN_TYPES.includes(name) || visited.has(name) || !typesByName.has(name)) return;
+        if (visited.has(name) || !typesByName.has(name)) return;
         if (visiting.has(name)) {
             issues.push({ level: "error", path: `types.${name}`, message: "Cyclic type selector reference." });
             return;
@@ -412,8 +756,11 @@ export function validateModel(model) {
     };
     for (const name of typeNames) visitSelector(name);
 
-    if (!/^\d+\.\d+\.\d+/.test(model.version || "")) {
+    const semver = parseSemVer(model.version);
+    if (!semver) {
         issues.push({ level: "error", path: "toml-schema.version", message: "version must be a full SemVer string (e.g. 1.0.0)." });
+    } else if (semver.major !== 1 || semver.minor > 0) {
+        issues.push({ level: "error", path: "toml-schema.version", message: `Unsupported TOML Schema version: ${model.version}.` });
     }
 
     return issues;

--- a/.github/extensions/tosd-editor/model.test.mjs
+++ b/.github/extensions/tosd-editor/model.test.mjs
@@ -1,0 +1,306 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { parseDocument, serializeDocument, validateModel } from "./model.mjs";
+import { parseToml } from "./toml.mjs";
+
+const REPO = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const definition = (name, props, children = []) => ({ name, props, children });
+const model = (elements = [], types = [], version = "1.0.0") => ({
+    version,
+    meta: null,
+    types,
+    elements,
+});
+const errors = (value) => validateModel(value).filter((issue) => issue.level === "error");
+
+test("all checked-in schemas parse and semantically round-trip", () => {
+    const files = execFileSync("git", ["ls-files", "*.tosd"], { cwd: REPO, encoding: "utf8" })
+        .trim()
+        .split("\n")
+        .filter(Boolean);
+
+    for (const file of files) {
+        const parsed = parseDocument(readFileSync(resolve(REPO, file), "utf8"));
+        assert.deepEqual(parseDocument(serializeDocument(parsed)), parsed, file);
+        assert.deepEqual(errors(parsed), [], file);
+    }
+});
+
+test("property-name child definitions coexist with schema properties", () => {
+    const source = `
+[toml-schema]
+version = "1.0.0"
+
+[types.module]
+type = "table"
+
+[types.module.type]
+type = "string"
+
+[elements]
+`;
+    const parsed = parseDocument(source);
+    assert.equal(parsed.types[0].props.type, "table");
+    assert.equal(parsed.types[0].children[0].name, "type");
+    assert.equal(parsed.types[0].children[0].props.type, "string");
+    assert.deepEqual(parseDocument(serializeDocument(parsed)), parsed);
+});
+
+test("large TOML integers round-trip without precision loss", () => {
+    const source = `
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "integer"
+allowedvalues = [ 9223372036854775807, -9223372036854775808 ]
+`;
+    const parsed = parseDocument(source);
+    const serialized = serializeDocument(parsed);
+    assert.match(serialized, /9223372036854775807/);
+    assert.match(serialized, /-9223372036854775808/);
+    assert.deepEqual(parseDocument(serialized), parsed);
+});
+
+test("floating-point spellings and non-finite metadata round-trip", () => {
+    const source = `
+[toml-schema]
+version = "1.0.0"
+
+[toml-schema.meta]
+positive = inf
+negative = -inf
+missing = nan
+
+[elements.value]
+type = "float"
+allowedvalues = [ 1.0, 1e0, inf, nan ]
+`;
+    const parsed = parseDocument(source);
+    const serialized = serializeDocument(parsed);
+    assert.match(serialized, /allowedvalues = \[ 1\.0, 1e0, inf, nan \]/);
+    assert.deepEqual(parseDocument(serialized), parsed);
+    assert.deepEqual(errors(parsed), []);
+});
+
+test("TOML integers outside the signed 64-bit range are rejected", () => {
+    for (const value of ["9223372036854775808", "-9223372036854775809"]) {
+        const source = `
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "integer"
+allowedvalues = [ ${value} ]
+`;
+        assert.throws(() => parseDocument(source), /signed 64-bit/);
+    }
+});
+
+test("schema property TOML types are not coerced", () => {
+    const malformedProperties = [
+        `optional = "false"`,
+        `minlength = "1"`,
+        `description = 123`,
+        `oneof = [ 1, 2 ]`,
+        `allowedvalues = "value"`,
+    ];
+    for (const property of malformedProperties) {
+        const source = `
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "string"
+${property}
+`;
+        assert.throws(() => parseDocument(source), property);
+    }
+});
+
+test("range validation compares exact integers and normalized temporal fields", () => {
+    const tooSmall = model([definition("value", {
+        type: "integer",
+        min: "9223372036854775807",
+        allowedvalues: ["9223372036854775806"],
+    })]);
+    assert.ok(errors(tooSmall).some((issue) => issue.message.includes("violates `min`")));
+
+    const equivalentTime = model([definition("value", {
+        type: "local-time",
+        min: "12:00:00.100",
+        allowedvalues: ["12:00:00.1"],
+    })]);
+    assert.deepEqual(errors(equivalentTime), []);
+
+    const equivalentInstant = model([definition("value", {
+        type: "offset-date-time",
+        min: "2026-08-18T12:00:00-04:00",
+        allowedvalues: ["2026-08-18T16:00:00Z"],
+    })]);
+    assert.deepEqual(errors(equivalentInstant), []);
+});
+
+test("duplicate top-level and nested definition names are rejected", () => {
+    const duplicates = model([
+        definition("same", { type: "string" }),
+        definition("same", { type: "integer" }),
+        definition("parent", { type: "table" }, [
+            definition("child", { type: "string" }),
+            definition("child", { type: "boolean" }),
+        ]),
+    ]);
+    assert.equal(errors(duplicates).filter((issue) => issue.message.includes("Duplicate schema definition")).length, 2);
+});
+
+test("metadata keys with apostrophes serialize as valid TOML", () => {
+    const source = `
+[toml-schema]
+version = "1.0.0"
+
+[toml-schema.meta]
+"it's" = 1
+
+[elements]
+`;
+    const parsed = parseDocument(source);
+    assert.deepEqual(parseDocument(serializeDocument(parsed)), parsed);
+});
+
+test("toml-schema.meta must be a table", () => {
+    const source = `
+[toml-schema]
+version = "1.0.0"
+meta = "not a table"
+
+[elements]
+`;
+    assert.throws(() => parseDocument(source), /meta must be a table/);
+});
+
+test("array item enums do not use array length constraints as string lengths", () => {
+    const valid = model([definition("values", {
+        type: "array",
+        itemtype: "string",
+        minlength: 3,
+        allowedvalues: ['"x"'],
+    })]);
+    assert.deepEqual(errors(valid), []);
+});
+
+test("tuple items are mutually exclusive with allowedvalues", () => {
+    const invalid = model([definition("values", {
+        type: "array",
+        items: ["string", "integer"],
+        allowedvalues: ['"x"', "1"],
+    })]);
+    assert.ok(errors(invalid).some((issue) => issue.message.includes("mutually exclusive with `allowedvalues`")));
+});
+
+test("empty allowedvalues arrays remain valid and round-trip", () => {
+    const source = `
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "string"
+allowedvalues = []
+`;
+    const parsed = parseDocument(source);
+    assert.deepEqual(errors(parsed), []);
+    assert.deepEqual(parseDocument(serializeDocument(parsed)), parsed);
+});
+
+test("duplicate TOML keys and table declarations are rejected", () => {
+    const duplicateKey = `
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "string"
+type = "integer"
+`;
+    const duplicateTable = `
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "string"
+
+[elements.value]
+type = "integer"
+`;
+    assert.throws(() => parseDocument(duplicateKey), /Duplicate key/);
+    assert.throws(() => parseDocument(duplicateTable), /Duplicate table declaration/);
+});
+
+test("TOML keys cannot modify object prototypes", () => {
+    assert.equal({}.polluted, undefined);
+    const parsed = parseToml("__proto__.polluted = true");
+    assert.equal(parsed.__proto__.polluted, true);
+    assert.equal({}.polluted, undefined);
+});
+
+test("invalid calendar, clock, and offset fields are rejected", () => {
+    for (const value of [
+        "2023-99-99",
+        "2023-02-29",
+        "25:61:61",
+        "2026-08-18T25:00:00",
+        "2026-08-18T12:00:00+99:99",
+    ]) {
+        assert.throws(() => parseToml(`value = ${value}`), /Invalid/);
+    }
+    assert.doesNotThrow(() => parseToml("value = 2024-02-29T23:59:59.100+23:59"));
+});
+
+test("document structure violations are rejected while parsing", () => {
+    const malformed = [
+        `[types.X]\ntype = "string"\n`,
+        `[toml-schema]\nversion = "1.0.0"\n[elements]\n[extra]\nx = 1\n`,
+        `[toml-schema]\nversion = "1.0.0"\n[elements.x]\ntype = "table"\ntypo = "value"\n`,
+        `[toml-schema]\nversion = 1\n[elements]\n`,
+        `[toml-schema]\nversion = "1.0.0"\ncustom = "value"\n[elements]\n`,
+    ];
+    for (const source of malformed) assert.throws(() => parseDocument(source));
+});
+
+test("current schema-load rules reject malformed models", () => {
+    const malformed = [
+        model([], [definition("string", { type: "string" })]),
+        model([definition("x", { oneof: ["any", "string"] })]),
+        model([definition("x", { type: "array", itemtype: "collection" })]),
+        model([definition("x", { type: "string", minlength: -1 })]),
+        model([definition("x", { type: "string", minlength: 2, maxlength: 1 })]),
+        model(
+            [definition("x", { type: "types.S", allowedvalues: ['"x"'] })],
+            [definition("S", { type: "string" })],
+        ),
+        model([definition("x", { type: "float", min: "nan" })]),
+        model([definition("x", { type: "integer", min: '"x"' })]),
+        model([definition("x", { type: "string", pattern: "^[a-z]+$", allowedvalues: ['"123"'] })]),
+        model([], [], "1.0.0garbage"),
+        model([], [], "2.0.0"),
+    ];
+    for (const value of malformed) assert.ok(errors(value).length > 0);
+});
+
+test("supported patch, prerelease, and build versions remain valid", () => {
+    for (const version of ["1.0.0", "1.0.9", "1.0.0-rc.1", "1.0.0-1a", "1.0.0+build.7"]) {
+        assert.deepEqual(errors(model([], [], version)), [], version);
+    }
+});
+
+test("portable patterns use Unicode scalar-value semantics", () => {
+    const value = model([definition("emoji", {
+        type: "string",
+        pattern: "^.$",
+        allowedvalues: ['"😀"'],
+    })]);
+    assert.deepEqual(errors(value), []);
+});

--- a/.github/extensions/tosd-editor/styles.css
+++ b/.github/extensions/tosd-editor/styles.css
@@ -325,6 +325,7 @@ button.danger:hover {
     min-width: 0;
     min-height: 0;
     border-right: 1px solid var(--tosd-border);
+    position: relative;
 }
 
 .diagram-bar {
@@ -1269,4 +1270,169 @@ pre.preview::-webkit-scrollbar-thumb,
 pre.preview::-webkit-scrollbar-thumb:hover {
     background: color-mix(in srgb, var(--tosd-muted) 50%, transparent);
     background-clip: padding-box;
+}
+
+/* Undo / redo icon buttons ---------------------------------------------- */
+.btn.icon-btn {
+    padding: 5px 8px;
+}
+
+.btn.icon-btn .bi {
+    font-size: 15px;
+    line-height: 1;
+}
+
+button:disabled {
+    opacity: 0.4;
+    cursor: default;
+    pointer-events: none;
+}
+
+/* Keyboard focus rings --------------------------------------------------- */
+.dg-box:focus-visible,
+.dg-root:focus-visible {
+    outline: 2px solid var(--color-focus-outline, var(--tosd-accent));
+    outline-offset: 2px;
+}
+
+.vtab:focus-visible,
+.legend-glyph:focus-visible {
+    outline: 2px solid var(--color-focus-outline, var(--tosd-accent));
+    outline-offset: 1px;
+}
+
+.diagram-scroll:focus-visible {
+    outline: 2px solid var(--color-focus-outline, var(--tosd-accent));
+    outline-offset: -2px;
+}
+
+/* Unresolved reference state -------------------------------------------- */
+.dg-box.has-error {
+    border-color: color-mix(in srgb, var(--tosd-error) 55%, var(--tosd-border));
+}
+
+.dg-box.has-error::before {
+    background: var(--tosd-error);
+}
+
+.dg-warn {
+    color: var(--tosd-error);
+    font-size: 12px;
+    line-height: 1;
+    margin-left: 2px;
+    flex: 0 0 auto;
+}
+
+.field input.invalid,
+.list-row input.invalid {
+    border-color: var(--tosd-error);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--tosd-error) 14%, transparent);
+}
+
+.field-err {
+    color: var(--tosd-error);
+    font-size: 11px;
+    margin-top: 4px;
+    min-height: 0;
+}
+
+.field-err:empty {
+    margin-top: 0;
+}
+
+.add-row {
+    margin-top: 2px;
+}
+
+/* Legend ----------------------------------------------------------------- */
+.legend-toggle.active,
+#legend-toggle.active {
+    color: var(--tosd-accent);
+    border-color: color-mix(in srgb, var(--tosd-accent) 45%, var(--tosd-border));
+    background: var(--tosd-accent-soft);
+}
+
+.legend {
+    position: absolute;
+    left: 12px;
+    bottom: 12px;
+    z-index: 5;
+    max-width: min(420px, calc(100% - 24px));
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 10px 18px;
+    padding: 14px 16px;
+    background: color-mix(in srgb, var(--tosd-bg) 92%, transparent);
+    backdrop-filter: blur(6px);
+    border: 1px solid var(--tosd-border);
+    border-radius: 10px;
+    box-shadow: 0 8px 28px rgba(31, 35, 40, 0.16);
+}
+
+.legend-title {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-weight: 600;
+    color: var(--tosd-muted);
+    margin-bottom: 6px;
+}
+
+.legend-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 4px;
+    font-size: 11.5px;
+}
+
+.legend-glyph {
+    width: 20px;
+    text-align: center;
+    font-size: 13px;
+    color: var(--tosd-muted);
+    flex: 0 0 auto;
+}
+
+.legend-glyph.choice { color: var(--cat-choice); }
+.legend-glyph.repeat { color: var(--cat-array); }
+.legend-glyph.sequence { color: var(--tosd-muted); }
+.legend-glyph.warn { color: var(--tosd-error); }
+
+.legend-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 3px;
+    flex: 0 0 auto;
+    background: var(--cat, var(--tosd-muted));
+}
+
+.legend-dot[data-cat="string"] { background: var(--cat-string); }
+.legend-dot[data-cat="number"] { background: var(--cat-number); }
+.legend-dot[data-cat="boolean"] { background: var(--cat-boolean); }
+.legend-dot[data-cat="date"] { background: var(--cat-date); }
+.legend-dot[data-cat="table"] { background: var(--cat-table); }
+.legend-dot[data-cat="array"] { background: var(--cat-array); }
+.legend-dot[data-cat="ref"] { background: var(--cat-ref); }
+.legend-dot[data-cat="choice"] { background: var(--cat-choice); }
+
+.legend-label {
+    color: var(--text-color-default);
+}
+
+/* Reduced motion --------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.001ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.001ms !important;
+        scroll-behavior: auto !important;
+    }
+
+    .modal-err.working::before {
+        animation: none !important;
+        border-top-color: color-mix(in srgb, var(--tosd-accent) 30%, transparent);
+    }
 }

--- a/.github/extensions/tosd-editor/toml.mjs
+++ b/.github/extensions/tosd-editor/toml.mjs
@@ -16,6 +16,8 @@
 
 export class TomlError extends Error {}
 
+const TABLE_COLLISIONS = Symbol("table-collisions");
+
 const DATETIME_RE =
     /^(\d{4}-\d{2}-\d{2}([Tt ]\d{2}:\d{2}:\d{2}(\.\d+)?([Zz]|[+-]\d{2}:\d{2})?)?|\d{2}:\d{2}:\d{2}(\.\d+)?)$/;
 
@@ -32,9 +34,10 @@ function classifyDatetime(raw) {
 // Parser
 // ---------------------------------------------------------------------------
 
-export function parseToml(text) {
-    const root = {};
+export function parseToml(text, { allowTableValueCollisions = false } = {}) {
+    const root = Object.create(null);
     let current = root;
+    const declaredTables = new Set();
 
     const lines = splitLogicalLines(text);
     for (const line of lines) {
@@ -49,7 +52,10 @@ export function parseToml(text) {
             } else {
                 const name = trimmed.slice(1, trimmed.lastIndexOf("]")).trim();
                 const path = parseKeyPath(name);
-                current = enterTable(root, path);
+                const tableId = JSON.stringify(path);
+                if (declaredTables.has(tableId)) throw new TomlError(`Duplicate table declaration: ${name}`);
+                declaredTables.add(tableId);
+                current = enterTable(root, path, allowTableValueCollisions);
             }
             continue;
         }
@@ -217,11 +223,26 @@ export function parseKeyPath(text) {
     return parts;
 }
 
-function enterTable(root, path) {
+function enterTable(root, path, allowTableValueCollisions) {
     let node = root;
     for (const key of path) {
-        if (node[key] === undefined) node[key] = {};
-        node = node[key];
+        if (node[key] === undefined) {
+            node[key] = Object.create(null);
+            node = node[key];
+            continue;
+        }
+        if (isPlainTable(node[key])) {
+            node = node[key];
+            continue;
+        }
+        if (!allowTableValueCollisions) {
+            throw new TomlError(`Cannot redefine value as table: ${key}`);
+        }
+        if (!node[TABLE_COLLISIONS]) {
+            Object.defineProperty(node, TABLE_COLLISIONS, { value: Object.create(null), enumerable: false });
+        }
+        if (!node[TABLE_COLLISIONS][key]) node[TABLE_COLLISIONS][key] = Object.create(null);
+        node = node[TABLE_COLLISIONS][key];
     }
     return node;
 }
@@ -230,12 +251,12 @@ function enterArrayTable(root, path) {
     let node = root;
     for (let i = 0; i < path.length - 1; i++) {
         const key = path[i];
-        if (node[key] === undefined) node[key] = {};
+        if (node[key] === undefined) node[key] = Object.create(null);
         node = node[key];
     }
     const last = path[path.length - 1];
     if (!Array.isArray(node[last])) node[last] = [];
-    const entry = {};
+    const entry = Object.create(null);
     node[last].push(entry);
     return entry;
 }
@@ -244,10 +265,13 @@ function assignKey(table, path, value) {
     let node = table;
     for (let i = 0; i < path.length - 1; i++) {
         const key = path[i];
-        if (node[key] === undefined) node[key] = {};
+        if (node[key] === undefined) node[key] = Object.create(null);
+        if (!isPlainTable(node[key])) throw new TomlError(`Cannot redefine value as dotted key: ${key}`);
         node = node[key];
     }
-    node[path[path.length - 1]] = value;
+    const key = path[path.length - 1];
+    if (Object.prototype.hasOwnProperty.call(node, key)) throw new TomlError(`Duplicate key: ${key}`);
+    node[key] = value;
 }
 
 export function parseValue(text) {
@@ -265,7 +289,10 @@ export function parseValue(text) {
 
     if (DATETIME_RE.test(s)) {
         const kind = classifyDatetime(s);
-        if (kind) return { __datetime: kind, value: s };
+        if (kind) {
+            if (!validDatetime(s, kind)) throw new TomlError(`Invalid ${kind} value: ${s}`);
+            return { __datetime: kind, value: s };
+        }
     }
 
     const num = parseNumber(s);
@@ -276,16 +303,55 @@ export function parseValue(text) {
 
 function parseNumber(s) {
     if (/^[+-]?(inf|nan)$/.test(s)) {
-        if (s.endsWith("nan")) return NaN;
-        return s[0] === "-" ? -Infinity : Infinity;
+        return { __float: true, value: s };
     }
     const cleaned = s.replace(/_/g, "");
-    if (/^[+-]?0x[0-9a-fA-F]+$/.test(cleaned)) return parseInt(cleaned, 16);
-    if (/^[+-]?0o[0-7]+$/.test(cleaned)) return parseInt(cleaned.replace(/0o/, ""), 8);
-    if (/^[+-]?0b[01]+$/.test(cleaned)) return parseInt(cleaned.replace(/0b/, ""), 2);
-    if (/^[+-]?\d+$/.test(cleaned)) return parseInt(cleaned, 10);
-    if (/^[+-]?(\d+(\.\d+)?([eE][+-]?\d+)?)$/.test(cleaned)) return parseFloat(cleaned);
+    if (/^[+-]?0x[0-9a-fA-F]+$/.test(cleaned)) return parseInteger(cleaned, 16);
+    if (/^[+-]?0o[0-7]+$/.test(cleaned)) return parseInteger(cleaned, 8);
+    if (/^[+-]?0b[01]+$/.test(cleaned)) return parseInteger(cleaned, 2);
+    if (/^[+-]?\d+$/.test(cleaned)) return parseInteger(cleaned, 10);
+    if (/^[+-]?(\d+(\.\d+)?([eE][+-]?\d+)?)$/.test(cleaned)) return { __float: true, value: s };
     return undefined;
+}
+
+function parseInteger(token, radix) {
+    let value;
+    if (radix === 10) {
+        value = BigInt(token);
+    } else {
+        const sign = token.startsWith("-") ? -1n : 1n;
+        const unsigned = token.replace(/^[+-]/, "");
+        value = sign * BigInt(unsigned);
+    }
+
+    if (value < -(1n << 63n) || value > (1n << 63n) - 1n) {
+        throw new TomlError(`Integer is outside the signed 64-bit TOML range: ${token}`);
+    }
+    const number = Number(value);
+    return Number.isSafeInteger(number) ? number : { __integer: true, value: token };
+}
+
+function validDatetime(raw, kind) {
+    const dateMatch = /^(\d{4})-(\d{2})-(\d{2})/.exec(raw);
+    if (dateMatch) {
+        const year = Number(dateMatch[1]);
+        const month = Number(dateMatch[2]);
+        const day = Number(dateMatch[3]);
+        const leap = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+        const days = [31, leap ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+        if (month < 1 || month > 12 || day < 1 || day > days[month - 1]) return false;
+    }
+    if (kind === "local-date") return true;
+
+    const timeMatch = /(?:^|[Tt ])(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?/.exec(raw);
+    if (!timeMatch) return false;
+    if (Number(timeMatch[1]) > 23 || Number(timeMatch[2]) > 59 || Number(timeMatch[3]) > 59) return false;
+
+    if (kind === "offset-date-time") {
+        const offset = /([+-])(\d{2}):(\d{2})$/.exec(raw);
+        if (offset && (Number(offset[2]) > 23 || Number(offset[3]) > 59)) return false;
+    }
+    return true;
 }
 
 function parseBasicString(s) {
@@ -375,7 +441,7 @@ function parseArray(s) {
 function parseInlineTable(s) {
     const inner = s.slice(1, s.lastIndexOf("}"));
     const tokens = splitTopLevel(inner);
-    const obj = {};
+    const obj = Object.create(null);
     for (const tok of tokens) {
         const t = tok.trim();
         if (t === "") continue;
@@ -444,6 +510,8 @@ export function formatValue(value) {
     if (typeof value === "number") return formatNumber(value);
     if (typeof value === "string") return formatString(value);
     if (Array.isArray(value)) return "[ " + value.map(formatValue).join(", ") + " ]";
+    if (value.__integer) return value.value;
+    if (value.__float) return value.value;
     if (value.__datetime) return value.value;
     if (value.__inline) return formatInline(value.value);
     if (typeof value === "object") return formatInline(value);
@@ -490,7 +558,13 @@ export function isPlainTable(value) {
         value !== null &&
         typeof value === "object" &&
         !Array.isArray(value) &&
+        !value.__integer &&
+        !value.__float &&
         !value.__datetime &&
         !value.__inline
     );
+}
+
+export function tableCollisions(value) {
+    return value?.[TABLE_COLLISIONS] || {};
 }


### PR DESCRIPTION
The visual editor had fallen behind the current TOML Schema language and could silently accept, rewrite, or lose valid schema constructs. This updates it into a safer, specification-aligned authoring surface while improving keyboard and assistive-technology support.

## What changed

- Align parsing and validation with the current schema vocabulary, document structure, reference restrictions, container semantics, constraints, SemVer rules, and portable regex behavior.
- Preserve exact signed 64-bit integers, floating-point spellings, temporal values, typed/nested metadata, empty enumerations, and schema child names that collide with property keywords.
- Reject malformed TOML, duplicate definitions, invalid property types, unsafe prototype keys, unsupported versions, and invalid numeric or temporal boundaries.
- Add editable descriptions, inline reference feedback, a diagram legend, accessible tree navigation, modal focus handling, reduced-motion behavior, delete confirmation, and undo/redo.
- Prevent invalid schemas from being written to disk and prevent dismissed asynchronous modal requests from overwriting newer edits.
- Add conformance tests covering every checked-in `.tosd` file plus parser, serializer, validation, numeric, temporal, metadata, and security edge cases.

## Validation

- `node --test .github/extensions/tosd-editor/model.test.mjs`
- JavaScript syntax checks for all extension modules
- UI regression checks for keyboard navigation, modal lifecycle, history, metadata preservation, and empty enumerations