### PR TITLE
Improve website responsive hierarchy

### DIFF
--- a/.impeccable/critique/2026-08-19T16-24-31Z__docs-index-html.md
+++ b/.impeccable/critique/2026-08-19T16-24-31Z__docs-index-html.md
@@ -1,0 +1,108 @@
+---
+target: the website toml-schema.org
+total_score: 26
+max_score: 36
+na_heuristics: 9
+p0_count: 0
+p1_count: 2
+timestamp: 2026-08-19T16-24-31Z
+slug: docs-index-html
+---
+Method: dual-agent (A: design-review · B: detector-evidence)
+
+## Design Health Score
+
+| # | Heuristic | Score | Key Issue |
+|---|-----------|-------|-----------|
+| 1 | Visibility of System Status | 3 | Static links have clear hover/focus states, but the long page gives no location cue. |
+| 2 | Match System / Real World | 4 | Copy and examples speak fluent TOML and use real project artifacts. |
+| 3 | User Control and Freedom | 2 | Non-sticky navigation and an undiscoverable horizontally scrolling mobile menu make long-page movement cumbersome. |
+| 4 | Consistency and Standards | 3 | Components are cohesive, but duplicate specification CTAs and equal-weight navigation blur hierarchy. |
+| 5 | Error Prevention | 3 | Few risky actions exist; links and labels are generally explicit. |
+| 6 | Recognition Rather Than Recall | 2 | Seven tour panels lack progress or a local index, forcing users to retain context across a long scroll. |
+| 7 | Flexibility and Efficiency | 2 | Return visitors get no persistent shortcut to the editor, specification, or implementations. |
+| 8 | Aesthetic and Minimalist Design | 2 | Calm styling is undermined by competing CTAs and broken code-panel containment. |
+| 9 | Error Recovery | n/a | This static persuasion surface exposes no recoverable error state. |
+| 10 | Help and Documentation | 3 | Specification, implementation, and feedback paths are visible and concrete. |
+| **Total** | | **26/36** | **Good (72%)** |
+
+## Design Specificity Verdict
+
+**Specific content, strategically generic sequence.** The page is unmistakably about TOML Schema: the hero example, SemVer language, `.tosd` references, implementation evidence, and paired schema/TOML samples are real and credible. The composition does not capitalize on that specificity. Its strongest differentiator, the visual editor, appears after a conventional three-card value proposition and proof band, while the hero prioritizes reading the specification.
+
+The deterministic scan returned **13 anti-pattern findings**. They were concentrated around the eyebrow treatment, seven hairline-border/wide-shadow card treatments, four long-line warnings, and global single-font/cream-palette signals. The line-length and global palette/font warnings are mostly false positives for this technical site; the repeated shadowed-card treatment supports the broader finding that the visual language is competent but category-familiar.
+
+Browser injection succeeded through direct evaluation after the HTTPS page rejected the localhost script tag. The browser reported 13 findings and produced desktop overlay and mobile evidence. No reliable persistent user-visible overlay tab remains; the evidence was captured during the assessment.
+
+## Overall Impression
+
+The homepage earns technical trust quickly, but it does not convert that trust into one obvious next action. The biggest opportunity is to make the editor the first-viewport proof object and restructure the rest of the page around a single adoption path.
+
+## What's Working
+
+1. **The value proposition is immediate.** “Validate TOML without leaving TOML” is short, differentiated, and legible to the target audience.
+2. **Proof is real rather than promotional.** The checked-in schema example, validation result, and Java/Go/Rust implementations create credible developer evidence without invented claims.
+3. **The visual system is restrained and accessible by default.** Focus outlines, semantic structure, dark-mode tokens, meaningful image alt text, and consistent component patterns form a solid base.
+
+## Priority Issues
+
+### [P1] Code examples break their containers
+
+**Why it matters:** At 390px, long schema examples bleed beyond rounded tour cards and the viewport without a clear horizontal-scroll cue. On desktop, `height: calc(100% - 24px)` combines with overflow behavior to create clipped examples and nested vertical scrolling. A documentation page about structured correctness looks visibly broken.
+
+**Fix:** Remove the fixed height from `.tour-step pre`, explicitly allow vertical growth, constrain every grid child with `min-width: 0`, and preserve horizontal scrolling inside the card. Add a subtle edge fade only when horizontal overflow exists.
+
+**Suggested command:** `/impeccable adapt`
+
+### [P1] The page has no decisive conversion path
+
+**Why it matters:** Seven equal-weight navigation choices, two hero actions, and several later CTAs ask visitors to choose among specification, evidence, editor, implementations, and GitHub before the page establishes a primary journey.
+
+**Fix:** Make “Explore the TOML Schema Editor” the primary action, retain the specification as the secondary action, reduce top-level navigation to the highest-value destinations, and demote later repeated CTAs to contextual text links.
+
+**Suggested command:** `/impeccable distill`
+
+### [P2] The editor arrives after generic category language
+
+**Why it matters:** “Native / Practical / Toolable” could describe many developer tools. Visitors encounter these conventional cards before seeing the editor screenshot that only this project can own.
+
+**Fix:** Move a condensed editor proof object into or immediately below the hero, then use the three benefits as annotations tied to visible editor behavior rather than standalone adjective cards.
+
+**Suggested command:** `/impeccable bolder`
+
+### [P2] The seven-step tour creates competence fatigue
+
+**Why it matters:** Repeated two-column code panels have little change in rhythm, no progress cue, and require users to remember earlier concepts. The page’s emotional arc peaks before its longest section, then ends on implementation inventory.
+
+**Fix:** Add a compact tour index, group examples into fundamentals/structure/constraints, and end with a focused next step rather than another card row.
+
+**Suggested command:** `/impeccable layout`
+
+### [P2] Mobile navigation hides overflow
+
+**Why it matters:** The horizontally scrolling menu clips its final item with no fade, chevron, or partial-item cue. Users may never discover all destinations.
+
+**Fix:** Replace the seven-item strip with a compact menu or add a clear scroll affordance and visible current-location state.
+
+**Suggested command:** `/impeccable adapt`
+
+## Persona Red Flags
+
+**Alex (Impatient Power User):** Alex wants the implementation or editor immediately. The non-sticky seven-item navigation and repeated specification CTA add scanning cost, while the editor is buried below multiple sections.
+
+**Jordan (First-Timer):** Jordan understands the headline but faces nine first-viewport choices across navigation and hero actions. Terms such as `itemtype`, `oneof`, and `dependentrequired` become dense before the page provides a simple “start here” path.
+
+**Sam (Accessibility-Dependent User):** Semantic headings, focus styles, and alt text are strong. The mobile menu’s visually hidden overflow and code examples that escape their containers become serious problems at zoom or narrow widths, where spatial relationships are already harder to track.
+
+## Minor Observations
+
+- The proof band is strong evidence but its entire content is one large link, making reading and activation visually indistinguishable.
+- The editor screenshot is too small on the homepage to function as the memorable proof object described in the surface brief.
+- The page ends on implementation cards rather than a confident adoption or contribution CTA.
+- The automated eyebrow, single-font, and cream-palette warnings are intentional enough to ignore unless a broader redesign is requested.
+
+## Questions to Consider
+
+- If the editor is the product’s clearest differentiator, why is the specification still the hero’s primary action?
+- What could be removed from the seven-item navigation without blocking a serious evaluator?
+- Could the tour teach through one progressively built schema instead of seven visually identical panels?

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="description" content="TOML Schema is a TOML-native schema language for validating TOML configuration documents.">
   <link rel="canonical" href="https://toml-schema.org/">
   <title>TOML Schema</title>
