### PR TITLE
Fix stale website implementation claims

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,7 +26,7 @@ This repository contains the TOML Schema specification/proposal plus reference i
 - `reference-implementations/go` is the `tomlschema.org/go` importable Go package.
 - `reference-implementations/rust` provides both the `toml_schema` Rust library and the canonical `toml-schema` CLI.
 - `reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java` covers the checked-in examples, self-schema validation, and validation errors.
-- Java, Go, and Rust ABNF conformance tests read `toml-schema.abnf` and check implementation schema properties and built-in type names against it.
+- Java, Go, .NET, and Rust ABNF conformance tests read `toml-schema.abnf` and check implementation schema properties and built-in type names against it.
 
 ## Key conventions
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -20,7 +20,7 @@ TOML Schema keeps schemas in TOML itself. Its GitHub Copilot App canvas editor t
 
 ## Operating Context
 
-Developers work in the GitHub Copilot App with this repository open, edit `.tosd` schema files, inspect their generated TOML, and use the repository's Java, Go, or Rust reference implementations to validate TOML documents.
+Developers work in the GitHub Copilot App with this repository open, edit `.tosd` schema files, inspect their generated TOML, and use the repository's Java, Go, .NET, or Rust reference implementations to validate TOML documents.
 
 ## Capabilities and Constraints
 
@@ -37,7 +37,7 @@ Use the names "TOML Schema" and "TOML Schema Editor." Describe the product direc
 
 - The working canvas extension lives in `.github/extensions/tosd-editor/`.
 - Checked-in `.tosd` examples and the TOML Schema self-schema provide real demonstration content.
