### PR TITLE
Remove dead terminology from TOML Schema specification

### DIFF
--- a/.github/extensions/tosd-editor/client.js
+++ b/.github/extensions/tosd-editor/client.js
@@ -883,7 +883,7 @@ function renderEditor() {
         box.append(listField("anyof", "anyof (at least one)", p.anyof || [], (arr) => setListProp(p, "anyof", arr), true));
     }
 
-    // string pattern + allowedvalues for simple types
+    // String pattern and allowed values for scalar types.
     if (t === "string") {
         box.append(textField("pattern", "Pattern (regex)", p.pattern || "", (v) => setProp(p, "pattern", v), true,
             "Portable RE2-profile regular expression."));

--- a/.github/extensions/tosd-editor/model.mjs
+++ b/.github/extensions/tosd-editor/model.mjs
@@ -143,9 +143,6 @@ function tableToNode(name, table, path) {
             node.children.push(tableToNode(key, value, `${path}.${key}`));
         } else if (ALL_PROPS.has(key)) {
             node.props[key] = decodeProp(key, value, path);
-        } else if (key === "arraytype") {
-            // Preserve removed syntax long enough for validation to report it.
-            node.props[key] = String(value);
         } else {
             throw new TomlError(`Unsupported schema property at ${path}: ${key}`);
         }
@@ -1345,10 +1342,6 @@ export function validateModel(model) {
         const fixedChildren = fixedChildrenForNode(node);
         let compiledPattern = null;
 
-        if (p.arraytype != null) {
-            issues.push({ level: "error", path: label, message: "`arraytype` is not supported; use `itemtype`." });
-        }
-
         const exclusivity = ["type", "oneof", "anyof"].filter((key) => Object.prototype.hasOwnProperty.call(p, key));
         for (const key of ["type", "itemtype"]) {
             if (Object.prototype.hasOwnProperty.call(p, key) && !String(p[key]).trim()) {
@@ -1526,7 +1519,7 @@ export function validateModel(model) {
                 issues.push({ level: "error", path: label, message: "`allowedvalues` must be an array of TOML values." });
             }
             if (p.type && !SIMPLE_TYPES.has(p.type) && p.type !== "array") {
-                issues.push({ level: "error", path: label, message: "`allowedvalues` requires a simple type or `array`." });
+                issues.push({ level: "error", path: label, message: "`allowedvalues` requires a scalar, unconstrained, or `array` type." });
             }
             const expectedKind = p.type === "array"
                 ? (resolvedKinds(p.itemtype).size === 1 ? [...resolvedKinds(p.itemtype)][0] : null)

--- a/SPEC.md
+++ b/SPEC.md
@@ -2,7 +2,7 @@
 
 TOML Schema is a set of TOML-based constructs that define the structure, the names, and the types of configuration data on a TOML file.
 
-The TOML Schema is used to validate the input of a TOML file during parsing to:
+TOML Schema validates the parsed input of a TOML file to:
 
 1. Eliminate or reduce misconfiguration that could potentially damage if only validated during production evaluation,
 1. Be leveraged by editors and other tools to provide and enrich auto-completion and code hints for validation on the fly.
@@ -35,12 +35,11 @@ command.
 - [Elements table - `[elements]`](#elements-table---elements)
 - [Types table - `[types]`](#types-table---types)
   - [Quoted and Special Keys](#quoted-and-special-keys)
-  - [Simple Types - `<simple-type>`](#simple-types---simple-type)
-    - [Allowed Values for Simple Types - `allowedvalues`](#allowed-values-for-simple-types---allowedvalues)
+  - [Scalar and Unconstrained Built-in Types](#scalar-and-unconstrained-built-in-types)
+    - [Allowed Values - `allowedvalues`](#allowed-values---allowedvalues)
   - [Minimum Value / Maximum Value - `min` and `max`](#minimum-value--maximum-value---min-and-max)
   - [Length - `minlength` and `maxlength`](#length---minlength-and-maxlength)
-  - [Conditions on `any`](#conditions-on-any)
-  - [Block Types](#block-types)
+  - [Container Types](#container-types)
     - [Tables](#tables)
     - [Arrays](#arrays)
       - [Observations on Conditions to Arrays](#observations-on-conditions-to-arrays)
@@ -360,7 +359,7 @@ detailed sections below remain authoritative.
 | `description`, `optional`, `default`, `deprecated` | Any definition, including a named reference or alternative selector |
 | `itemtype` | A definition with built-in `type = "array"` or `type = "collection"` |
 | `items` | A definition with built-in `type = "array"`; mutually exclusive with `itemtype`, `allowedvalues`, `min`, `max`, `minlength`, and `maxlength` |
-| `allowedvalues` | A simple built-in type, or the items of a non-tuple `array` |
+| `allowedvalues` | A scalar or unconstrained built-in type, or the items of a non-tuple `array` |
 | `pattern` | A definition with built-in `type = "string"` |
 | `keypattern` | A definition with built-in `type = "collection"` |
 | `min`, `max` | A numeric or temporal built-in type, or an `array` whose `itemtype` resolves to one comparable kind |
@@ -420,11 +419,14 @@ type = "boolean"
 type = "string"
 ```
 
-### Simple Types - `<simple-type>`
+### Scalar and Unconstrained Built-in Types
 
-List of considered simple types:
+The unconstrained built-in type is:
 
 - Any: `any`
+
+The scalar built-in types are:
+
 - String: `string`
 - Integer: `integer`
 - Float: `float`
@@ -434,9 +436,10 @@ List of considered simple types:
 - Local Date: `local-date`
 - Local Time: `local-time`
 
-#### Allowed Values for Simple Types - `allowedvalues`
+#### Allowed Values - `allowedvalues`
 
-`allowedvalues` provides an enumeration for a simple built-in type. On an
+`allowedvalues` provides an enumeration for a scalar or unconstrained built-in
+type. On an
 `array`, it instead enumerates the values permitted for each item, as described
 under [Observations on Conditions to Arrays](#observations-on-conditions-to-arrays).
 It is invalid on a `table` or `collection`.
@@ -448,7 +451,7 @@ equality between integers and floats does not make their TOML kinds
 interchangeable for this schema-load check. A malformed enumeration MUST be
 rejected at schema-load time.
 
-For a non-array simple type, when `allowedvalues` is combined with `pattern`,
+For a non-array definition, when `allowedvalues` is combined with `pattern`,
 `min`, `max`, `minlength`, or `maxlength`, every entry in `allowedvalues` MUST
 satisfy every applicable constraint. A schema containing an entry that violates
 one of those constraints is malformed, and schema loaders MUST reject it at
@@ -527,27 +530,16 @@ another built-in type, an alternative selector, or a named type reference.
 Schema loaders MUST reject an incompatible length constraint at schema-load time rather
 than silently ignoring it.
 
-### Conditions on `any`
-
-No `min` or `max` condition may be applied to type `any`. The schema loader
-MUST reject such a schema.
-
-An unconstrained value may declare `type = "any"`, and arrays may use `any` in
-`itemtype` or `items`. A direct `any` entry in `oneof` or `anyof` is malformed
-because it would add an unconstrained branch to an alternative type selector.
-
-### Block Types
+### Container Types
 
 - Array: `array`
-- Table: `table` (*)
-- Collection: `collection` (*)
+- Table: `table`
+- Collection: `collection`
 
-(*) The schema also explicitly defines two types:
-
-1. The implicit TOML type `table` for specifying child elements associated to the parent.
-1. A type for a collection of elements, `collection`.
-
-For simplicity, there is no definition of `inline table` since these are just tables that can be expressed inlined in a TOML document.
+`array` and `table` correspond to parsed TOML value kinds. `collection` is a
+schema-level specialization of `table` for dynamically named entries. TOML
+inline tables parse as table values and therefore do not need a separate
+built-in type.
 
 #### Tables
 
@@ -573,10 +565,6 @@ Arrays can be defined by mixing the following properties:
  - `max`: the maximum value allowed for each comparable array item (e.g. 8080).
  - `allowedvalues`: enumeration of possible values.
  - `uniqueitems`: whether every parsed array item must be unique.
-
-`arraytype` is not a TOML Schema property. Schema loaders MUST reject schema
-definitions that declare it. Use `itemtype` for both built-in and named member
-types.
 
 Example for schema definition:
 
@@ -1348,7 +1336,7 @@ This mirrors JSON Schema's `propertyNames: { pattern: ... }`, applied to TOML ma
 
 ## Validation and Data Model
 
-It is NOT the goal of a TOML Schema to ever modify the data output of a TOML object during parsing.
+TOML Schema validation does not modify the parsed TOML data model.
 
 A validator MUST NOT mutate, replace, or augment the TOML data object produced
 by the underlying parser. An API that returns that object MUST return the same
@@ -1472,9 +1460,10 @@ TOML Schema files MUST use the extension `.tosd`.
 
 ## MIME Type
 
-When transferring TOML Schema files over the internet, the MIME type MUST be:
+TOML Schema documents are valid TOML documents. When transferring them over
+the internet, implementations SHOULD use the registered TOML media type:
 
- - application/tosd
+ - `application/toml`
 
 ## TOML Reference of a TOML Schema
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -282,7 +282,7 @@ retries = 3</code></pre>
           <div class="spec-item"><strong>Semantic rules</strong><span><code>dependentrequired</code>, <code>mutuallyexclusive</code>, and <code>exactlyone</code> constrain direct sibling presence.</span></div>
           <div class="spec-item"><strong>Annotations</strong><span><code>default</code> is non-mutating metadata; <code>deprecated</code> produces warnings without invalidating a document.</span></div>
           <div class="spec-item"><strong>Containers and tuples</strong><span><code>itemtype</code> validates homogeneous array and collection members; <code>items</code> defines positional arrays.</span></div>
-          <div class="spec-item"><strong>Media type</strong><span>TOML Schema files use <code>.tosd</code> and <code>application/tosd</code>.</span></div>
+          <div class="spec-item"><strong>Media type</strong><span>TOML Schema files use <code>.tosd</code> and the registered <code>application/toml</code> media type.</span></div>
         </div>
         <div class="actions">
           <a class="button" href="/spec/">Read the full specification</a>

--- a/reference-implementations/go/schema.go
+++ b/reference-implementations/go/schema.go
@@ -946,7 +946,7 @@ func parseDefinition(name string, path []string, table map[string]any, source *s
 		return Definition{}, fmt.Errorf("%s can only define pattern when type is string", name)
 	}
 	if hasAllowedValues && (typeName == TypeTable || typeName == TypeCollection) {
-		return Definition{}, fmt.Errorf("%s can only define allowedvalues for simple types or arrays", name)
+		return Definition{}, fmt.Errorf("%s can only define allowedvalues for scalar, unconstrained, or array types", name)
 	}
 	if (minLength != nil || maxLength != nil) &&
 		typeName != TypeString && typeName != TypeArray && typeName != TypeCollection {

--- a/reference-implementations/go/schema_test.go
+++ b/reference-implementations/go/schema_test.go
@@ -778,20 +778,20 @@ colors = [ "red", "green" ]
 	}
 }
 
-func TestRejectsRemovedArraytypeProperty(t *testing.T) {
+func TestRejectsUnknownProperty(t *testing.T) {
 	dir := t.TempDir()
-	schemaPath := write(t, dir, "arraytype.tosd", `
+	schemaPath := write(t, dir, "unknown-property.tosd", `
 [toml-schema]
 version = "1.0.0"
 
 [elements.values]
 type = "array"
-arraytype = "string"
+unknownproperty = "string"
 `)
 
 	if _, err := LoadSchema(schemaPath); err == nil ||
-		!strings.Contains(err.Error(), "unsupported property: arraytype") {
-		t.Fatalf("expected arraytype to be rejected as unsupported, got %v", err)
+		!strings.Contains(err.Error(), "unsupported property: unknownproperty") {
+		t.Fatalf("expected unknown property to be rejected as unsupported, got %v", err)
 	}
 }
 
@@ -1662,10 +1662,6 @@ location = "ignored.tosd"
 	if strings.Contains(schemaText, "[elements.toml-schema]") {
 		t.Fatalf("extracted schema should not include reserved metadata:\n%s", schemaText)
 	}
-	if strings.Contains(schemaText, "arraytype") {
-		t.Fatalf("extracted schema should not contain removed arraytype:\n%s", schemaText)
-	}
-
 	schema, err := LoadSchema(extractedSchema)
 	if err != nil {
 		t.Fatal(err)

--- a/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
@@ -115,9 +115,6 @@ final class SchemaLoader {
     }
 
     private SchemaDefinition parseDefinition(String name, TomlTable table) {
-        if (getPropertyValue(table, "arraytype") != null) {
-            throw new SchemaException(name + " contains unsupported property: arraytype");
-        }
         String typeSelector = getString(table, "type");
         SchemaType type = typeSelector == null
                 ? null
@@ -250,7 +247,7 @@ final class SchemaLoader {
             throw new SchemaException(name + " can only define pattern when type is string");
         }
         if (hasAllowedValues && (type == SchemaType.TABLE || type == SchemaType.COLLECTION)) {
-            throw new SchemaException(name + " can only define allowedvalues for simple types or arrays");
+            throw new SchemaException(name + " can only define allowedvalues for scalar, unconstrained, or array types");
         }
         if ((minLength != null || maxLength != null)
                 && type != SchemaType.STRING

--- a/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
+++ b/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
@@ -416,18 +416,18 @@ class TomlSchemaTest {
     }
 
     @Test
-    void rejectsRemovedArraytypeAsUnsupported() throws IOException {
-        Path schema = write("removed-arraytype.tosd", """
+    void rejectsUnknownPropertyAsUnsupported() throws IOException {
+        Path schema = write("unknown-property.tosd", """
                 [toml-schema]
                 version = "1.0.0"
 
                 [elements.values]
                 type = "array"
-                arraytype = "string"
+                unknownproperty = "string"
                 """);
 
         SchemaException error = assertThrows(SchemaException.class, () -> TomlSchema.load(schema));
-        assertTrue(error.getMessage().contains("unsupported property: arraytype"), error::getMessage);
+        assertTrue(error.getMessage().contains("unsupported property: unknownproperty"), error::getMessage);
     }
 
     @Test
@@ -1956,7 +1956,6 @@ class TomlSchemaTest {
         assertTrue(schemaText.contains("[elements.title]"));
         assertTrue(schemaText.contains("type = \"string\""));
         assertTrue(schemaText.contains("itemtype = \"integer\""));
-        assertFalse(schemaText.contains("arraytype"));
         assertTrue(schemaText.contains("[elements.owner]"));
         assertTrue(schemaText.contains("[elements.owner.name]"));
         assertFalse(schemaText.contains("[elements.toml-schema]"));

--- a/reference-implementations/rust/src/schema.rs
+++ b/reference-implementations/rust/src/schema.rs
@@ -1158,9 +1158,6 @@ fn parse_definition(
     table: &Table,
     context: SyntaxContext<'_>,
 ) -> Result<Definition, String> {
-    if property_value(table, "arraytype").is_some() {
-        return Err(format!("{name} contains unsupported property: arraytype"));
-    }
     let type_selector = get_string(name, table, "type")?;
     let mut type_name = type_selector.as_deref().and_then(SchemaType::parse);
     let reference = type_selector
@@ -1336,7 +1333,7 @@ fn parse_definition(
     }
     if has_allowed_values && matches!(type_name, Some(SchemaType::Table | SchemaType::Collection)) {
         return Err(format!(
-            "{name} can only define allowedvalues for simple types or arrays"
+            "{name} can only define allowedvalues for scalar, unconstrained, or array types"
         ));
     }
     if (min_length.is_some() || max_length.is_some())

--- a/reference-implementations/rust/tests/integration.rs
+++ b/reference-implementations/rust/tests/integration.rs
@@ -813,8 +813,8 @@ min = 1
 }
 
 #[test]
-fn rejects_removed_arraytype_property() {
-    let directory = tempfile_dir("removed-arraytype");
+fn rejects_unknown_property() {
+    let directory = tempfile_dir("unknown-property");
     let schema_path = write_file(
         &directory,
         "schema.tosd",
@@ -824,11 +824,11 @@ version = "1.0.0"
 
 [elements.values]
 type = "array"
-arraytype = "integer"
+unknownproperty = "integer"
 "#,
     );
 
-    let error = Schema::load(&schema_path).expect_err("arraytype must be unsupported");
+    let error = Schema::load(&schema_path).expect_err("unknown property must be unsupported");
     assert!(
         error.contains("unsupported property"),
         "unexpected error: {error}"


### PR DESCRIPTION
The specification retained terminology and compatibility notes for concepts that are no longer part of the TOML Schema vocabulary. This made obsolete names such as `arraytype` appear more significant than ordinary unsupported properties and left the type taxonomy inconsistent with the formal grammar.

This change:
- replaces the old simple/block type taxonomy with scalar, unconstrained, and container built-in types
- removes the redundant `any` section and `arraytype`-specific rejection paths
- keeps generic unknown-property rejection coverage in Java, Go, Rust, and the schema editor
- clarifies that validation operates on parsed TOML data
- keeps `.tosd` as the file extension while using the registered `application/toml` media type
- updates the generated documentation surfaces