### PR TITLE
Clarify TOML Schema validation semantics

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -213,7 +213,7 @@ version = "1.0.0"
 
 Schema loaders MUST reject schema documents whose `version` is missing, is not a string, or is not a valid SemVer value. Shorthand values such as `"1"` and `"1.0"` are invalid.
 
-An implementation that supports TOML Schema version `MAJOR.MINOR.PATCH` MUST accept schema documents with the same major version and a minor version less than or equal to the implementation's supported minor version. Patch versions, pre-release identifiers, and build metadata do not add schema-language features and do not affect compatibility. Schema loaders MUST reject schema documents with an unsupported major version or a greater minor version.
+An implementation that supports TOML Schema version `MAJOR.MINOR.PATCH` MUST accept schema documents with the same major version and a minor version less than or equal to the implementation's supported minor version. Patch versions, pre-release identifiers, and build metadata do not add schema-language features and do not affect compatibility. Schema loaders MUST reject schema documents with an unsupported major version or a greater minor version. Support for schema documents from an earlier major version is implementation-defined; an implementation MUST NOT treat support for a later major version as implicit support for an earlier one.
 
 ## Elements table - `[elements]`
 
@@ -356,7 +356,7 @@ detailed sections below remain authoritative.
 | `allof` | Conjunctively applies one or more compatible type references in addition to the local definition |
 | `description`, `optional`, `default`, `deprecated` | Any definition, including a named reference or alternative selector |
 | `itemtype` | A definition with built-in `type = "array"` or `type = "collection"` |
-| `items` | A definition with built-in `type = "array"`; mutually exclusive with `itemtype`, `allowedvalues`, `minlength`, and `maxlength` |
+| `items` | A definition with built-in `type = "array"`; mutually exclusive with `itemtype`, `allowedvalues`, `min`, `max`, `minlength`, and `maxlength` |
 | `allowedvalues` | A simple built-in type, or the items of a non-tuple `array` |
 | `pattern` | A definition with built-in `type = "string"` |
 | `keypattern` | A definition with built-in `type = "collection"` |