-- Java, Go, and Rust reference implementations and the real-world validation report provide implementation evidence.
+- Java, Go, .NET, and Rust reference implementations and the real-world validation report provide implementation evidence.
 - No testimonials, customer logos, or benchmark claims are available and none should be invented.
 
 ## Product Principles

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![TOML 1.0](https://img.shields.io/badge/TOML-1.0-9c4121)](https://toml.io/en/v1.0.0)
 [![Java 25](https://img.shields.io/badge/Java-25-007396)](REFERENCE_IMPLEMENTATIONS.md#java)
 [![Go 1.26.6](https://img.shields.io/badge/Go-1.26.6-00ADD8)](REFERENCE_IMPLEMENTATIONS.md#go)
+[![.NET 9](https://img.shields.io/badge/.NET-9.0-512BD4)](REFERENCE_IMPLEMENTATIONS.md#net)
 [![Rust 1.75](https://img.shields.io/badge/Rust-1.75-dea584)](REFERENCE_IMPLEMENTATIONS.md#rust)
 
 TOML Schema is a TOML-based schema language for describing and validating the structure, names, value types, and common semantic relationships of TOML configuration files.
@@ -68,7 +69,7 @@ type = "table"
 
 ## Reference implementations
 
-Java, Go, and Rust reference libraries live under `reference-implementations/`.
+Java, Go, .NET, and Rust reference libraries live under `reference-implementations/`.
 The Rust implementation provides the canonical `toml-schema` CLI. See
 [Reference implementations](REFERENCE_IMPLEMENTATIONS.md) for implementation
 status, CLI usage, schema extraction, and conformance expectations.

--- a/REFERENCE_IMPLEMENTATIONS.md
+++ b/REFERENCE_IMPLEMENTATIONS.md
@@ -1,6 +1,6 @@
 # Reference Implementations
 
-Build and use the TOML Schema reference libraries in Java, Go, and Rust. Rust also
+Build and use the TOML Schema reference libraries in Java, Go, .NET, and Rust. Rust also
 provides the canonical `toml-schema` command-line interface for validation, schema
 discovery through `[toml-schema].location`, and starter-schema extraction.
 
@@ -102,7 +102,7 @@ dotnet test reference-implementations/dotnet
 Run one test:
 
 ```shell
-dotnet test reference-implementations/dotnet -k "ValidatesCheckedInExample"
+dotnet test reference-implementations/dotnet --filter "ValidatesCheckedInExample"
 ```
 
 Build the library:
@@ -217,7 +217,7 @@ language-version compatibility rules from `SPEC.md`, and expose validation and
 schema extraction commands suitable for automation and editor integration.
 
 The GitHub Actions workflow in `.github/workflows/reference-implementations.yml`
-enforces these expectations for Java, Go, and Rust. Rust additionally exercises
+enforces these expectations for Java, Go, .NET, and Rust. Rust additionally exercises
 the canonical CLI end to end.
 
 ## TOML version profile
@@ -228,11 +228,12 @@ The current reference implementations parse TOML with libraries that target TOML
 
 - Java: [Tomlj](https://github.com/tomlj/tomlj) `1.1.1`, which documents support up to TOML 1.0.0.
 - Go: [`pelletier/go-toml`](https://github.com/pelletier/go-toml) `v2.3.1`, which targets TOML 1.0.
+- .NET: [Tomlyn](https://github.com/xoofx/Tomlyn) `2.10.1`, which targets TOML 1.0.
 - Rust: [`toml`](https://crates.io/crates/toml) `1`, which targets TOML 1.0.
 
-For that reason, the reference implementations' current effective parser profile is **TOML 1.0**. TOML 1.1 syntax (for example multi-line inline tables, trailing commas in inline tables, omitted seconds in date-times, or the `\e` and `\xHH` string escapes) is not guaranteed to parse in either reference implementation until the underlying TOML parser declares TOML 1.1 conformance.
+For that reason, the reference implementations' current effective parser profile is **TOML 1.0**. TOML 1.1 syntax (for example multi-line inline tables, trailing commas in inline tables, omitted seconds in date-times, or the `\e` and `\xHH` string escapes) is not guaranteed to parse in any reference implementation until the underlying TOML parser declares TOML 1.1 conformance.
 
-Upgrading either reference implementation to a TOML 1.1-conformant parser is tracked separately. When that happens, the expected follow-up changes are:
+Upgrading a reference implementation to a TOML 1.1-conformant parser is tracked separately. When that happens, the expected follow-up changes are:
 
 1. Bump the TOML badge in [`README.md`](README.md) and the parser notes in the status table above to TOML 1.1.
 1. Update the ABNF preamble in [`toml-schema.abnf`](toml-schema.abnf) to reference TOML 1.1 as the underlying grammar.

--- a/docs/index.html
+++ b/docs/index.html
@@ -95,7 +95,7 @@ uniqueitems = true</code></pre>
           <article class="card">
             <span class="badge">Toolable</span>
             <h3>Reference implementations</h3>
-            <p>Java, Go, and Rust implementations validate examples, self-schema behavior, and CLI workflows in CI.</p>
+            <p>Java, Go, .NET, and Rust libraries validate examples and self-schema behavior in CI; Rust also exercises the canonical CLI end to end.</p>
           </article>
         </div>
       </section>
@@ -367,18 +367,23 @@ retries = 3</code></pre>
         <div class="implementations">
           <article class="card">
             <span class="badge">Java</span>
-            <h3>Library and CLI</h3>
+            <h3>Library</h3>
             <p>Uses Tomlj to parse TOML and validates documents against <code>.tosd</code> schemas.</p>
           </article>
           <article class="card">
             <span class="badge">Go</span>
-            <h3>Library and CLI</h3>
+            <h3>Library</h3>
             <p>Uses go-toml and supports explicit schema validation and schema-location lookup.</p>
           </article>
           <article class="card">
+            <span class="badge">.NET</span>
+            <h3>Library</h3>
+            <p>Uses Tomlyn to parse TOML and validates documents against <code>.tosd</code> schemas.</p>
+          </article>
+          <article class="card">
             <span class="badge">Rust</span>
-            <h3>Library and CLI</h3>
-            <p>Uses the Rust <code>toml</code> crate and mirrors cross-language behavior.</p>
+            <h3>Library and canonical CLI</h3>
+            <p>Uses the Rust <code>toml</code> crate and provides validation, schema discovery, and schema extraction commands.</p>
           </article>
         </div>
         <div class="actions">

--- a/docs/validation-report/index.html
+++ b/docs/validation-report/index.html
@@ -48,7 +48,9 @@
         <h1>16 of 18 real-world TOML files validated unchanged.</h1>
         <p class="lead">
           We took public configuration files from six established TOML ecosystems,
-          downloaded them directly from GitHub, and ran the Java reference validator.
+          downloaded them directly from GitHub, and validated them against proposed
+          schemas. The results were reproduced with the canonical Rust CLI at the
+          pinned revision below.
           No source file was rewritten to fit the schema.
         </p>
         <div class="actions">
@@ -61,7 +63,7 @@
         <span><strong>18</strong> public files</span>
         <span><strong>6</strong> ecosystems</span>
         <span><strong>5 of 6</strong> schemas passed every file</span>
-        <span><strong>2</strong> precise diagnostics</span>
+        <span><strong>4</strong> diagnostic paths across 2 files</span>
       </div>
 
       <section class="report-section report-intro">
@@ -103,7 +105,7 @@
               <div><h3>Cargo</h3><p>Packages, workspaces, target dependencies, profiles, and metadata.</p></div>
               <div class="result-actions">
                 <span class="status status-pass"><span aria-hidden="true">✓</span> 3 / 3 valid</span>
-                <a class="schema-link" href="https://github.com/brunoborges/toml-schema/blob/main/examples/cargo.tosd">View schema <span aria-hidden="true">→</span></a>
+                <a class="schema-link" href="https://github.com/brunoborges/toml-schema/blob/a7ced5595bdae08af9390f54c4997e91719b8e12/examples/cargo.tosd">View schema <span aria-hidden="true">→</span></a>
               </div>
             </div>
             <ul class="source-list">
@@ -118,7 +120,7 @@
               <div><h3>pyproject</h3><p>PEP 621 metadata, dependency groups, build systems, and open tool namespaces.</p></div>
               <div class="result-actions">
                 <span class="status status-pass"><span aria-hidden="true">✓</span> 3 / 3 valid</span>
-                <a class="schema-link" href="https://github.com/brunoborges/toml-schema/blob/main/examples/pyproject.tosd">View schema <span aria-hidden="true">→</span></a>
+                <a class="schema-link" href="https://github.com/brunoborges/toml-schema/blob/a7ced5595bdae08af9390f54c4997e91719b8e12/examples/pyproject.tosd">View schema <span aria-hidden="true">→</span></a>
               </div>
             </div>
             <ul class="source-list">
@@ -133,7 +135,7 @@
               <div><h3>Hugo</h3><p>Site settings, modules, theme parameters, languages, and pagination.</p></div>
               <div class="result-actions">
                 <span class="status status-mixed"><span aria-hidden="true">!</span> 1 / 3 valid</span>
-                <a class="schema-link" href="https://github.com/brunoborges/toml-schema/blob/main/examples/hugo.tosd">View schema <span aria-hidden="true">→</span></a>
+                <a class="schema-link" href="https://github.com/brunoborges/toml-schema/blob/a7ced5595bdae08af9390f54c4997e91719b8e12/examples/hugo.tosd">View schema <span aria-hidden="true">→</span></a>
               </div>
             </div>
             <ul class="source-list">
@@ -148,7 +150,7 @@
               <div><h3>Netlify</h3><p>Build contexts, redirects, headers, environment values, and deployment behavior.</p></div>
               <div class="result-actions">
                 <span class="status status-pass"><span aria-hidden="true">✓</span> 3 / 3 valid</span>
-                <a class="schema-link" href="https://github.com/brunoborges/toml-schema/blob/main/examples/netlify.tosd">View schema <span aria-hidden="true">→</span></a>
+                <a class="schema-link" href="https://github.com/brunoborges/toml-schema/blob/a7ced5595bdae08af9390f54c4997e91719b8e12/examples/netlify.tosd">View schema <span aria-hidden="true">→</span></a>
               </div>
             </div>
             <ul class="source-list">
@@ -163,7 +165,7 @@
               <div><h3>Cloudflare Wrangler</h3><p>Worker entry points, bindings, routes, variables, and compatibility settings.</p></div>
               <div class="result-actions">
                 <span class="status status-pass"><span aria-hidden="true">✓</span> 3 / 3 valid</span>
-                <a class="schema-link" href="https://github.com/brunoborges/toml-schema/blob/main/examples/wrangler.tosd">View schema <span aria-hidden="true">→</span></a>
+                <a class="schema-link" href="https://github.com/brunoborges/toml-schema/blob/a7ced5595bdae08af9390f54c4997e91719b8e12/examples/wrangler.tosd">View schema <span aria-hidden="true">→</span></a>
               </div>
             </div>
             <ul class="source-list">
@@ -178,7 +180,7 @@
               <div><h3>GitLab Runner</h3><p>Global settings, runner arrays, executors, and service configuration.</p></div>
               <div class="result-actions">
                 <span class="status status-pass"><span aria-hidden="true">✓</span> 3 / 3 valid</span>
-                <a class="schema-link" href="https://github.com/brunoborges/toml-schema/blob/main/examples/gitlab-runner.tosd">View schema <span aria-hidden="true">→</span></a>
+                <a class="schema-link" href="https://github.com/brunoborges/toml-schema/blob/a7ced5595bdae08af9390f54c4997e91719b8e12/examples/gitlab-runner.tosd">View schema <span aria-hidden="true">→</span></a>
               </div>
             </div>
             <ul class="source-list">
@@ -218,7 +220,7 @@
         <ol class="method-list">
           <li><strong>Search public GitHub repositories.</strong><span>Prefer project configuration over vendor documentation and template-only examples.</span></li>
           <li><strong>Pin and download the source.</strong><span>Use repository content directly; do not normalize casing, remove unknown keys, or otherwise prepare it for the schema.</span></li>
-          <li><strong>Validate with the reference CLI.</strong><span>Pair each file with the corresponding proposed <code>.tosd</code> schema.</span></li>
+          <li><strong>Validate with the canonical CLI.</strong><span>At revision <code>a7ced5595bda</code>, pair each file with the corresponding pinned <code>.tosd</code> schema.</span></li>
           <li><strong>Record every outcome.</strong><span>Count strict validation failures as failures and retain the diagnostic paths.</span></li>
         </ol>
         <div class="command-block">
@@ -226,7 +228,10 @@
             <strong>Reproduce a validation</strong>
             <button class="copy-button" type="button" data-copy-target="validation-command" aria-live="polite">Copy command</button>
           </div>
-          <pre><code id="validation-command">java -jar toml-schema-1.0.0-rc.2.jar \
+          <pre><code id="validation-command">git clone https://github.com/brunoborges/toml-schema.git toml-schema-report
+cd toml-schema-report
+git checkout a7ced5595bdae08af9390f54c4997e91719b8e12
+cargo run --quiet --manifest-path reference-implementations/rust/Cargo.toml -- \
   validate examples/cargo.tosd path/to/Cargo.toml</code></pre>
         </div>
       </section>

--- a/reference-implementations/dotnet/README.md
+++ b/reference-implementations/dotnet/README.md
@@ -21,7 +21,7 @@ dotnet test reference-implementations/dotnet
 Run a single test:
 
 ```shell
-dotnet test reference-implementations/dotnet -k "ValidatesCheckedInExample"
+dotnet test reference-implementations/dotnet --filter "ValidatesCheckedInExample"
 ```
 
 Build the library:

--- a/scripts/render-docs.mjs
+++ b/scripts/render-docs.mjs
@@ -13,6 +13,7 @@ const repositoryUrl = "https://github.com/brunoborges/toml-schema";
 const repositoryDirectories = new Set([
   "reference-implementations/java",
   "reference-implementations/go",
+  "reference-implementations/dotnet",
   "reference-implementations/rust",
 ]);
 const pages = [
@@ -28,7 +29,7 @@ const pages = [
     source: "REFERENCE_IMPLEMENTATIONS.md",
     output: join("implementations", "index.html"),
     description:
-      "Build and use the Java, Go, and Rust TOML Schema reference implementations as libraries and command-line tools.",
+      "Build and use the Java, Go, .NET, and Rust TOML Schema reference libraries and the canonical Rust command-line interface.",
     canonical: "https://toml-schema.org/implementations/",
     activeNav: "implementations",
   },


### PR DESCRIPTION
The website still described removed Java and Go CLIs, omitted the .NET reference library, and offered an obsolete Java command for reproducing the validation report. This made the published capability and evidence pages disagree with the current repository.

## What changed

- Present Java, Go, and .NET as libraries and Rust as the canonical CLI.
- Include .NET in the homepage, generated implementation docs, parser profile, CI wording, README, and product context.
- Replace the report's Java command with a reproducible Rust CLI workflow pinned to the exact validator and schema revision.
- Pin every report schema link and correct the summary from two diagnostics to four diagnostic paths across two files.
- Fix the documented .NET single-test command to use `--filter`.

## Verification

- Regenerated the documentation pages successfully.
- Confirmed the corrected .NET test command runs the intended test.
- Reproduced the report's 16 passing files and four Hugo diagnostic paths with the pinned Rust CLI and schemas.