### PR TITLE
Add document-driven schema discovery to Java and .NET

### DIFF
--- a/REFERENCE_IMPLEMENTATIONS.md
+++ b/REFERENCE_IMPLEMENTATIONS.md
@@ -8,9 +8,9 @@ discovery through `[toml-schema].location`, and starter-schema extraction.
 
 | Language | Location | Requires | Interfaces |
 | --- | --- | --- | --- |
-| Java | [`reference-implementations/java`](reference-implementations/java) | Java 25 and Maven | Library |
+| Java | [`reference-implementations/java`](reference-implementations/java) | Java 25 and Maven | Library, schema discovery |
 | Go | [`reference-implementations/go`](reference-implementations/go) | Go 1.26.6 | Library, schema discovery, schema extraction |
-| .NET | [`reference-implementations/dotnet`](reference-implementations/dotnet) | .NET 9.0 | Library |
+| .NET | [`reference-implementations/dotnet`](reference-implementations/dotnet) | .NET 9.0 | Library, schema discovery |
 | Rust | [`reference-implementations/rust`](reference-implementations/rust) | Rust 1.75 and Cargo | Library, canonical CLI, schema discovery, schema extraction |
 
 The implementations use TOML 1.0 parsers and share the same conformance expectations.
@@ -20,7 +20,9 @@ package-registry releases.
 ## Java
 
 The Java 25 reference library uses [Tomlj](https://github.com/tomlj/tomlj) to
-parse TOML and validates the parsed data model against a `.tosd` schema.
+parse TOML and validates the parsed data model against a `.tosd` schema. Its
+library API also supports document-driven schema discovery through
+`[toml-schema].location`.
 
 Run the full Java test suite:
 
@@ -51,6 +53,24 @@ ValidationResult result = TomlSchema
     .load(Path.of("config.tosd"))
     .validate(Path.of("config.toml"));
 ```
+
+Validate using `[toml-schema].location` from the TOML document:
+
+```java
+import java.nio.file.Path;
+import org.tomlschema.TomlSchema;
+import org.tomlschema.ValidationResult;
+
+ValidationResult result = TomlSchema.validateDocument(Path.of("config.toml"));
+```
+
+`TomlSchema.discover(...)` resolves a relative `[toml-schema].location` from the
+document's parent directory, also accepts an absolute local path or a
+hierarchical `file` URI, and rejects unsupported URI schemes, opaque `file`
+URIs, non-local hosts, and query/fragment components. The document's
+`[toml-schema].version` is optional; when present, discovery rejects a
+major-version mismatch and reports other unequal versions as warnings on the
+returned `DiscoveredSchema`.
 
 The Java test suite reads `toml-schema.abnf` as a conformance guard and checks that the implementation's supported schema properties and built-in type names match the grammar.
 
@@ -92,6 +112,8 @@ The Go test suite includes an ABNF conformance test (`abnf_conformance_test.go`)
 
 The .NET 9.0 reference library uses [Tomlyn](https://github.com/xoofx/Tomlyn)
 to parse TOML and validates the parsed data model against a `.tosd` schema.
+Its library API also supports document-driven schema discovery through
+`[toml-schema].location`.
 
 Run the full .NET test suite:
 
@@ -125,6 +147,22 @@ if (!result.IsValid)
         Console.WriteLine($"{error.Path}: {error.Message}");
 }
 ```
+
+Validate using `[toml-schema].location` from the TOML document:
+
+```csharp
+using TomlSchema;
+
+var result = TomlSchema.TomlSchema.ValidateDocument("config.toml");
+```
+
+`TomlSchema.Discover(...)` resolves a relative `[toml-schema].location` from
+the document's parent directory, also accepts an absolute local path or a
+hierarchical `file` URI, and rejects unsupported URI schemes, opaque `file`
+URIs, non-local hosts, and query/fragment components. The document's
+`[toml-schema].version` is optional; when present, discovery rejects a
+major-version mismatch and reports other unequal versions as warnings on the
+returned `DiscoveredSchema`.
 
 The .NET test suite reads `toml-schema.abnf` as a conformance guard and checks that the implementation's supported schema properties and built-in type names match the grammar.
 

--- a/reference-implementations/dotnet/README.md
+++ b/reference-implementations/dotnet/README.md
@@ -3,7 +3,8 @@
 .NET 9.0 reference library targeting the current, unreleased
 [TOML Schema 1.0.0](../../SPEC.md). It parses TOML with
 [Tomlyn](https://github.com/xoofx/Tomlyn) `2.10.1` (TOML 1.0) and validates the
-parsed data model against a `.tosd` schema.
+parsed data model against a `.tosd` schema, including document-driven schema
+discovery through `[toml-schema].location`.
 
 - Assembly: `TomlSchema`
 - Namespace: `TomlSchema`
@@ -60,6 +61,34 @@ var defaultValue = schema.DefaultValue("field_name");
 
 `DefaultValue(...)` exposes effective default annotations. Validation never
 inserts defaults or mutates parsed TOML.
+
+## Schema discovery
+
+`TomlSchema.Discover(string)` and `TomlSchema.ValidateDocument(string)` load
+the schema referenced by a TOML document's reserved `[toml-schema].location`,
+following the resolution rules in [`SPEC.md`](../../SPEC.md#toml-reference-of-a-toml-schema):
+
+```csharp
+using TomlSchema;
+
+// Discover the schema and validate the document in one step, without parsing it twice.
+var result = TomlSchema.TomlSchema.ValidateDocument("config.toml");
+
+// Or inspect the discovered schema, parsed document, and any version warnings first.
+var discovered = TomlSchema.TomlSchema.Discover("config.toml");
+foreach (var warning in discovered.Warnings)
+{
+    Console.WriteLine($"Warning: {warning.Message}");
+}
+```
+
+A relative `location` resolves against the document's parent directory, not
+the current working directory. An absolute local path and a hierarchical
+`file` URI are also supported; unsupported URI schemes, opaque `file` URIs,
+non-local hosts, and query/fragment components are rejected. The optional
+document `[toml-schema].version` is compared against the resolved schema's
+declared version: a major-version mismatch fails discovery, while any other
+difference is reported as a warning rather than an error.
 
 ## Conformance
 

--- a/reference-implementations/dotnet/TomlSchema.Tests/SchemaDiscoveryTests.cs
+++ b/reference-implementations/dotnet/TomlSchema.Tests/SchemaDiscoveryTests.cs
@@ -1,0 +1,450 @@
+namespace TomlSchema.Tests;
+
+using Xunit;
+
+/// <summary>
+/// Tests document-driven schema discovery through <c>[toml-schema].location</c>,
+/// mirroring the behavioral cases covered by the Go and Rust reference implementations.
+/// </summary>
+public class SchemaDiscoveryTests
+{
+    [Fact]
+    public void DiscoversSchemaFromRelativeLocation()
+    {
+        var dir = CreateTestDirectory();
+        Write(dir, "schema.tosd", """
+            [toml-schema]
+            version = "1.0.0"
+
+            [elements.title]
+            type = "string"
+            """);
+        var documentPath = Write(dir, "document.toml", """
+            title = "Example"
+
+            [toml-schema]
+            version = "1.0.0"
+            location = "schema.tosd"
+            """);
+
+        var discovered = TomlSchema.Discover(documentPath);
+        var result = discovered.Validate();
+
+        Assert.True(result.IsValid, $"Validation failed: {string.Join(", ", result.Errors.Select(e => e.Message))}");
+        Assert.Empty(discovered.Warnings);
+    }
+
+    [Fact]
+    public void ValidateDocumentDiscoversAndValidatesInOneStep()
+    {
+        var dir = CreateTestDirectory();
+        Write(dir, "schema.tosd", """
+            [toml-schema]
+            version = "1.0.0"
+
+            [elements.title]
+            type = "string"
+            """);
+        var documentPath = Write(dir, "document.toml", """
+            title = "Example"
+
+            [toml-schema]
+            location = "schema.tosd"
+            """);
+
+        var result = TomlSchema.ValidateDocument(documentPath);
+
+        Assert.True(result.IsValid, $"Validation failed: {string.Join(", ", result.Errors.Select(e => e.Message))}");
+    }
+
+    [Fact]
+    public void ResolvesRelativeLocationAgainstDocumentDirectoryNotWorkingDirectory()
+    {
+        var dir = CreateTestDirectory();
+        Directory.CreateDirectory(Path.Combine(dir, "schemas"));
+        Directory.CreateDirectory(Path.Combine(dir, "documents"));
+        Write(dir, "schemas/schema.tosd", """
+            [toml-schema]
+            version = "1.0.0"
+
+            [elements.title]
+            type = "string"
+            """);
+        var documentPath = Write(dir, "documents/document.toml", """
+            title = "Example"
+
+            [toml-schema]
+            location = "../schemas/schema.tosd"
+            """);
+
+        var result = TomlSchema.ValidateDocument(documentPath);
+
+        Assert.True(result.IsValid, $"Validation failed: {string.Join(", ", result.Errors.Select(e => e.Message))}");
+    }
+
+    [Fact]
+    public void ResolvesAbsoluteLocalPathLocation()
+    {
+        var dir = CreateTestDirectory();
+        var schemaPath = Write(dir, "schema.tosd", """
+            [toml-schema]
+            version = "1.0.0"
+
+            [elements.title]
+            type = "string"
+            """);
+        var documentPath = Write(dir, "document.toml", $$"""
+            title = "Example"
+
+            [toml-schema]
+            location = "{{schemaPath.Replace("\\", "\\\\")}}"
+            """);
+
+        var result = TomlSchema.ValidateDocument(documentPath);
+
+        Assert.True(result.IsValid, $"Validation failed: {string.Join(", ", result.Errors.Select(e => e.Message))}");
+    }
+
+    [Fact]
+    public void ResolvesAbsoluteFileUriLocation()
+    {
+        var dir = CreateTestDirectory();
+        var schemaPath = Write(dir, "schema.tosd", """
+            [toml-schema]
+            version = "1.0.0"
+
+            [elements.title]
+            type = "string"
+            """);
+        var fileUri = new Uri(schemaPath).ToString();
+        var documentPath = Write(dir, "document.toml", $$"""
+            title = "Example"
+
+            [toml-schema]
+            location = "{{fileUri}}"
+            """);
+
+        var result = TomlSchema.ValidateDocument(documentPath);
+
+        Assert.True(result.IsValid, $"Validation failed: {string.Join(", ", result.Errors.Select(e => e.Message))}");
+    }
+
+    [Fact]
+    public void FailsDiscoveryWhenLocationMissing()
+    {
+        var dir = CreateTestDirectory();
+        var documentPath = Write(dir, "document.toml", """
+            title = "Example"
+
+            [toml-schema]
+            version = "1.0.0"
+            """);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => TomlSchema.Discover(documentPath));
+        Assert.Contains("does not contain [toml-schema].location", exception.Message);
+    }
+
+    [Fact]
+    public void FailsDiscoveryWhenLocationIsBlank()
+    {
+        var dir = CreateTestDirectory();
+        var documentPath = Write(dir, "document.toml", """
+            [toml-schema]
+            location = "   "
+            """);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => TomlSchema.Discover(documentPath));
+        Assert.Contains("does not contain [toml-schema].location", exception.Message);
+    }
+
+    [Fact]
+    public void FailsDiscoveryWhenMetadataHasNoTomlSchemaTable()
+    {
+        var dir = CreateTestDirectory();
+        var documentPath = Write(dir, "document.toml", """
+            title = "Example"
+            """);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => TomlSchema.Discover(documentPath));
+        Assert.Contains("does not contain [toml-schema].location", exception.Message);
+    }
+
+    [Fact]
+    public void RejectsNonScalarSchemaReferenceMetadata()
+    {
+        var dir = CreateTestDirectory();
+        var documentPath = Write(dir, "document.toml", """
+            [toml-schema]
+            location = ["schema.tosd"]
+            """);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => TomlSchema.Discover(documentPath));
+        Assert.Contains("must be a scalar value", exception.Message);
+    }
+
+    [Fact]
+    public void RejectsArrayOfTablesSchemaReferenceMetadata()
+    {
+        var dir = CreateTestDirectory();
+        var documentPath = Write(dir, "document.toml", """
+            [toml-schema]
+            location = "schema.tosd"
+
+            [[toml-schema.entries]]
+            name = "a"
+
+            [[toml-schema.entries]]
+            name = "b"
+            """);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => TomlSchema.Discover(documentPath));
+        Assert.Contains("must be a scalar value", exception.Message);
+    }
+
+    [Fact]
+    public void RejectsInlineTableSchemaReferenceMetadata()
+    {
+        var dir = CreateTestDirectory();
+        var documentPath = Write(dir, "document.toml", """
+            [toml-schema]
+            location = "schema.tosd"
+            meta = { author = "me" }
+            """);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => TomlSchema.Discover(documentPath));
+        Assert.Contains("must be a scalar value", exception.Message);
+    }
+
+    [Fact]
+    public void WarnsOnNonMajorVersionMismatch()
+    {
+        var dir = CreateTestDirectory();
+        Write(dir, "schema.tosd", """
+            [toml-schema]
+            version = "1.0.1"
+
+            [elements.title]
+            type = "string"
+            """);
+        var documentPath = Write(dir, "document.toml", """
+            title = "Example"
+
+            [toml-schema]
+            version = "1.0.0"
+            location = "schema.tosd"
+            """);
+
+        var discovered = TomlSchema.Discover(documentPath);
+
+        Assert.Single(discovered.Warnings);
+        Assert.Contains("1.0.0", discovered.Warnings[0].Message);
+        Assert.Contains("1.0.1", discovered.Warnings[0].Message);
+        Assert.True(discovered.Validate().IsValid);
+    }
+
+    [Fact]
+    public void FailsOnMajorVersionMismatch()
+    {
+        var dir = CreateTestDirectory();
+        Write(dir, "schema.tosd", """
+            [toml-schema]
+            version = "1.0.1"
+
+            [elements.title]
+            type = "string"
+            """);
+        var documentPath = Write(dir, "document.toml", """
+            title = "Example"
+
+            [toml-schema]
+            version = "2.0.0"
+            location = "schema.tosd"
+            """);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => TomlSchema.Discover(documentPath));
+        Assert.Contains("major version", exception.Message);
+    }
+
+    [Fact]
+    public void RejectsUnsupportedUriScheme()
+    {
+        var dir = CreateTestDirectory();
+        var documentPath = Write(dir, "document.toml", """
+            [toml-schema]
+            location = "https://example.com/schema.tosd"
+            """);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => TomlSchema.Discover(documentPath));
+        Assert.Contains("unsupported schema location URI scheme: https", exception.Message);
+    }
+
+    [Fact]
+    public void RejectsOpaqueFileUri()
+    {
+        var dir = CreateTestDirectory();
+        var documentPath = Write(dir, "document.toml", """
+            [toml-schema]
+            location = "file:schema.tosd"
+            """);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => TomlSchema.Discover(documentPath));
+        Assert.Contains("invalid file schema location", exception.Message);
+    }
+
+    [Fact]
+    public void RejectsFileUriWithQueryComponent()
+    {
+        var dir = CreateTestDirectory();
+        var documentPath = Write(dir, "document.toml", """
+            [toml-schema]
+            location = "file:///schema.tosd?version=1"
+            """);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => TomlSchema.Discover(documentPath));
+        Assert.Contains("invalid file schema location", exception.Message);
+    }
+
+    [Fact]
+    public void RejectsFileUriWithFragmentComponent()
+    {
+        var dir = CreateTestDirectory();
+        var documentPath = Write(dir, "document.toml", """
+            [toml-schema]
+            location = "file:///schema.tosd#fragment"
+            """);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => TomlSchema.Discover(documentPath));
+        Assert.Contains("invalid file schema location", exception.Message);
+    }
+
+    [Fact]
+    public void RejectsFileUriWithNonLocalHost()
+    {
+        var dir = CreateTestDirectory();
+        var documentPath = Write(dir, "document.toml", """
+            [toml-schema]
+            location = "file://example.com/schema.tosd"
+            """);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => TomlSchema.Discover(documentPath));
+        Assert.Contains("non-local host", exception.Message);
+    }
+
+    [Fact]
+    public void AcceptsFileUriWithLocalhostHost()
+    {
+        var dir = CreateTestDirectory();
+        var schemaPath = Write(dir, "schema.tosd", """
+            [toml-schema]
+            version = "1.0.0"
+
+            [elements.title]
+            type = "string"
+            """);
+        var hostQualifiedUri = "file://localhost" + schemaPath.Replace('\\', '/');
+        var documentPath = Write(dir, "document.toml", $$"""
+            title = "Example"
+
+            [toml-schema]
+            location = "{{hostQualifiedUri}}"
+            """);
+
+        var result = TomlSchema.ValidateDocument(documentPath);
+
+        Assert.True(result.IsValid, $"Validation failed: {string.Join(", ", result.Errors.Select(e => e.Message))}");
+    }
+
+    [Fact]
+    public void RejectsEncodedPathSeparatorInFileUri()
+    {
+        var dir = CreateTestDirectory();
+        var documentPath = Write(dir, "document.toml", """
+            [toml-schema]
+            location = "file:///tmp%2Fschema.tosd"
+            """);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => TomlSchema.Discover(documentPath));
+        Assert.Contains("encoded path separator", exception.Message);
+    }
+
+    [Fact]
+    public void RejectsInvalidUriReferenceCharacters()
+    {
+        var dir = CreateTestDirectory();
+        var documentPath = Write(dir, "document.toml", """
+            [toml-schema]
+            location = "sche ma.tosd"
+            """);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => TomlSchema.Discover(documentPath));
+        Assert.Contains("invalid [toml-schema].location URI", exception.Message);
+    }
+
+    [Fact]
+    public void IgnoresReservedTomlSchemaTableDuringApplicationValidationByDefault()
+    {
+        var dir = CreateTestDirectory();
+        Write(dir, "schema.tosd", """
+            [toml-schema]
+            version = "1.0.0"
+
+            [elements.title]
+            type = "string"
+            """);
+        var documentPath = Write(dir, "document.toml", """
+            title = "Example"
+
+            [toml-schema]
+            version = "1.0.0"
+            location = "schema.tosd"
+            extra-key = "ignored by discovery, reserved for validation"
+            """);
+
+        var result = TomlSchema.ValidateDocument(documentPath);
+
+        Assert.True(result.IsValid, $"Validation failed: {string.Join(", ", result.Errors.Select(e => e.Message))}");
+    }
+
+    [Fact]
+    public void ValidatesReservedTomlSchemaTableWhenExplicitlyModeled()
+    {
+        var dir = CreateTestDirectory();
+        Write(dir, "schema.tosd", """
+            [toml-schema]
+            version = "1.0.0"
+
+            [elements.title]
+            type = "string"
+
+            [elements."toml-schema"]
+            type = "table"
+            [elements."toml-schema".location]
+            type = "string"
+            """);
+        var documentPath = Write(dir, "document.toml", """
+            title = "Example"
+
+            [toml-schema]
+            location = "schema.tosd"
+            """);
+
+        var result = TomlSchema.ValidateDocument(documentPath);
+
+        Assert.True(result.IsValid, $"Validation failed: {string.Join(", ", result.Errors.Select(e => e.Message))}");
+    }
+
+    private static string CreateTestDirectory()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "toml-schema-discovery-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static string Write(string dir, string relativePath, string content)
+    {
+        var path = Path.Combine(dir, relativePath.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, content);
+        return path;
+    }
+}