@@ -30,9 +30,7 @@
       </a>
       <nav aria-label="Primary navigation">
         <a href="/editor/">Editor</a>
-        <a href="#why">Why</a>
         <a href="/validation-report/">Evidence</a>
-        <a href="#tour">Tour</a>
         <a href="/spec/">Spec</a>
         <a href="/implementations/">Implementations</a>
         <a href="https://github.com/brunoborges/toml-schema">GitHub</a>
@@ -42,15 +40,14 @@
     <main>
       <section class="hero">
         <div>
-          <div class="eyebrow">A TOML-native schema language</div>
           <h1>Validate TOML without leaving TOML.</h1>
           <p class="lead">
             TOML Schema describes structure, value types, reusable constraints,
             and common semantic relationships using TOML syntax itself.
           </p>
           <div class="actions">
-            <a class="button" href="/spec/">Read the specification</a>
-            <a class="button-secondary" href="/validation-report/">See real-world results</a>
+            <a class="button" href="/editor/">Explore the editor</a>
+            <a class="button-secondary" href="/spec/">Read the specification</a>
           </div>
         </div>
         <aside class="panel" aria-label="Example TOML Schema document">
@@ -349,7 +346,7 @@ retries = 3</code></pre>
           <div class="spec-item"><strong>Media type</strong><span>TOML Schema files use <code>.tosd</code> and the registered <code>application/toml</code> media type.</span></div>
         </div>
         <div class="actions">