@@ -438,6 +438,13 @@ List of considered simple types:
 under [Observations on Conditions to Arrays](#observations-on-conditions-to-arrays).
 It is invalid on a `table` or `collection`.
 
+The `allowedvalues` array MUST contain at least one entry. Every entry on a
+non-array definition MUST have the TOML kind selected by that definition;
+`type = "any"` is the exception and permits entries of any TOML kind. Numeric
+equality between integers and floats does not make their TOML kinds
+interchangeable for this schema-load check. A malformed enumeration MUST be
+rejected at schema-load time.
+
 For a non-array simple type, when `allowedvalues` is combined with `pattern`, `min`, `max`, `minlength`, or `maxlength`, every entry in `allowedvalues` MUST satisfy every applicable constraint. A schema containing an entry that violates one of those constraints is malformed, and schema loaders MUST reject it at schema-load time.
 
 After a schema with `allowedvalues` has been loaded successfully, a document
@@ -498,7 +505,9 @@ an `array`, or a `collection`.
 
 For `string` values, length is counted as the number of Unicode scalar values after TOML parsing and escape processing. It is not the number of UTF-8 bytes, UTF-16 code units, or user-perceived grapheme clusters. For example, `"\U0001F600"` has length 1, while `"e\u0301"` has length 2 because it is composed of two Unicode scalar values.
 
-For `array` and `collection` values, length is counted as the number of items or dynamic entries.
+For an `array`, length is its number of items. For a `collection`, length is
+the number of dynamic entries to which `itemtype` applies; fixed child
+definitions are excluded from the count.
 
 Both `minlength` and `maxlength` MUST be integers `>= 0`. When both are present, `minlength` MUST be less than or equal to `maxlength`. A schema violating either rule is malformed and schema loaders MUST reject it at schema-load time.
 
@@ -588,6 +597,13 @@ When `allowedvalues` is present on an array, every array item MUST be a member
 of that enumeration. The enumeration does not have to be sorted. If `min` or
 `max` is also present, every enumerated value MUST satisfy the applicable
 inclusive boundary; an enumerated value need not equal either boundary.
+
+When the array declares `itemtype`, every enumerated value MUST have a TOML
+kind permitted by the effective item type. Named references, aliases, and
+`oneof` or `anyof` alternatives are resolved before this check. An `itemtype`
+that permits `any` permits enumeration entries of any TOML kind. This
+schema-load check verifies the permitted TOML kind; constraints inside a named
+item definition still apply normally when a document array is validated.
 
 `minlength` and `maxlength` constrain the document array's item count, not the
 number of entries in `allowedvalues`. The schema loader MUST reject an
@@ -682,6 +698,7 @@ Semantics:
  - `items` is ordered, and each index validates against the corresponding referenced type.
  - When `items` is present, the array MUST have exactly the same number of items.
  - `items` is mutually exclusive with `itemtype`.
+ - `items` is also mutually exclusive with `min` and `max`.
  - `items` is also mutually exclusive with `minlength` and `maxlength`.
  - `items` is mutually exclusive with `allowedvalues`; constraints for a tuple
    position belong in the reusable definition referenced at that position.
@@ -707,9 +724,11 @@ differ elsewhere remain distinct. A schema loader MUST reject a non-boolean
 
 One can set an element of type `collection` when there is a need to have multiple children with dynamic, user-provided keys or table headers.
 
-A `collection` is also a `table` and, therefore, it may have fixed child
-definitions in addition to dynamically named entries. Fixed children may use
-any schema definition, including nested tables, arrays, and named types.
+A `collection` is represented by a TOML table and may have fixed child
+definitions in addition to dynamically named entries. It remains a distinct
+schema type from `table` because it applies `itemtype` and collection
+unknown-key semantics to dynamic entries. Fixed children may use any schema
+definition, including nested tables, arrays, and named types.
 
 A `collection` requires at least one effective `itemtype` constraint to define
 the type of its dynamic child values. The constraint may be declared locally or
@@ -1211,6 +1230,12 @@ The pattern is not implicitly anchored. A value validates if the regular
 expression matches anywhere in the string. Authors who require a full-string
 match MUST anchor the expression with `^` and `$`.
 
+Patterns are evaluated without multiline or dot-all modes. `^` matches only
+the start of the complete parsed string, `$` matches only its end (not a
+position before a final line feed), and `.` does not match a line feed. These
+rules also apply when an implementation uses a regular-expression engine with
+different defaults.
+
 ### Key Pattern - `keypattern`
 
 This property may only be used on a `collection`. It constrains the **keys** (entry names) of the
@@ -1407,7 +1432,10 @@ valid pre-release and build suffixes are optional, as defined by
 
 After resolving and loading the schema, a validator MUST compare these two language versions when the referencing document provides `version`. A different major version is incompatible and schema discovery MUST fail. Any other unequal version, including a minor, patch, pre-release, or build metadata difference, MUST produce a warning but MUST NOT by itself cause validation to fail. Compatibility between the resolved schema and the validator remains governed by [Schema Versioning](#schema-versioning).
 
-The root `[toml-schema]` table is reserved for schema-reference metadata.
+In a target TOML document, the root `[toml-schema]` table is reserved for
+schema-reference metadata. This is a different context from the metadata table
+inside a schema document, which may contain `[toml-schema.meta]` as described
+under [Metadata Table - `[toml-schema]`](#metadata-table---toml-schema).
 `location` and `version` are the only keys interpreted by this specification.
 Implementations MAY permit additional extension keys, but every direct value in
 this table MUST be a TOML scalar: string, integer, float, boolean, offset

--- a/reference-implementations/go/schema.go
+++ b/reference-implementations/go/schema.go
@@ -203,6 +203,9 @@ func LoadSchema(path string) (*Schema, error) {
 	if err := schema.validateSelectorCycles(); err != nil {
 		return nil, err
 	}
+	if err := schema.validateAllowedValueTypes(); err != nil {
+		return nil, err
+	}
 	if err := schema.validateSemantics(); err != nil {
 		return nil, err
 	}
@@ -807,6 +810,9 @@ func parseDefinition(name string, path []string, table map[string]any, source *s
 		return Definition{}, err
 	}
 	hasAllowedValues := propertyValue(table, "allowedvalues") != nil
+	if hasAllowedValues && len(allowedValues) == 0 {
+		return Definition{}, fmt.Errorf("%s allowedvalues must contain at least one entry", name)
+	}
 	hasOneOf := propertyValue(table, "oneof") != nil
 	hasAnyOf := propertyValue(table, "anyof") != nil
 	oneOf, err := getStringArrayValues(table, "oneof")
@@ -920,6 +926,9 @@ func parseDefinition(name string, path []string, table map[string]any, source *s
 		}
 		if hasAllowedValues {
 			return Definition{}, fmt.Errorf("%s cannot define allowedvalues together with items", name)
+		}
+		if propertyValue(table, "min") != nil || propertyValue(table, "max") != nil {
+			return Definition{}, fmt.Errorf("%s cannot define min or max together with items", name)
 		}
 	}
 	min := propertyValue(table, "min")
@@ -1149,6 +1158,96 @@ func (s *Schema) validateArrayRanges() error {
 			if err := validateDefinition(definition); err != nil {
 				return err
 			}
+		}
+	}
+	return nil
+}
+
+func (s *Schema) validateAllowedValueTypes() error {
+	var validateDefinition func(Definition) error
+	validateDefinition = func(definition Definition) error {
+		permittedTypes := map[SchemaType]bool{}
+		if len(definition.allowedValues) > 0 {
+			if definition.typeName == TypeArray {
+				if definition.itemReference != "" {
+					if err := s.collectReferenceTypes(
+						definition.itemReference,
+						map[string]bool{},
+						permittedTypes,
+					); err != nil {
+						return err
+					}
+				}
+			} else if definition.typeName != "" {
+				permittedTypes[definition.typeName] = true
+			}
+			for index, value := range definition.allowedValues {
+				matches := len(permittedTypes) == 0
+				for typeName := range permittedTypes {
+					if isType(value, typeName) {
+						matches = true
+						break
+					}
+				}
+				if !matches {
+					return fmt.Errorf(
+						"%s allowedvalues[%d] does not match the permitted TOML type",
+						definition.name,
+						index,
+					)
+				}
+			}
+		}
+		for _, child := range definition.children {
+			if err := validateDefinition(child); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for _, definitions := range []map[string]Definition{s.types, s.elements} {
+		for _, definition := range definitions {
+			if err := validateDefinition(definition); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (s *Schema) collectReferenceTypes(
+	reference string,
+	seen map[string]bool,
+	types map[SchemaType]bool,
+) error {
+	normalized := normalizeReference(reference)
+	if builtInType, ok := parseSchemaType(normalized); ok {
+		types[builtInType] = true
+		return nil
+	}
+	if seen[normalized] {
+		return fmt.Errorf("cyclic type reference: %s", normalized)
+	}
+	definition, ok := s.types[normalized]
+	if !ok {
+		return fmt.Errorf("unknown type reference: %s", reference)
+	}
+	seen[normalized] = true
+	defer delete(seen, normalized)
+	if definition.reference != "" {
+		return s.collectReferenceTypes(definition.reference, seen, types)
+	}
+	alternatives := definition.oneOf
+	if len(alternatives) == 0 {
+		alternatives = definition.anyOf
+	}
+	if len(alternatives) == 0 {
+		types[definition.typeName] = true
+		return nil
+	}
+	for _, alternative := range alternatives {
+		if err := s.collectReferenceTypes(alternative, seen, types); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/reference-implementations/go/schema_test.go
+++ b/reference-implementations/go/schema_test.go
@@ -422,6 +422,19 @@ type = "string"
 allowedvalues = [ "ok", "long" ]
 maxlength = 2
 `,
+		`
+type = "string"
+allowedvalues = []
+`,
+		`
+type = "string"
+allowedvalues = [ 1 ]
+`,
+		`
+type = "array"
+itemtype = "integer"
+allowedvalues = [ "one" ]
+`,
 	}
 
 	for index, definition := range malformedDefinitions {
@@ -744,18 +757,12 @@ version = "1.0.0"
 [elements.colors]
 type = "array"
 allowedvalues = [ "red", "blue" ]
-
-[elements.unrestricted]
-type = "array"
-allowedvalues = []
 `)
 	validPath := write(t, dir, "valid-array-allowedvalues.toml", `
 colors = [ "red", "blue" ]
-unrestricted = [ 1, 2 ]
 `)
 	invalidPath := write(t, dir, "invalid-array-allowedvalues.toml", `
 colors = [ "red", "green" ]
-unrestricted = [ 1, 2 ]
 `)
 
 	schema, err := LoadSchema(schemaPath)
@@ -1374,7 +1381,16 @@ version = "1.0.0"
 [elements.value]
 type = "array"
 items = [ "string", "integer" ]
-allowedvalues = []
+allowedvalues = [ 1 ]
+`,
+		`
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "array"
+items = [ "string", "integer" ]
+min = 1
 `,
 	}
 	for index, schemaContent := range conflicts {
@@ -1388,8 +1404,8 @@ allowedvalues = []
 func TestRejectsAllowedValuesOnTableAndCollection(t *testing.T) {
 	dir := t.TempDir()
 	definitions := []string{
-		"type = \"table\"\nallowedvalues = []",
-		"type = \"collection\"\nitemtype = \"string\"\nallowedvalues = []",
+		"type = \"table\"\nallowedvalues = [ 1 ]",
+		"type = \"collection\"\nitemtype = \"string\"\nallowedvalues = [ 1 ]",
 	}
 	for index, definition := range definitions {
 		schema := fmt.Sprintf(`

--- a/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
@@ -54,6 +54,8 @@ final class SchemaLoader {
         validateReferences(types, types);
         validateReferences(types, elements);
         validateSelectorCycles(types);
+        validateAllowedValueTypes(types, types);
+        validateAllowedValueTypes(types, elements);
         validateArrayRangeConstraints(types, types);
         validateArrayRangeConstraints(types, elements);
         validateDefinitionSemantics(types, types);
@@ -140,6 +142,9 @@ final class SchemaLoader {
         Integer maxLength = getInteger(table, "maxlength");
         boolean hasAllowedValues = getPropertyValue(table, "allowedvalues") != null;
         List<Object> allowedValues = getArrayValues(table, "allowedvalues");
+        if (hasAllowedValues && allowedValues.isEmpty()) {
+            throw new SchemaException(name + " allowedvalues must contain at least one entry");
+        }
         boolean hasOneOf = getPropertyValue(table, "oneof") != null;
         boolean hasAnyOf = getPropertyValue(table, "anyof") != null;
         List<String> oneOf = getStringArrayValues(table, "oneof");
@@ -226,6 +231,9 @@ final class SchemaLoader {
             }
             if (hasAllowedValues) {
                 throw new SchemaException(name + " cannot define allowedvalues together with items");
+            }
+            if (getPropertyValue(table, "min") != null || getPropertyValue(table, "max") != null) {
+                throw new SchemaException(name + " cannot define min or max together with items");
             }
         }
         if (minLength != null && maxLength != null && minLength > maxLength) {
@@ -601,6 +609,47 @@ final class SchemaLoader {
             }
             validateArrayRangeConstraints(types, definition.children());
         }
+    }
+
+    private void validateAllowedValueTypes(
+            Map<String, SchemaDefinition> types,
+            Map<String, SchemaDefinition> definitions
+    ) {
+        for (SchemaDefinition definition : definitions.values()) {
+            Set<SchemaType> permittedTypes = Set.of();
+            if (!definition.allowedValues().isEmpty()) {
+                if (definition.type() == SchemaType.ARRAY && definition.itemReference() != null) {
+                    permittedTypes = resolveItemTypes(definition.itemReference(), types, new HashSet<>());
+                } else if (definition.type() != SchemaType.ARRAY) {
+                    permittedTypes = Set.of(definition.type());
+                }
+                for (int index = 0; index < definition.allowedValues().size(); index++) {
+                    Object value = definition.allowedValues().get(index);
+                    if (!permittedTypes.isEmpty()
+                            && permittedTypes.stream().noneMatch(type -> valueMatchesType(value, type))) {
+                        throw new SchemaException(definition.name() + " allowedvalues[" + index
+                                + "] does not match the permitted TOML type");
+                    }
+                }
+            }
+            validateAllowedValueTypes(types, definition.children());
+        }
+    }
+
+    private boolean valueMatchesType(Object value, SchemaType type) {
+        return switch (type) {
+            case ANY -> true;
+            case STRING -> value instanceof String;
+            case INTEGER -> value instanceof Long;
+            case FLOAT -> value instanceof Double;
+            case BOOLEAN -> value instanceof Boolean;
+            case OFFSET_DATE_TIME -> value instanceof OffsetDateTime;
+            case LOCAL_DATE_TIME -> value instanceof LocalDateTime;
+            case LOCAL_DATE -> value instanceof LocalDate;
+            case LOCAL_TIME -> value instanceof LocalTime;
+            case ARRAY -> value instanceof TomlArray;
+            case TABLE, COLLECTION -> value instanceof TomlTable;
+        };
     }
 
     private Set<SchemaType> resolveItemTypes(

--- a/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
+++ b/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
@@ -981,19 +981,29 @@ class TomlSchemaTest {
                 [elements.value]
                 type = "array"
                 items = [ "string", "integer" ]
-                allowedvalues = []
+                allowedvalues = [ 1 ]
+                """);
+        Path withRange = write("tuple-range-conflict.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.value]
+                type = "array"
+                items = [ "string", "integer" ]
+                min = 1
                 """);
 
         assertThrows(SchemaException.class, () -> TomlSchema.load(withItemtype));
         assertThrows(SchemaException.class, () -> TomlSchema.load(withLength));
         assertThrows(SchemaException.class, () -> TomlSchema.load(withAllowedValues));
+        assertThrows(SchemaException.class, () -> TomlSchema.load(withRange));
     }
 
     @Test
     void rejectsAllowedValuesOnTableAndCollection() throws IOException {
         for (String definition : List.of(
-                "type = \"table\"\nallowedvalues = []",
-                "type = \"collection\"\nitemtype = \"string\"\nallowedvalues = []"
+                "type = \"table\"\nallowedvalues = [ 1 ]",
+                "type = \"collection\"\nitemtype = \"string\"\nallowedvalues = [ 1 ]"
         )) {
             Path schema = write("container-allowedvalues.tosd", """
                    [toml-schema]
@@ -1560,6 +1570,19 @@ class TomlSchemaTest {
                 type = "string"
                 allowedvalues = [ "ok", "long" ]
                 maxlength = 2
+                """,
+                """
+                type = "string"
+                allowedvalues = []
+                """,
+                """
+                type = "string"
+                allowedvalues = [ 1 ]
+                """,
+                """
+                type = "array"
+                itemtype = "integer"
+                allowedvalues = [ "one" ]
                 """
         );
 

--- a/reference-implementations/rust/src/schema.rs
+++ b/reference-implementations/rust/src/schema.rs
@@ -377,6 +377,7 @@ impl Schema {
         schema.validate_references(&schema.types)?;
         schema.validate_references(&schema.elements)?;
         schema.validate_selector_cycles()?;
+        schema.validate_allowed_value_types()?;
         schema.validate_definition_semantics()?;
         schema.validate_array_range_definitions()?;
         schema.validate_defaults()?;
@@ -434,6 +435,46 @@ impl Schema {
     fn validate_array_range_definitions(&self) -> Result<(), String> {
         for definition in self.types.values().chain(self.elements.values()) {
             self.validate_array_range_definition(definition)?;
+        }
+        Ok(())
+    }
+
+    fn validate_allowed_value_types(&self) -> Result<(), String> {
+        for definition in self.types.values().chain(self.elements.values()) {
+            self.validate_allowed_value_definition(definition)?;
+        }
+        Ok(())
+    }
+
+    fn validate_allowed_value_definition(&self, definition: &Definition) -> Result<(), String> {
+        let mut permitted_types = HashSet::new();
+        if !definition.allowed_values.is_empty() {
+            if definition.type_name == Some(SchemaType::Array) {
+                if let Some(reference) = definition.item_reference.as_deref() {
+                    self.collect_reference_types(
+                        reference,
+                        &mut HashSet::new(),
+                        &mut permitted_types,
+                    )?;
+                }
+            } else if let Some(type_name) = definition.type_name {
+                permitted_types.insert(type_name);
+            }
+            for (index, value) in definition.allowed_values.iter().enumerate() {
+                if !permitted_types.is_empty()
+                    && !permitted_types
+                        .iter()
+                        .any(|type_name| value_matches_type(value, *type_name))
+                {
+                    return Err(format!(
+                        "{} allowedvalues[{index}] does not match the permitted TOML type",
+                        definition.name
+                    ));
+                }
+            }
+        }
+        for child in definition.children.values() {
+            self.validate_allowed_value_definition(child)?;
         }
         Ok(())
     }
@@ -1146,6 +1187,11 @@ fn parse_definition(
     let max_length = get_unsigned_integer(name, table, "maxlength")?;
     let has_allowed_values = property_value(table, "allowedvalues").is_some();
     let allowed_values = get_array_values(name, table, "allowedvalues")?;
+    if has_allowed_values && allowed_values.is_empty() {
+        return Err(format!(
+            "{name} allowedvalues must contain at least one entry"
+        ));
+    }
     let has_one_of = property_value(table, "oneof").is_some();
     let has_any_of = property_value(table, "anyof").is_some();
     let one_of = get_string_array_values(name, table, "oneof")?;

--- a/reference-implementations/rust/tests/integration.rs
+++ b/reference-implementations/rust/tests/integration.rs
@@ -449,6 +449,19 @@ type = "string"
 allowedvalues = [ "ok", "long" ]
 maxlength = 2
 "#,
+        r#"
+type = "string"
+allowedvalues = []
+"#,
+        r#"
+type = "string"
+allowedvalues = [ 1 ]
+"#,
+        r#"
+type = "array"
+itemtype = "integer"
+allowedvalues = [ "one" ]
+"#,
     ];
 
     for (index, definition) in malformed_definitions.iter().enumerate() {
@@ -507,10 +520,6 @@ version = "1.0.0"
 [elements.values]
 type = "array"
 allowedvalues = [ 1, 2 ]
-
-[elements.unrestricted]
-type = "array"
-allowedvalues = []
 "#,
     );
     let valid_document = write_file(
@@ -518,7 +527,6 @@ allowedvalues = []
         "valid.toml",
         r#"
 values = [ 1, 2 ]
-unrestricted = [ 1, "two", true ]
 "#,
     );
     let invalid_document = write_file(
@@ -526,7 +534,6 @@ unrestricted = [ 1, "two", true ]
         "invalid.toml",
         r#"
 values = [ 1, 3 ]
-unrestricted = [ 1, "two", true ]
 "#,
     );
 
@@ -1752,7 +1759,16 @@ version = "1.0.0"
 [elements.value]
 type = "array"
 items = [ "string", "integer" ]
-allowedvalues = []
+allowedvalues = [ 1 ]
+"#,
+        r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "array"
+items = [ "string", "integer" ]
+min = 1
 "#,
     ];
     for (index, content) in conflicts.iter().enumerate() {
@@ -1766,8 +1782,8 @@ allowedvalues = []
 fn rejects_allowed_values_on_table_and_collection() {
     let directory = tempfile_dir("container-allowedvalues");
     let definitions = [
-        "type = \"table\"\nallowedvalues = []",
-        "type = \"collection\"\nitemtype = \"string\"\nallowedvalues = []",
+        "type = \"table\"\nallowedvalues = [ 1 ]",
+        "type = \"collection\"\nitemtype = \"string\"\nallowedvalues = [ 1 ]",
     ];
     for (index, definition) in definitions.iter().enumerate() {
         let schema_path = write_file(


### PR DESCRIPTION
TOML Schema leaves several edge cases open to incompatible interpretation, particularly around regular expressions, collection length, tuple constraints, and enumerated values. This change makes those rules explicit and keeps the Java, Go, and Rust reference implementations aligned.

## Summary

- Define whole-string anchor and dot behavior for the portable RE2 profile.
- Count only dynamic entries for collection length constraints and clarify how collections differ from tables.
- Make tuple `items` incompatible with `min` and `max`.
- Require non-empty, type-compatible `allowedvalues`, including arrays whose `itemtype` resolves through named references or alternatives.
- Clarify earlier-major-version support and distinguish schema metadata from target-document schema references.
- Add matching schema-loader enforcement and conformance coverage across all three reference implementations.

## Validation

- Java Maven test suite
- Go test suite
- Rust test suite