--- a/reference-implementations/dotnet/TomlSchema/DiscoveredSchema.cs
+++ b/reference-implementations/dotnet/TomlSchema/DiscoveredSchema.cs
@@ -1,0 +1,36 @@
+namespace TomlSchema;
+
+using Tomlyn.Model;
+
+/// <summary>
+/// The outcome of discovering a schema from a TOML document via its reserved
+/// <c>[toml-schema].location</c>, as described in SPEC.md's
+/// "TOML Reference of a TOML Schema" section.
+/// </summary>
+/// <param name="Schema">The discovered and loaded schema.</param>
+/// <param name="Document">The parsed TOML document that referenced the schema.</param>
+/// <param name="Warnings">
+/// Non-fatal version-compatibility warnings produced while comparing the document's
+/// expected TOML Schema version against the resolved schema's declared version; empty
+/// when the document omits <c>[toml-schema].version</c> or the versions match exactly.
+/// </param>
+public sealed record DiscoveredSchema(
+    TomlSchema Schema,
+    TomlTable Document,
+    IReadOnlyList<ValidationWarning> Warnings)
+{
+    /// <summary>
+    /// Validates the discovered document against the discovered schema, including any
+    /// version-compatibility warnings produced during discovery.
+    /// </summary>
+    public ValidationResult Validate()
+    {
+        var result = Schema.Validate(Document);
+        if (Warnings.Count == 0)
+            return result;
+
+        var combined = new List<ValidationWarning>(Warnings);
+        combined.AddRange(result.Warnings);
+        return new ValidationResult(result.Errors, combined);
+    }
+}

