### PR TITLE
Unify navigation across site pages

### DIFF
--- a/docs/validation-report/index.html
+++ b/docs/validation-report/index.html
@@ -29,9 +29,11 @@
         <span class="visually-hidden">TOML Schema</span>
       </a>
       <nav aria-label="Primary navigation">
-        <a href="/">Home</a>
+        <a href="/#why">Why</a>
         <a href="/validation-report/" aria-current="page">Evidence</a>
+        <a href="/#tour">Tour</a>
         <a href="/spec/">Spec</a>
+        <a href="/implementations/">Implementations</a>
         <a href="https://github.com/brunoborges/toml-schema">GitHub</a>
       </nav>
     </header>


### PR DESCRIPTION
The validation report used a reduced navigation menu that differed from the front page and generated documentation pages.

Align its primary navigation with the rest of the site by linking to Why, Evidence, Tour, Spec, Implementations, and GitHub while preserving the active Evidence state.