### PR TITLE
Remove unreachable types from industry examples

### DIFF
--- a/examples/cargo.tosd
+++ b/examples/cargo.tosd
@@ -19,9 +19,6 @@ oneof = [ "string", "types.workspaceInherited" ]
 [types.stringArrayOrWorkspace]
 oneof = [ "types.stringArray", "types.workspaceInherited" ]
 
-[types.booleanOrWorkspace]
-oneof = [ "boolean", "types.workspaceInherited" ]
-
 [types.stringOrBoolean]
 oneof = [ "string", "boolean" ]
 

--- a/examples/gitlab-runner.tosd
+++ b/examples/gitlab-runner.tosd
@@ -10,16 +10,9 @@ oneof = [ "integer", "float" ]
 type = "string"
 pattern = '^(?:[0-9]+(?:\.[0-9]+)?(?:ns|us|ms|s|m|h))+$'
 
-[types.durationOrInteger]
-oneof = [ "types.durationValue", "integer" ]
-
 [types.stringArray]
 type = "array"
 itemtype = "string"
-
-[types.integerArray]
-type = "array"
-itemtype = "integer"
 
 [types.stringMap]
 type = "collection"

--- a/examples/hugo.tosd
+++ b/examples/hugo.tosd
@@ -17,10 +17,6 @@ oneof = [ "string", "types.stringArray" ]
 type = "collection"
 itemtype = "any"
 
-[types.stringMap]
-type = "collection"
-itemtype = "string"
-
 [types.buildStats]
 type = "table"
 

--- a/examples/wrangler.tosd
+++ b/examples/wrangler.tosd
@@ -351,14 +351,6 @@ type = "table"
     [types.idBinding.id]
     type = "string"
 
-[types.nameBinding]
-
-    [types.nameBinding.binding]
-    type = "string"
-
-    [types.nameBinding.name]
-    type = "string"
-
 [types.namespaceBinding]
 
     [types.namespaceBinding.binding]
@@ -741,17 +733,9 @@ type = "table"
 type = "array"
 itemtype = "types.container"
 
-[types.arrayOfSimpleBindings]
-type = "array"
-itemtype = "types.simpleBinding"
-
 [types.arrayOfIdBindings]
 type = "array"
 itemtype = "types.idBinding"
-
-[types.arrayOfNameBindings]
-type = "array"
-itemtype = "types.nameBinding"
 
 [types.arrayOfNamespaceBindings]
 type = "array"


### PR DESCRIPTION
Several industry example schemas contained reusable type definitions that were not reachable from `[elements]`, either directly or through another reusable type. These dead definitions made the examples harder to review and suggested schema coverage that did not actually exist.

Remove seven unreachable types from the Cargo, GitLab Runner, Hugo, and Wrangler examples. Netlify and PyProject required no changes. After the cleanup, every reusable type in all six industry examples is reachable and all references resolve to defined types.