--- a/reference-implementations/dotnet/TomlSchema/SchemaDiscovery.cs
+++ b/reference-implementations/dotnet/TomlSchema/SchemaDiscovery.cs
@@ -1,0 +1,186 @@
+namespace TomlSchema;
+
+using Tomlyn;
+using Tomlyn.Model;
+using System.Text.RegularExpressions;
+
+/// <summary>
+/// Discovers a schema referenced by a TOML document's reserved
+/// <c>[toml-schema].location</c>, following the resolution and
+/// version-compatibility rules of SPEC.md's
+/// "TOML Reference of a TOML Schema" section.
+/// </summary>
+internal static class SchemaDiscovery
+{
+    private static readonly Regex SemVerPattern = new(
+        @"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)"
+        + @"(?:-((?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)"
+        + @"(?:\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?"
+        + @"(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$",
+        RegexOptions.Compiled
+    );
+
+    public static DiscoveredSchema Discover(string documentPath)
+    {
+        var content = File.ReadAllText(documentPath);
+        var document = TomlSerializer.Deserialize<TomlTable>(content)
+            ?? throw new InvalidOperationException($"Failed to parse document: {documentPath}");
+
+        if (!document.TryGetValue("toml-schema", out var metadataObj) || metadataObj is not TomlTable metadata)
+            throw new InvalidOperationException("document does not contain [toml-schema].location");
+
+        foreach (var (key, value) in metadata)
+        {
+            if (!IsScalar(value))
+                throw new InvalidOperationException($"document [toml-schema].{key} must be a scalar value");
+        }
+
+        if (!metadata.TryGetValue("location", out var locationObj) || locationObj is not string location
+            || string.IsNullOrWhiteSpace(location))
+            throw new InvalidOperationException("document does not contain [toml-schema].location");
+
+        var schemaPath = ResolveSchemaLocation(documentPath, location.Trim());
+        var schema = TomlSchema.Load(schemaPath);
+
+        var warnings = new List<ValidationWarning>();
+        if (metadata.TryGetValue("version", out var versionObj))
+        {
+            if (versionObj is not string expectedVersion)
+                throw new InvalidOperationException("document [toml-schema].version must be a SemVer string");
+
+            var expectedMatch = SemVerPattern.Match(expectedVersion);
+            if (!expectedMatch.Success)
+                throw new InvalidOperationException(
+                    "document [toml-schema].version must use SemVer MAJOR.MINOR.PATCH syntax");
+
+            var actualMatch = SemVerPattern.Match(schema.Version);
+            var expectedMajor = expectedMatch.Groups[1].Value;
+            var actualMajor = actualMatch.Groups[1].Value;
+
+            if (expectedMajor != actualMajor)
+            {
+                throw new InvalidOperationException(
+                    $"document expects TOML Schema major version {expectedVersion}, "
+                    + $"but resolved schema uses {schema.Version}");
+            }
+
+            if (expectedVersion != schema.Version)
+            {
+                warnings.Add(new ValidationWarning(
+                    "$",
+                    $"document expects TOML Schema version {expectedVersion}, but resolved schema uses {schema.Version}",
+                    "schema-version"));
+            }
+        }
+
+        return new DiscoveredSchema(schema, document, warnings);
+    }
+
+    private static bool IsScalar(object? value) =>
+        value is not TomlTable && value is not TomlArray && value is not TomlTableArray;
+
+    private static string ResolveSchemaLocation(string documentPath, string location)
+    {
+        if (IsAbsoluteLocalPath(location))
+            return Path.GetFullPath(location);
+
+        if (HasInvalidUriReferenceCharacter(location))
+            throw new InvalidOperationException($"invalid [toml-schema].location URI: {location}");
+
+        Uri reference;
+        try
+        {
+            reference = new Uri(location, UriKind.RelativeOrAbsolute);
+        }
+        catch (UriFormatException ex)
+        {
+            throw new InvalidOperationException($"invalid [toml-schema].location URI: {location}: {ex.Message}");
+        }
+
+        var absoluteDocumentPath = Path.GetFullPath(documentPath);
+        var baseUri = new Uri("file://" + ToUriPath(absoluteDocumentPath), UriKind.Absolute);
+        Uri resolved;
+        try
+        {
+            resolved = reference.IsAbsoluteUri ? reference : new Uri(baseUri, reference);
+        }
+        catch (UriFormatException)
+        {
+            // A malformed absolute reference, such as an opaque "file:schema.tosd" URI that lacks
+            // the authority component a hierarchical file URI requires, fails during resolution.
+            throw new InvalidOperationException($"invalid file schema location: {location}");
+        }
+
+        if (!string.Equals(resolved.Scheme, "file", StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException($"unsupported schema location URI scheme: {resolved.Scheme}");
+
+        return LocalPathFromFileUri(location, resolved);
+    }
+
+    private static string ToUriPath(string absolutePath)
+    {
+        var normalized = absolutePath.Replace('\\', '/');
+        return normalized.StartsWith('/') ? normalized : "/" + normalized;
+    }
+
+    private static bool IsAbsoluteLocalPath(string location)
+    {
+        if (location.StartsWith('/'))
+            return true;
+        if (location.Length >= 3 && char.IsLetter(location[0]) && location[1] == ':'
+            && (location[2] == '\\' || location[2] == '/'))
+            return true;
+        return false;
+    }
+
+    private static bool HasInvalidUriReferenceCharacter(string reference)
+    {
+        foreach (var character in reference)
+        {
+            if (character <= ' ' || character == 0x7f)
+                return true;
+            switch (character)
+            {
+                case '\\':
+                case '"':
+                case '<':
+                case '>':
+                case '^':
+                case '`':
+                case '{':
+                case '|':
+                case '}':
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    private static string LocalPathFromFileUri(string location, Uri uri)
+    {
+        if (!string.IsNullOrEmpty(uri.UserInfo) || !string.IsNullOrEmpty(uri.Query)
+            || !string.IsNullOrEmpty(uri.Fragment))
+            throw new InvalidOperationException($"invalid file schema location: {location}");
+
+        var host = uri.Host;
+        if (!string.IsNullOrEmpty(host) && !string.Equals(host, "localhost", StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException($"file URI has a non-local host: {location}");
+
+        // System.Uri decodes %2F/%5C while parsing, so an encoded separator can only be detected
+        // by inspecting the original, still-escaped [toml-schema].location text.
+        var lowerLocation = location.ToLowerInvariant();
+        if (lowerLocation.Contains("%2f") || lowerLocation.Contains("%5c"))
+            throw new InvalidOperationException($"file URI contains an encoded path separator: {location}");
+
+        // AbsolutePath (not LocalPath) is used because LocalPath renders a UNC-style
+        // "\\host\path" form whenever a host component is present, even a benign "localhost".
+        var path = uri.AbsolutePath;
+        if (string.IsNullOrEmpty(path) || path.Contains('\0'))
+            throw new InvalidOperationException($"file URI does not contain a safe path: {location}");
+
+        if (!Path.IsPathRooted(path))
+            throw new InvalidOperationException($"file URI path is not absolute: {location}");
+
+        return Path.GetFullPath(path);
+    }
+}

--- a/reference-implementations/dotnet/TomlSchema/TomlSchema.cs
+++ b/reference-implementations/dotnet/TomlSchema/TomlSchema.cs
@@ -55,6 +55,33 @@ public class TomlSchema
         return validator.Validate(document);
     }
 
+    /// <summary>
+    /// Discovers and loads the schema referenced by a TOML document's reserved
+    /// <c>[toml-schema].location</c>, following the resolution and version-compatibility
+    /// rules of SPEC.md's "TOML Reference of a TOML Schema" section.
+    /// </summary>
+    /// <remarks>
+    /// A relative <c>location</c> is resolved against <paramref name="documentPath"/>'s
+    /// parent, not the current working directory. An absolute local path or a
+    /// <c>file</c> URI with a hierarchical, local path is also supported. Unsupported URI
+    /// schemes, opaque <c>file</c> URIs, non-local hosts, query/fragment components, and
+    /// encoded path separators are rejected. When the document declares an optional
+    /// <c>[toml-schema].version</c>, a major-version mismatch against the resolved schema
+    /// fails discovery, while any other version difference is reported as a warning on the
+    /// returned <see cref="DiscoveredSchema"/>.
+    /// </remarks>
+    /// <param name="documentPath">The TOML document whose schema-reference metadata is discovered.</param>
+    /// <returns>The discovered schema, the parsed document, and any version-compatibility warnings.</returns>
+    public static DiscoveredSchema Discover(string documentPath) => SchemaDiscovery.Discover(documentPath);
+
+    /// <summary>
+    /// Discovers the schema referenced by a TOML document and validates that same document
+    /// against it in one step, without parsing the document twice.
+    /// </summary>
+    /// <param name="documentPath">The TOML document to discover a schema for and validate.</param>
+    /// <returns>The validation result, including any discovery version-compatibility warnings.</returns>
+    public static ValidationResult ValidateDocument(string documentPath) => Discover(documentPath).Validate();
+
     /// <summary>Gets the schema language version.</summary>
     public string Version => _version;
 

--- a/reference-implementations/java/README.md
+++ b/reference-implementations/java/README.md
@@ -3,7 +3,8 @@
 Java 25 reference library targeting the current, unreleased
 [TOML Schema 1.0.0](../../SPEC.md). It parses TOML with
 [Tomlj](https://github.com/tomlj/tomlj) `1.1.1` (TOML 1.0) and validates the
-parsed data model against a `.tosd` schema.
+parsed data model against a `.tosd` schema, including document-driven schema
+discovery through `[toml-schema].location`.
 
 - Coordinates: `org.tomlschema:toml-schema`
 - Java package: `org.tomlschema`
@@ -50,6 +51,34 @@ result.warnings(); // warning-only diagnostics, including deprecations
 
 `TomlSchema.defaultValue(...)` and `typeDefaultValue(...)` expose effective
 default annotations. Validation never inserts defaults or mutates parsed TOML.
+
+### Schema discovery
+
+`TomlSchema.discover(Path)` and `TomlSchema.validateDocument(Path)` load the
+schema referenced by a TOML document's reserved `[toml-schema].location`,
+following the resolution rules in [`SPEC.md`](../../SPEC.md#toml-reference-of-a-toml-schema):
+
+```java
+import java.nio.file.Path;
+import org.tomlschema.DiscoveredSchema;
+import org.tomlschema.TomlSchema;
+import org.tomlschema.ValidationResult;
+
+// Discover the schema and validate the document in one step, without parsing it twice.
+ValidationResult result = TomlSchema.validateDocument(Path.of("config.toml"));
+
+// Or inspect the discovered schema, parsed document, and any version warnings first.
+DiscoveredSchema discovered = TomlSchema.discover(Path.of("config.toml"));
+discovered.warnings(); // non-fatal [toml-schema].version compatibility warnings
+```
+
+A relative `location` resolves against the document's parent directory, not
+the current working directory. An absolute local path and a hierarchical
+`file` URI are also supported; unsupported URI schemes, opaque `file` URIs,
+non-local hosts, and query/fragment components are rejected. The optional
+document `[toml-schema].version` is compared against the resolved schema's
+declared version: a major-version mismatch fails discovery, while any other
+difference is reported as a warning rather than an error.
 
 ## Conformance
 

--- a/reference-implementations/java/src/main/java/org/tomlschema/DiscoveredSchema.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/DiscoveredSchema.java
@@ -1,0 +1,39 @@
+package org.tomlschema;
+
+import org.tomlj.TomlParseResult;
+
+import java.util.List;
+
+/**
+ * The outcome of discovering a schema from a TOML document via its reserved
+ * {@code [toml-schema].location}, as described in SPEC.md's
+ * "TOML Reference of a TOML Schema" section.
+ *
+ * @param schema the discovered and loaded schema
+ * @param document the parsed TOML document that referenced the schema
+ * @param warnings non-fatal version-compatibility warnings produced while comparing
+ *                  the document's expected TOML Schema version against the resolved
+ *                  schema's declared version; empty when the document omits
+ *                  {@code [toml-schema].version} or the versions match exactly
+ */
+public record DiscoveredSchema(TomlSchema schema, TomlParseResult document, List<ValidationWarning> warnings) {
+    public DiscoveredSchema {
+        warnings = List.copyOf(warnings);
+    }
+
+    /**
+     * Validates the discovered document against the discovered schema, including any
+     * version-compatibility warnings produced during discovery.
+     *
+     * @return the combined validation result
+     */
+    public ValidationResult validate() {
+        ValidationResult result = schema.validate(document);
+        if (warnings.isEmpty()) {
+            return result;
+        }
+        List<ValidationWarning> combined = new java.util.ArrayList<>(warnings);
+        combined.addAll(result.warnings());
+        return new ValidationResult(result.errors(), combined);
+    }
+}

--- a/reference-implementations/java/src/main/java/org/tomlschema/SchemaDiscovery.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/SchemaDiscovery.java
@@ -1,0 +1,168 @@
+package org.tomlschema;
+
+import org.tomlj.Toml;
+import org.tomlj.TomlArray;
+import org.tomlj.TomlParseResult;
+import org.tomlj.TomlTable;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Discovers a schema referenced by a TOML document's reserved
+ * {@code [toml-schema].location}, following the resolution and
+ * version-compatibility rules of SPEC.md's
+ * "TOML Reference of a TOML Schema" section.
+ */
+final class SchemaDiscovery {
+    private SchemaDiscovery() {
+    }
+
+    static DiscoveredSchema discover(Path documentPath) throws IOException {
+        TomlParseResult document = Toml.parse(documentPath);
+        if (document.hasErrors()) {
+            throw new SchemaException("Unable to parse document " + documentPath + ": "
+                    + formatParseErrors(document));
+        }
+
+        TomlTable metadata = document.getTable("toml-schema");
+        if (metadata == null) {
+            throw new SchemaException("document does not contain [toml-schema].location");
+        }
+        for (String key : metadata.keySet()) {
+            if (!isScalar(metadata.get(key))) {
+                throw new SchemaException("document [toml-schema]." + key + " must be a scalar value");
+            }
+        }
+        Object rawLocation = metadata.get("location");
+        String location = rawLocation instanceof String value ? value.strip() : "";
+        if (location.isEmpty()) {
+            throw new SchemaException("document does not contain [toml-schema].location");
+        }
+
+        Path schemaPath = resolveSchemaLocation(documentPath, location);
+        TomlSchema schema = TomlSchema.load(schemaPath);
+
+        List<ValidationWarning> warnings = new ArrayList<>();
+        if (metadata.contains("version")) {
+            TomlSchemaVersion.Version expected = TomlSchemaVersion.parseDocumentVersion(metadata.get("version"));
+            TomlSchemaVersion.Version actual = TomlSchemaVersion.parseDocumentVersion(schema.version());
+            if (!expected.major().equals(actual.major())) {
+                throw new SchemaException("document expects TOML Schema major version " + expected.value()
+                        + ", but resolved schema uses " + schema.version());
+            }
+            if (!expected.value().equals(schema.version())) {
+                warnings.add(new ValidationWarning("schema-version", "$",
+                        "document expects TOML Schema version " + expected.value()
+                                + ", but resolved schema uses " + schema.version()));
+            }
+        }
+
+        return new DiscoveredSchema(schema, document, warnings);
+    }
+
+    private static boolean isScalar(Object value) {
+        return !(value instanceof TomlArray) && !(value instanceof TomlTable);
+    }
+
+    private static Path resolveSchemaLocation(Path documentPath, String location) {
+        if (isAbsoluteLocalPath(location)) {
+            return Path.of(location).normalize();
+        }
+        if (hasInvalidUriReferenceCharacter(location)) {
+            throw new SchemaException("invalid [toml-schema].location URI: " + location);
+        }
+        URI reference;
+        try {
+            reference = new URI(location);
+        } catch (URISyntaxException e) {
+            throw new SchemaException("invalid [toml-schema].location URI: " + location + ": " + e.getMessage());
+        }
+        URI base = documentPath.toAbsolutePath().normalize().toUri();
+        URI resolved = base.resolve(reference);
+        if (!"file".equalsIgnoreCase(resolved.getScheme())) {
+            throw new SchemaException("unsupported schema location URI scheme: " + resolved.getScheme());
+        }
+        return localPathFromFileUri(location, resolved);
+    }
+
+    private static boolean isAbsoluteLocalPath(String location) {
+        if (location.startsWith("/")) {
+            return true;
+        }
+        if (location.length() >= 3 && Character.isLetter(location.charAt(0)) && location.charAt(1) == ':'
+                && (location.charAt(2) == '\\' || location.charAt(2) == '/')) {
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean hasInvalidUriReferenceCharacter(String reference) {
+        for (int i = 0; i < reference.length(); i++) {
+            char character = reference.charAt(i);
+            if (character <= ' ' || character == 0x7f) {
+                return true;
+            }
+            switch (character) {
+                case '\\':
+                case '"':
+                case '<':
+                case '>':
+                case '^':
+                case '`':
+                case '{':
+                case '|':
+                case '}':
+                    return true;
+                default:
+                    break;
+            }
+        }
+        return false;
+    }
+
+    private static Path localPathFromFileUri(String location, URI uri) {
+        if (uri.isOpaque() || uri.getUserInfo() != null || uri.getRawQuery() != null || uri.getRawFragment() != null) {
+            throw new SchemaException("invalid file schema location: " + location);
+        }
+        String host = uri.getHost();
+        if (host != null && !host.isEmpty() && !"localhost".equalsIgnoreCase(host)) {
+            throw new SchemaException("file URI has a non-local host: " + location);
+        }
+        String rawPath = uri.getRawPath();
+        if (rawPath == null) {
+            throw new SchemaException("invalid file schema location: " + location);
+        }
+        String lowerRawPath = rawPath.toLowerCase(Locale.ROOT);
+        if (lowerRawPath.contains("%2f") || lowerRawPath.contains("%5c")) {
+            throw new SchemaException("file URI contains an encoded path separator: " + location);
+        }
+        String path = uri.getPath();
+        if (path == null || path.isEmpty() || path.indexOf('\0') >= 0) {
+            throw new SchemaException("file URI does not contain a safe path: " + location);
+        }
+        if (path.length() >= 3 && path.charAt(0) == '/' && Character.isLetter(path.charAt(1)) && path.charAt(2) == ':') {
+            path = path.substring(1);
+        }
+        try {
+            Path resolvedPath = Path.of(path);
+            if (!resolvedPath.isAbsolute()) {
+                throw new SchemaException("file URI path is not absolute: " + location);
+            }
+            return resolvedPath.normalize();
+        } catch (InvalidPathException e) {
+            throw new SchemaException("invalid file schema location: " + location, e);
+        }
+    }
+
+    private static String formatParseErrors(TomlParseResult document) {
+        return document.errors().stream().map(Object::toString)
+                .reduce((left, right) -> left + "; " + right).orElse("");
+    }
+}

--- a/reference-implementations/java/src/main/java/org/tomlschema/TomlSchema.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/TomlSchema.java
@@ -66,6 +66,46 @@ public final class TomlSchema {
         return new TomlSchemaValidator(this).validate(document);
     }
 
+    /**
+     * Discovers and loads the schema referenced by a TOML document's reserved
+     * {@code [toml-schema].location}, following the resolution and
+     * version-compatibility rules of SPEC.md's
+     * "TOML Reference of a TOML Schema" section.
+     *
+     * <p>A relative {@code location} is resolved against {@code documentPath}'s
+     * parent, not the current working directory. An absolute local path or a
+     * {@code file} URI with a hierarchical, local path is also supported.
+     * Unsupported URI schemes, opaque {@code file} URIs, non-local hosts,
+     * query/fragment components, and encoded path separators are rejected.
+     * When the document declares an optional {@code [toml-schema].version}, a
+     * major-version mismatch against the resolved schema fails discovery,
+     * while any other version difference is reported as a warning on the
+     * returned {@link DiscoveredSchema}.
+     *
+     * @param documentPath the TOML document whose schema-reference metadata is discovered
+     * @return the discovered schema, the parsed document, and any version-compatibility warnings
+     * @throws IOException if the document cannot be read or parsed
+     * @throws SchemaException if the schema-reference metadata is missing or invalid, the
+     *         location cannot be resolved safely, or the schema versions are incompatible
+     */
+    public static DiscoveredSchema discover(Path documentPath) throws IOException {
+        return SchemaDiscovery.discover(documentPath);
+    }
+
+    /**
+     * Discovers the schema referenced by a TOML document and validates that same
+     * document against it in one step, without parsing the document twice.
+     *
+     * @param documentPath the TOML document to discover a schema for and validate
+     * @return the validation result, including any discovery version-compatibility warnings
+     * @throws IOException if the document cannot be read or parsed
+     * @throws SchemaException if the schema-reference metadata is missing or invalid, the
+     *         location cannot be resolved safely, or the schema versions are incompatible
+     */
+    public static ValidationResult validateDocument(Path documentPath) throws IOException {
+        return discover(documentPath).validate();
+    }
+
     Path source() {
         return source;
     }

--- a/reference-implementations/java/src/test/java/org/tomlschema/SchemaDiscoveryTest.java
+++ b/reference-implementations/java/src/test/java/org/tomlschema/SchemaDiscoveryTest.java
@@ -1,0 +1,412 @@
+package org.tomlschema;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests document-driven schema discovery through {@code [toml-schema].location},
+ * mirroring the behavioral cases covered by the Go and Rust reference implementations.
+ */
+class SchemaDiscoveryTest {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void discoversSchemaFromRelativeLocation() throws IOException {
+        write("schema.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.title]
+                type = "string"
+                """);
+        Path document = write("document.toml", """
+                title = "Example"
+
+                [toml-schema]
+                version = "1.0.0"
+                location = "schema.tosd"
+                """);
+
+        DiscoveredSchema discovered = TomlSchema.discover(document);
+        ValidationResult result = discovered.validate();
+
+        assertTrue(result.isValid(), () -> result.errors().toString());
+        assertTrue(discovered.warnings().isEmpty());
+    }
+
+    @Test
+    void validateDocumentDiscoversAndValidatesInOneStep() throws IOException {
+        write("schema.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.title]
+                type = "string"
+                """);
+        Path document = write("document.toml", """
+                title = "Example"
+
+                [toml-schema]
+                location = "schema.tosd"
+                """);
+
+        ValidationResult result = TomlSchema.validateDocument(document);
+
+        assertTrue(result.isValid(), () -> result.errors().toString());
+    }
+
+    @Test
+    void resolvesRelativeLocationAgainstDocumentDirectoryNotWorkingDirectory() throws IOException {
+        Files.createDirectories(tempDir.resolve("schemas"));
+        Files.createDirectories(tempDir.resolve("documents"));
+        write("schemas/schema.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.title]
+                type = "string"
+                """);
+        Path document = write("documents/document.toml", """
+                title = "Example"
+
+                [toml-schema]
+                location = "../schemas/schema.tosd"
+                """);
+
+        ValidationResult result = TomlSchema.validateDocument(document);
+
+        assertTrue(result.isValid(), () -> result.errors().toString());
+    }
+
+    @Test
+    void resolvesAbsoluteLocalPathLocation() throws IOException {
+        Path schema = write("schema.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.title]
+                type = "string"
+                """);
+        Path document = write("document.toml", """
+                title = "Example"
+
+                [toml-schema]
+                location = "%s"
+                """.formatted(schema.toAbsolutePath().toString().replace("\\", "\\\\")));
+
+        ValidationResult result = TomlSchema.validateDocument(document);
+
+        assertTrue(result.isValid(), () -> result.errors().toString());
+    }
+
+    @Test
+    void resolvesAbsoluteFileUriLocation() throws IOException {
+        Path schema = write("schema.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.title]
+                type = "string"
+                """);
+        String fileUri = schema.toAbsolutePath().normalize().toUri().toString();
+        Path document = write("document.toml", """
+                title = "Example"
+
+                [toml-schema]
+                location = "%s"
+                """.formatted(fileUri));
+
+        ValidationResult result = TomlSchema.validateDocument(document);
+
+        assertTrue(result.isValid(), () -> result.errors().toString());
+    }
+
+    @Test
+    void failsDiscoveryWhenLocationMissing() throws IOException {
+        Path document = write("document.toml", """
+                title = "Example"
+
+                [toml-schema]
+                version = "1.0.0"
+                """);
+
+        SchemaException exception = assertThrows(SchemaException.class, () -> TomlSchema.discover(document));
+        assertTrue(exception.getMessage().contains("does not contain [toml-schema].location"),
+                exception.getMessage());
+    }
+
+    @Test
+    void failsDiscoveryWhenLocationIsBlank() throws IOException {
+        Path document = write("document.toml", """
+                [toml-schema]
+                location = "   "
+                """);
+
+        SchemaException exception = assertThrows(SchemaException.class, () -> TomlSchema.discover(document));
+        assertTrue(exception.getMessage().contains("does not contain [toml-schema].location"),
+                exception.getMessage());
+    }
+
+    @Test
+    void failsDiscoveryWhenMetadataHasNoTomlSchemaTable() throws IOException {
+        Path document = write("document.toml", """
+                title = "Example"
+                """);
+
+        SchemaException exception = assertThrows(SchemaException.class, () -> TomlSchema.discover(document));
+        assertTrue(exception.getMessage().contains("does not contain [toml-schema].location"),
+                exception.getMessage());
+    }
+
+    @Test
+    void rejectsNonScalarSchemaReferenceMetadata() throws IOException {
+        Path document = write("document.toml", """
+                [toml-schema]
+                location = ["schema.tosd"]
+                """);
+
+        SchemaException exception = assertThrows(SchemaException.class, () -> TomlSchema.discover(document));
+        assertTrue(exception.getMessage().contains("must be a scalar value"), exception.getMessage());
+    }
+
+    @Test
+    void rejectsArrayOfTablesSchemaReferenceMetadata() throws IOException {
+        Path document = write("document.toml", """
+                [toml-schema]
+                location = "schema.tosd"
+
+                [[toml-schema.entries]]
+                name = "a"
+
+                [[toml-schema.entries]]
+                name = "b"
+                """);
+
+        SchemaException exception = assertThrows(SchemaException.class, () -> TomlSchema.discover(document));
+        assertTrue(exception.getMessage().contains("must be a scalar value"), exception.getMessage());
+    }
+
+    @Test
+    void rejectsInlineTableSchemaReferenceMetadata() throws IOException {
+        Path document = write("document.toml", """
+                [toml-schema]
+                location = "schema.tosd"
+                meta = { author = "me" }
+                """);
+
+        SchemaException exception = assertThrows(SchemaException.class, () -> TomlSchema.discover(document));
+        assertTrue(exception.getMessage().contains("must be a scalar value"), exception.getMessage());
+    }
+
+    @Test
+    void warnsOnNonMajorVersionMismatch() throws IOException {
+        write("schema.tosd", """
+                [toml-schema]
+                version = "1.0.1"
+
+                [elements.title]
+                type = "string"
+                """);
+        Path document = write("document.toml", """
+                title = "Example"
+
+                [toml-schema]
+                version = "1.0.0"
+                location = "schema.tosd"
+                """);
+
+        DiscoveredSchema discovered = TomlSchema.discover(document);
+
+        assertEquals(1, discovered.warnings().size());
+        assertTrue(discovered.warnings().get(0).message().contains("1.0.0"));
+        assertTrue(discovered.warnings().get(0).message().contains("1.0.1"));
+        assertTrue(discovered.validate().isValid());
+    }
+
+    @Test
+    void failsOnMajorVersionMismatch() throws IOException {
+        write("schema.tosd", """
+                [toml-schema]
+                version = "1.0.1"
+
+                [elements.title]
+                type = "string"
+                """);
+        Path document = write("document.toml", """
+                title = "Example"
+
+                [toml-schema]
+                version = "2.0.0"
+                location = "schema.tosd"
+                """);
+
+        SchemaException exception = assertThrows(SchemaException.class, () -> TomlSchema.discover(document));
+        assertTrue(exception.getMessage().contains("major version"), exception.getMessage());
+    }
+
+    @Test
+    void rejectsUnsupportedUriScheme() throws IOException {
+        Path document = write("document.toml", """
+                [toml-schema]
+                location = "https://example.com/schema.tosd"
+                """);
+
+        SchemaException exception = assertThrows(SchemaException.class, () -> TomlSchema.discover(document));
+        assertTrue(exception.getMessage().contains("unsupported schema location URI scheme: https"),
+                exception.getMessage());
+    }
+
+    @Test
+    void rejectsOpaqueFileUri() throws IOException {
+        Path document = write("document.toml", """
+                [toml-schema]
+                location = "file:schema.tosd"
+                """);
+
+        SchemaException exception = assertThrows(SchemaException.class, () -> TomlSchema.discover(document));
+        assertTrue(exception.getMessage().contains("invalid file schema location"), exception.getMessage());
+    }
+
+    @Test
+    void rejectsFileUriWithQueryComponent() throws IOException {
+        Path document = write("document.toml", """
+                [toml-schema]
+                location = "file:///schema.tosd?version=1"
+                """);
+
+        SchemaException exception = assertThrows(SchemaException.class, () -> TomlSchema.discover(document));
+        assertTrue(exception.getMessage().contains("invalid file schema location"), exception.getMessage());
+    }
+
+    @Test
+    void rejectsFileUriWithFragmentComponent() throws IOException {
+        Path document = write("document.toml", """
+                [toml-schema]
+                location = "file:///schema.tosd#fragment"
+                """);
+
+        SchemaException exception = assertThrows(SchemaException.class, () -> TomlSchema.discover(document));
+        assertTrue(exception.getMessage().contains("invalid file schema location"), exception.getMessage());
+    }
+
+    @Test
+    void rejectsFileUriWithNonLocalHost() throws IOException {
+        Path document = write("document.toml", """
+                [toml-schema]
+                location = "file://example.com/schema.tosd"
+                """);
+
+        SchemaException exception = assertThrows(SchemaException.class, () -> TomlSchema.discover(document));
+        assertTrue(exception.getMessage().contains("non-local host"), exception.getMessage());
+    }
+
+    @Test
+    void acceptsFileUriWithLocalhostHost() throws IOException {
+        Path schema = write("schema.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.title]
+                type = "string"
+                """);
+        String hostQualifiedUri = "file://localhost" + schema.toAbsolutePath().normalize();
+        Path document = write("document.toml", """
+                title = "Example"
+
+                [toml-schema]
+                location = "%s"
+                """.formatted(hostQualifiedUri));
+
+        ValidationResult result = TomlSchema.validateDocument(document);
+
+        assertTrue(result.isValid(), () -> result.errors().toString());
+    }
+
+    @Test
+    void rejectsEncodedPathSeparatorInFileUri() throws IOException {
+        Path document = write("document.toml", """
+                [toml-schema]
+                location = "file:///tmp%2Fschema.tosd"
+                """);
+
+        SchemaException exception = assertThrows(SchemaException.class, () -> TomlSchema.discover(document));
+        assertTrue(exception.getMessage().contains("encoded path separator"), exception.getMessage());
+    }
+
+    @Test
+    void rejectsInvalidUriReferenceCharacters() throws IOException {
+        Path document = write("document.toml", """
+                [toml-schema]
+                location = "sche ma.tosd"
+                """);
+
+        SchemaException exception = assertThrows(SchemaException.class, () -> TomlSchema.discover(document));
+        assertTrue(exception.getMessage().contains("invalid [toml-schema].location URI"), exception.getMessage());
+    }
+
+    @Test
+    void ignoresReservedTomlSchemaTableDuringApplicationValidationByDefault() throws IOException {
+        write("schema.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.title]
+                type = "string"
+                """);
+        Path document = write("document.toml", """
+                title = "Example"
+
+                [toml-schema]
+                version = "1.0.0"
+                location = "schema.tosd"
+                extra-key = "ignored by discovery, reserved for validation"
+                """);
+
+        ValidationResult result = TomlSchema.validateDocument(document);
+
+        assertTrue(result.isValid(), () -> result.errors().toString());
+    }
+
+    @Test
+    void validatesReservedTomlSchemaTableWhenExplicitlyModeled() throws IOException {
+        write("schema.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.title]
+                type = "string"
+
+                [elements."toml-schema"]
+                type = "table"
+                [elements."toml-schema".location]
+                type = "string"
+                """);
+        Path document = write("document.toml", """
+                title = "Example"
+
+                [toml-schema]
+                location = "schema.tosd"
+                """);
+
+        ValidationResult result = TomlSchema.validateDocument(document);
+
+        assertTrue(result.isValid(), () -> result.errors().toString());
+    }
+
+    private Path write(String fileName, String content) throws IOException {
+        Path path = tempDir.resolve(fileName);
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, content, StandardCharsets.UTF_8);
+        return path;
+    }
+}


### PR DESCRIPTION
## Summary

Brings the Java and .NET reference libraries to parity with the Go and Rust reference implementations by adding document-driven schema discovery through `[toml-schema].location`, per SPEC.md's "TOML Reference of a TOML Schema" section (SPEC.md lines 1573-1622).

## New APIs

- **Java**: `TomlSchema.discover(Path)` → `DiscoveredSchema`, and `TomlSchema.validateDocument(Path)` for a one-step discover-and-validate.
- **.NET**: `TomlSchema.Discover(string)` → `DiscoveredSchema`, and `TomlSchema.ValidateDocument(string)` for a one-step discover-and-validate.

Both parse the document only once — `validateDocument`/`ValidateDocument` reuse the already-parsed document from discovery instead of parsing twice.

## Resolution and safety rules (matching Go/Rust)

- `[toml-schema]` metadata must contain only scalar values; tables, arrays, and arrays of tables under it are rejected.
- `location` is required and non-blank.
- A relative `location` resolves against the *document's* parent directory, not the process working directory.
- Absolute local paths and hierarchical `file://` URIs (including `file://localhost/...`) are supported.
- Rejected: unsupported URI schemes, opaque `file:` URIs, non-local hosts, query/fragment components, encoded path separators (`%2F`/`%5C`), and invalid URI-reference characters.
- Optional `[toml-schema].version` is compared against the resolved schema's declared version: a major-version mismatch fails discovery; any other difference (minor/patch/pre-release/build) is reported as a non-fatal warning on `DiscoveredSchema`.
- The reserved `[toml-schema]` table is still ignored during application validation by default, and only validated when a schema explicitly models `[elements."toml-schema"]`.

## Bug fix found in review

Tomlyn (the .NET TOML parser) represents `[[toml-schema.*]]` arrays of tables as `TomlTableArray`, a type distinct from `TomlArray`/`TomlTable`. The initial scalar check only excluded `TomlTable`/`TomlArray`, so an array-of-tables under `[toml-schema]` would have slipped past the mandatory scalar-only rule. Fixed by explicitly rejecting `TomlTableArray` too, with a new regression test (mirrored in both the Java and .NET test suites, since Tomlj already represents array-of-tables as `TomlArray` and was already covered).

## Testing

- `mvn -f reference-implementations/java/pom.xml test` — 107 tests, 0 failures.
- `dotnet test` (in `reference-implementations/dotnet`) — 50 tests, 0 failures.

## Scope

Independent of the website-truth-claims PR — only adds discovery to Java/.NET plus doc updates in `REFERENCE_IMPLEMENTATIONS.md` and the Java/.NET READMEs. No schema-extraction support is added (out of scope, matching the request).

Co-authored-by: Copilot App