-          <a class="button" href="/spec/">Read the full specification</a>
+          <a class="text-link" href="/spec/">Read the full specification <span aria-hidden="true">→</span></a>
         </div>
       </section>
 
@@ -377,7 +374,7 @@ retries = 3</code></pre>
           </article>
         </div>
         <div class="actions">
-          <a class="button" href="/implementations/">Build and use an implementation</a>
+          <a class="text-link" href="/implementations/">Build and use an implementation <span aria-hidden="true">→</span></a>
         </div>
       </section>
     </main>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -235,7 +235,10 @@ h3 {
   width: 10px;
 }
 pre {
+  max-width: 100%;
+  min-width: 0;
   margin: 0;
+  overscroll-behavior-inline: contain;
   overflow-x: auto;
   padding: 20px;
   white-space: pre;
@@ -285,6 +288,10 @@ pre {
   grid-template-columns: minmax(220px, 0.8fr) minmax(0, 1.2fr);
   padding: 22px;
 }
+.tour-step > *,
+.tour-examples > div {
+  min-width: 0;
+}
 .tour-step h3 {
   margin-top: 12px;
 }
@@ -311,8 +318,10 @@ pre {
   background: var(--cp-surface-soft);
   border: 1px solid var(--cp-border);
   border-radius: 0.625rem;
-  height: calc(100% - 24px);
+  height: auto;
   padding: 16px;
+  scrollbar-color: var(--cp-border-strong) transparent;
+  scrollbar-width: thin;
 }
 .spec-item {
   background: var(--cp-surface);
@@ -1006,24 +1015,37 @@ footer {
 }
 
 @media (max-width: 560px) {
-  body {
-    overflow-x: hidden;
-  }
   .page {
-    padding-inline: 18px;
+    padding-left: max(18px, env(safe-area-inset-left));
+    padding-right: max(18px, env(safe-area-inset-right));
   }
   nav {
-    flex-wrap: nowrap;
-    margin-inline: -18px;
-    overflow-x: auto;
-    padding: 0 18px 4px;
-    scrollbar-width: none;
-  }
-  nav::-webkit-scrollbar {
-    display: none;
+    display: grid;
+    gap: 8px;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    width: 100%;
   }
   nav a {
-    flex: 0 0 auto;
+    align-items: center;
+    justify-content: center;
+    min-height: 44px;
+    padding-inline: 8px;
+    text-align: center;
+  }
+  .hero .actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+  .hero .actions a {
+    justify-content: center;
+    min-height: 44px;
+    width: 100%;
+  }
+  .tour-step,
+  .tour-examples,
+  .tour-examples > div,
+  .tour-step pre {
+    max-width: 100%;
   }
   .report-hero {
     padding-top: 36px;
@@ -1079,6 +1101,12 @@ footer {
   .editor-copilot,
   .editor-open {
     padding-block: 64px;
+  }
+}
+
+@media (max-width: 420px) {
+  nav {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 

--- a/docs/validation-report/index.html
+++ b/docs/validation-report/index.html
@@ -35,9 +35,8 @@
         <span class="visually-hidden">TOML Schema</span>
       </a>
       <nav aria-label="Primary navigation">
-        <a href="/#why">Why</a>
+        <a href="/editor/">Editor</a>
         <a href="/validation-report/" aria-current="page">Evidence</a>
-        <a href="/#tour">Tour</a>
         <a href="/spec/">Spec</a>
         <a href="/implementations/">Implementations</a>
         <a href="https://github.com/brunoborges/toml-schema">GitHub</a>


### PR DESCRIPTION
The homepage's code examples and navigation broke down on narrow screens, while several equal-weight calls to action obscured the project's clearest path: exploring the TOML Schema Editor.

This change:
- contains scrollable schema examples within their cards at mobile and desktop widths
- replaces clipped mobile navigation with touch-sized responsive navigation
- makes the editor the primary homepage action and the specification secondary
- aligns navigation across the homepage and validation report
- preserves the design critique that documents the evidence and priorities behind the update