### PR TITLE
Add Python reference implementation

### DIFF
--- a/.github/workflows/reference-implementations.yml
+++ b/.github/workflows/reference-implementations.yml
@@ -70,6 +70,25 @@ jobs:
       - name: Test
         run: dotnet test reference-implementations/dotnet/TomlSchema.sln -v normal
 
+  python:
+    name: Python reference implementation
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install library
+        run: python -m pip install reference-implementations/python
+
+      - name: Test
+        run: python -m unittest discover -s reference-implementations/python/tests -v
+
   rust:
     name: Rust reference implementation
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Java 25](https://img.shields.io/badge/Java-25-007396)](REFERENCE_IMPLEMENTATIONS.md#java)
 [![Go 1.26.6](https://img.shields.io/badge/Go-1.26.6-00ADD8)](REFERENCE_IMPLEMENTATIONS.md#go)
 [![.NET 9](https://img.shields.io/badge/.NET-9.0-512BD4)](REFERENCE_IMPLEMENTATIONS.md#net)
+[![Python 3.11](https://img.shields.io/badge/Python-3.11+-3776AB)](REFERENCE_IMPLEMENTATIONS.md#python)
 [![Rust 1.75](https://img.shields.io/badge/Rust-1.75-dea584)](REFERENCE_IMPLEMENTATIONS.md#rust)
 
 TOML Schema is a TOML-based schema language for describing and validating the structure, names, value types, and common semantic relationships of TOML configuration files.
@@ -69,7 +70,7 @@ type = "table"
 
 ## Reference implementations
 
-Java, Go, .NET, and Rust reference libraries live under `reference-implementations/`.
+Java, Go, .NET, Python, and Rust reference libraries live under `reference-implementations/`.
 The Rust implementation provides the canonical `toml-schema` CLI. See
 [Reference implementations](REFERENCE_IMPLEMENTATIONS.md) for implementation
 status, CLI usage, schema extraction, and conformance expectations.

--- a/REFERENCE_IMPLEMENTATIONS.md
+++ b/REFERENCE_IMPLEMENTATIONS.md
@@ -1,6 +1,6 @@
 # Reference Implementations
 
-Build and use the TOML Schema reference libraries in Java, Go, .NET, and Rust. Rust also
+Build and use the TOML Schema reference libraries in Java, Go, .NET, Python, and Rust. Rust also
 provides the canonical `toml-schema` command-line interface for validation, schema
 discovery through `[toml-schema].location`, and starter-schema extraction.
 
@@ -11,6 +11,7 @@ discovery through `[toml-schema].location`, and starter-schema extraction.
 | Java | [`reference-implementations/java`](reference-implementations/java) | Java 25 and Maven | Library, schema discovery |
 | Go | [`reference-implementations/go`](reference-implementations/go) | Go 1.26.6 | Library, schema discovery, schema extraction |
 | .NET | [`reference-implementations/dotnet`](reference-implementations/dotnet) | .NET 9.0 | Library, schema discovery |
+| Python | [`reference-implementations/python`](reference-implementations/python) | Python 3.11+ | Library, schema discovery |
 | Rust | [`reference-implementations/rust`](reference-implementations/rust) | Rust 1.75 and Cargo | Library, canonical CLI, schema discovery, schema extraction |
 
 The implementations use TOML 1.0 parsers and share the same conformance expectations.
@@ -166,6 +167,51 @@ returned `DiscoveredSchema`.
 
 The .NET test suite reads `toml-schema.abnf` as a conformance guard and checks that the implementation's supported schema properties and built-in type names match the grammar.
 
+## Python
+
+The Python 3.11+ reference library uses the standard-library
+[`tomllib`](https://docs.python.org/3/library/tomllib.html) parser to validate
+parsed TOML documents against a `.tosd` schema. Its library API also supports
+document-driven schema discovery through `[toml-schema].location`.
+
+Run the full Python test suite:
+
+```shell
+python3 -m unittest discover -s reference-implementations/python/tests -v
+```
+
+Use the library API:
+
+```python
+from toml_schema import load_schema
+
+schema = load_schema("config.tosd")
+result = schema.validate_file("config.toml")
+
+if not result.valid:
+    for error in result.errors:
+        print(f"{error.path}: {error.message}")
+```
+
+Validate using `[toml-schema].location` from the TOML document:
+
+```python
+from toml_schema import validate_document
+
+result = validate_document("config.toml")
+```
+
+Schema discovery resolves relative locations from the document's parent
+directory, accepts absolute local paths and hierarchical `file` URIs, and
+rejects unsupported schemes, opaque `file` URIs, non-local hosts, and
+query/fragment components. An optional document `[toml-schema].version` must
+have a compatible major version; other version differences are reported as
+warnings.
+
+The Python test suite reads `toml-schema.abnf` as a conformance guard and checks
+that the implementation's supported schema properties and built-in type names
+match the grammar.
+
 ## Rust
 
 The Rust reference implementation uses the [`toml`](https://crates.io/crates/toml)
@@ -255,7 +301,7 @@ language-version compatibility rules from `SPEC.md`, and expose validation and
 schema extraction commands suitable for automation and editor integration.
 
 The GitHub Actions workflow in `.github/workflows/reference-implementations.yml`
-enforces these expectations for Java, Go, .NET, and Rust. Rust additionally exercises
+enforces these expectations for Java, Go, .NET, Python, and Rust. Rust additionally exercises
 the canonical CLI end to end.
 
 ## TOML version profile
@@ -267,6 +313,7 @@ The current reference implementations parse TOML with libraries that target TOML
 - Java: [Tomlj](https://github.com/tomlj/tomlj) `1.1.1`, which documents support up to TOML 1.0.0.
 - Go: [`pelletier/go-toml`](https://github.com/pelletier/go-toml) `v2.3.1`, which targets TOML 1.0.
 - .NET: [Tomlyn](https://github.com/xoofx/Tomlyn) `2.10.1`, which targets TOML 1.0.
+- Python: [`tomllib`](https://docs.python.org/3/library/tomllib.html), which targets TOML 1.0.
 - Rust: [`toml`](https://crates.io/crates/toml) `1`, which targets TOML 1.0.
 
 For that reason, the reference implementations' current effective parser profile is **TOML 1.0**. TOML 1.1 syntax (for example multi-line inline tables, trailing commas in inline tables, omitted seconds in date-times, or the `\e` and `\xHH` string escapes) is not guaranteed to parse in any reference implementation until the underlying TOML parser declares TOML 1.1 conformance.

--- a/reference-implementations/build-all.sh
+++ b/reference-implementations/build-all.sh
@@ -22,6 +22,9 @@ run_step "Building Go reference implementation" \
 run_step "Building .NET reference implementation" \
     dotnet build "$script_dir/dotnet"
 
+run_step "Building Python reference implementation" \
+    python3 -m compileall -q "$script_dir/python/src"
+
 run_step "Building Rust reference implementation" \
     cargo build --locked --release --manifest-path "$script_dir/rust/Cargo.toml"
 

--- a/reference-implementations/python/.gitignore
+++ b/reference-implementations/python/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.egg-info/
+build/
+dist/

--- a/reference-implementations/python/README.md
+++ b/reference-implementations/python/README.md
@@ -1,0 +1,153 @@
+# TOML Schema for Python
+
+A Python 3.11+ reference implementation of [TOML Schema](../../SPEC.md). It
+loads `.tosd` schema documents and validates parsed TOML documents against
+them, using only the standard library
+[`tomllib`](https://docs.python.org/3/library/tomllib.html) parser at
+runtime — there are no runtime dependencies.
+
+See [`SPEC.md`](../../SPEC.md) for the full TOML Schema language definition
+and [`REFERENCE_IMPLEMENTATIONS.md`](../../REFERENCE_IMPLEMENTATIONS.md) for
+cross-implementation conformance expectations.
+
+## Requirements
+
+Python 3.11 or later (for `tomllib`). No third-party runtime dependencies.
+
+## Installation
+
+```shell
+pip install -e reference-implementations/python
+```
+
+Or use the package directly from source by adding
+`reference-implementations/python/src` to `PYTHONPATH`.
+
+## Usage
+
+Load a schema and validate a TOML file against it:
+
+```python
+from toml_schema import load_schema
+
+schema = load_schema("config.tosd")
+result = schema.validate_file("config.toml")
+
+if not result.valid:
+    for error in result.errors:
+        print(f"{error.path}: {error.message}")
+```
+
+Validate an already-parsed document (e.g. loaded elsewhere), or use
+`load_document` for a thin wrapper around `tomllib`:
+
+```python
+from toml_schema import load_document, load_schema
+
+schema = load_schema("config.tosd")
+document = load_document("config.toml")
+result = schema.validate(document)
+```
+
+Discover a document's own schema through its `[toml-schema].location`
+metadata, and validate in one step:
+
+```python
+from toml_schema import validate_document
+
+result = validate_document("config.toml")
+```
+
+Or do it in two steps to keep the resolved `Schema` object (e.g. to inspect
+`schema.warnings` for discovery-time version-compatibility warnings):
+
+```python
+from toml_schema import schema_from_document
+
+schema, document = schema_from_document("config.toml")
+result = schema.validate(document)
+print(schema.warnings)  # e.g. schema-version compatibility notices
+```
+
+Schema discovery resolves relative `location` values against the document's
+own directory, accepts absolute local paths, and accepts hierarchical
+`file://` URIs (rejecting opaque `file:` URIs, non-local hosts, and
+query/fragment components). If the document declares
+`[toml-schema].version`, a differing-but-compatible (same major version)
+value produces a warning; an incompatible major version raises
+`toml_schema.DiscoveryError`.
+
+Inspect a schema's definitions and their effective (inherited) annotations:
+
+```python
+element = schema.element("database")
+print(element.description)
+print(element.default())        # (value, has_default)
+print(element.deprecated)
+child = element.child("host")    # nested Definition, or None
+```
+
+## Public API
+
+- `load_schema(path) -> Schema` — parses and fully validates a `.tosd`
+  schema file, raising `toml_schema.SchemaError` on any structural or
+  semantic problem.
+- `load_document(path) -> dict` — parses a TOML document with `tomllib`.
+- `Schema.validate(document: dict) -> ValidationResult`
+- `Schema.validate_file(path) -> ValidationResult`
+- `Schema.element(name) / Schema.type(name) -> Definition | None` — schema
+  element/named-type lookup with inherited annotations (`description`,
+  `deprecated`, `default()`) resolved.
+- `schema_from_document(document_path) -> (Schema, dict)` — schema
+  discovery via `[toml-schema].location`.
+- `validate_document(document_path) -> ValidationResult` — discovery +
+  validation in one call.
+- `ValidationResult` — `.valid`, `.errors`, `.warnings`, `.diagnostics`
+  (all diagnostics, errors and warnings, in the order produced).
+- `Diagnostic` (aliased as `ValidationError`) — `.severity`, `.code`,
+  `.path`, `.message`.
+- `Definition` — `.name`, `.type_name`, `.description`, `.deprecated`,
+  `.optional`, `.default()`, `.child(name)`, `.child_names()`, and the full
+  set of parsed constraints (`allowed_values`, `pattern`, `min`/`max`,
+  `min_length`/`max_length`, `one_of`/`any_of`/`all_of`, `condition`, sibling
+  rules, etc.) for programmatic inspection.
+- `SchemaError` / `DiscoveryError` — raised for schema-load and
+  discovery failures, respectively (both subclass `ValueError`).
+
+## Running the tests
+
+The test suite uses only the standard library `unittest` module (no
+`pytest` dependency):
+
+```shell
+python3 -m unittest discover -s reference-implementations/python/tests -v
+```
+
+The suite covers: the checked-in `config.tosd`/`config.toml` example, the
+self-schema (`toml-schema.tosd` validating itself and `config.tosd`),
+loading every schema under `examples/`, schema discovery (including `file://`
+URI edge cases and version-compatibility warnings), `allof`/`oneof`/`anyof`
+composition and closure rules, conditional (`if`/`then`/`else`) selectors,
+effective-annotation resolution across recursive and mutually-recursive
+named types, structured diagnostics, and an ABNF vocabulary-alignment
+conformance check against `toml-schema.abnf`.
+
+## Building
+
+The package uses a standard `setuptools`-based `pyproject.toml` (`src/`
+layout). If the `build` package is already installed:
+
+```shell
+python3 -m build reference-implementations/python
+```
+
+## Known limitations
+
+- `local-time` values are represented with Python's `datetime.time`, which
+  has microsecond precision. Go's reference implementation preserves
+  nanosecond precision. This does not affect any checked-in fixture (none
+  use sub-microsecond precision), but is noted here for completeness.
+- Pattern matching uses Python's `re` module rather than RE2. The patterns
+  used throughout this repository's schemas and tests are RE2/`re`
+  syntax-compatible (no lookaround, backreferences, or other RE2-incompatible
+  constructs), so this does not affect conformance in practice.

--- a/reference-implementations/python/pyproject.toml
+++ b/reference-implementations/python/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "toml-schema"
+version = "1.0.0-rc.2"
+description = "TOML Schema reference library: load .tosd schemas and validate TOML documents."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [{ name = "TOML Schema contributors" }]
+keywords = ["toml", "schema", "validation", "tosd"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Text Processing :: Markup",
+]
+dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/brunoborges/toml-schema"
+Specification = "https://github.com/brunoborges/toml-schema/blob/main/SPEC.md"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/reference-implementations/python/src/toml_schema/__init__.py
+++ b/reference-implementations/python/src/toml_schema/__init__.py
@@ -1,0 +1,56 @@
+"""TOML Schema reference library.
+
+Load ``.tosd`` schema documents (see SPEC.md) and validate TOML documents
+against them, using only the Python standard library (``tomllib``) at
+runtime.
+
+Quick start::
+
+    from toml_schema import load_schema
+
+    schema = load_schema("config.tosd")
+    result = schema.validate_file("config.toml")
+    if not result.valid:
+        for error in result.errors:
+            print(f"{error.path}: {error.message}")
+
+Discovering a document's own schema via its ``[toml-schema].location``
+metadata::
+
+    from toml_schema import validate_document
+
+    result = validate_document("config.toml")
+"""
+
+from ._definition import Condition, Definition
+from ._discovery import (
+    compare_document_schema_version,
+    resolve_schema_location,
+    schema_from_document,
+    validate_document,
+)
+from ._errors import DiscoveryError, SchemaError
+from ._schema import Schema, load_document, load_schema
+from ._types import Diagnostic, Severity, SchemaType, ValidationError, ValidationResult
+
+__version__ = "1.0.0-rc.2"
+
+__all__ = [
+    "__version__",
+    "load_schema",
+    "load_document",
+    "schema_from_document",
+    "validate_document",
+    "resolve_schema_location",
+    "compare_document_schema_version",
+    "Schema",
+    "Definition",
+    "Condition",
+    "ValidationResult",
+    "Diagnostic",
+    "ValidationError",
+    "Severity",
+    "SchemaType",
+    "SchemaError",
+    "DiscoveryError",
+]

--- a/reference-implementations/python/src/toml_schema/_compare.py
+++ b/reference-implementations/python/src/toml_schema/_compare.py
@@ -1,0 +1,201 @@
+"""TOML-aware value comparison, equality, and type-name helpers.
+
+These utilities implement TOML Schema's numeric-precision-preserving
+comparisons and its "TOML equality" semantics for allowedvalues,
+uniqueitems, and conditional selectors. They intentionally avoid comparing
+values through Python's native ``==``/``<`` operators for datetimes, because
+``datetime.datetime`` equality and ordering for timezone-aware values compare
+*instants*, while TOML Schema's allowedvalues/uniqueitems equality compares
+*literal* representations (same offset, same local time).
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import math
+from fractions import Fraction
+from typing import Any
+
+from ._types import SchemaType
+
+_RANGE_COMPARABLE = {
+    SchemaType.INTEGER,
+    SchemaType.FLOAT,
+    SchemaType.OFFSET_DATE_TIME,
+    SchemaType.LOCAL_DATE_TIME,
+    SchemaType.LOCAL_DATE,
+    SchemaType.LOCAL_TIME,
+}
+
+
+def is_range_comparable(type_name: SchemaType) -> bool:
+    return type_name in _RANGE_COMPARABLE
+
+
+def is_numeric(value: Any) -> bool:
+    """True for TOML integer/float values. Booleans are never numeric."""
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def is_nan(value: Any) -> bool:
+    return isinstance(value, float) and math.isnan(value)
+
+
+def is_offset_date_time(value: Any) -> bool:
+    return isinstance(value, _dt.datetime) and value.tzinfo is not None
+
+
+def is_local_date_time(value: Any) -> bool:
+    return isinstance(value, _dt.datetime) and value.tzinfo is None
+
+
+def is_local_date(value: Any) -> bool:
+    return isinstance(value, _dt.date) and not isinstance(value, _dt.datetime)
+
+
+def is_local_time(value: Any) -> bool:
+    return isinstance(value, _dt.time)
+
+
+def type_name_of(value: Any) -> str:
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, int):
+        return "integer"
+    if isinstance(value, float):
+        return "float"
+    if is_offset_date_time(value):
+        return "offset-date-time"
+    if is_local_date_time(value):
+        return "local-date-time"
+    if is_local_date(value):
+        return "local-date"
+    if is_local_time(value):
+        return "local-time"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, dict):
+        return "table"
+    return type(value).__name__
+
+
+def is_type(value: Any, type_name: SchemaType) -> bool:
+    if type_name == SchemaType.ANY:
+        return True
+    if type_name == SchemaType.STRING:
+        return isinstance(value, str)
+    if type_name == SchemaType.INTEGER:
+        return isinstance(value, int) and not isinstance(value, bool)
+    if type_name == SchemaType.FLOAT:
+        return isinstance(value, float)
+    if type_name == SchemaType.BOOLEAN:
+        return isinstance(value, bool)
+    if type_name == SchemaType.OFFSET_DATE_TIME:
+        return is_offset_date_time(value)
+    if type_name == SchemaType.LOCAL_DATE_TIME:
+        return is_local_date_time(value)
+    if type_name == SchemaType.LOCAL_DATE:
+        return is_local_date(value)
+    if type_name == SchemaType.LOCAL_TIME:
+        return is_local_time(value)
+    if type_name == SchemaType.ARRAY:
+        return isinstance(value, list)
+    if type_name in (SchemaType.TABLE, SchemaType.COLLECTION):
+        return isinstance(value, dict)
+    return False
+
+
+class IncomparableError(ValueError):
+    """Raised when two values cannot be ordered against each other."""
+
+
+def _numeric_rat(value: Any) -> Fraction:
+    if isinstance(value, int):
+        return Fraction(value)
+    return Fraction(value)  # exact binary value of the float
+
+
+def compare_numbers(left: Any, right: Any) -> int:
+    if is_nan(left) or is_nan(right):
+        raise IncomparableError("NaN is unordered")
+    if isinstance(left, int) and isinstance(right, int):
+        return (left > right) - (left < right)
+    left_is_float = isinstance(left, float)
+    right_is_float = isinstance(right, float)
+    if (left_is_float and math.isinf(left)) or (right_is_float and math.isinf(right)):
+        left_f = float(left)
+        right_f = float(right)
+        return (left_f > right_f) - (left_f < right_f)
+    left_rat = _numeric_rat(left)
+    right_rat = _numeric_rat(right)
+    return (left_rat > right_rat) - (left_rat < right_rat)
+
+
+def compare(value: Any, boundary: Any) -> int:
+    """Compares a value with a min/max boundary of a compatible kind.
+
+    Raises IncomparableError when the two values cannot be compared.
+    """
+    if is_numeric(value) and is_numeric(boundary):
+        return compare_numbers(value, boundary)
+    if is_offset_date_time(value) and is_offset_date_time(boundary):
+        return (value > boundary) - (value < boundary)
+    if is_local_date_time(value) and is_local_date_time(boundary):
+        return (value > boundary) - (value < boundary)
+    if is_local_date(value) and is_local_date(boundary):
+        return (value > boundary) - (value < boundary)
+    if is_local_time(value) and is_local_time(boundary):
+        return (value > boundary) - (value < boundary)
+    raise IncomparableError(
+        f"cannot compare {type_name_of(value)} with boundary {type_name_of(boundary)}"
+    )
+
+
+def _offset_date_times_equal(left: _dt.datetime, right: _dt.datetime) -> bool:
+    return (
+        left.year == right.year
+        and left.month == right.month
+        and left.day == right.day
+        and left.hour == right.hour
+        and left.minute == right.minute
+        and left.second == right.second
+        and left.microsecond == right.microsecond
+        and left.utcoffset() == right.utcoffset()
+    )
+
+
+def values_equal(allowed: Any, value: Any) -> bool:
+    """TOML equality: literal representation equality, not instant equality."""
+    if is_numeric(allowed) and is_numeric(value):
+        if is_nan(allowed) or is_nan(value):
+            return is_nan(allowed) and is_nan(value)
+        try:
+            return compare_numbers(allowed, value) == 0
+        except IncomparableError:
+            return False
+    if isinstance(allowed, bool) or isinstance(value, bool):
+        return isinstance(allowed, bool) and isinstance(value, bool) and allowed == value
+    if isinstance(allowed, str):
+        return isinstance(value, str) and allowed == value
+    if is_offset_date_time(allowed):
+        return is_offset_date_time(value) and _offset_date_times_equal(allowed, value)
+    if is_local_date_time(allowed):
+        return is_local_date_time(value) and allowed == value
+    if is_local_date(allowed):
+        return is_local_date(value) and allowed == value
+    if is_local_time(allowed):
+        return is_local_time(value) and allowed == value
+    if isinstance(allowed, list):
+        if not isinstance(value, list) or len(allowed) != len(value):
+            return False
+        return all(values_equal(a, b) for a, b in zip(allowed, value))
+    if isinstance(allowed, dict):
+        if not isinstance(value, dict) or len(allowed) != len(value):
+            return False
+        for key, allowed_value in allowed.items():
+            if key not in value or not values_equal(allowed_value, value[key]):
+                return False
+        return True
+    return allowed is None and value is None

--- a/reference-implementations/python/src/toml_schema/_definition.py
+++ b/reference-implementations/python/src/toml_schema/_definition.py
@@ -1,0 +1,72 @@
+"""The Definition and Condition data model for a parsed schema node."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Pattern, Tuple
+
+from ._types import SchemaType
+
+
+@dataclass
+class Condition:
+    """An ``if`` selector: ``{ key = ..., equals = ... }`` or
+    ``{ key = ..., in = [...] }``."""
+
+    key: str
+    has_equals: bool
+    equals: Any = None
+    in_values: Tuple[Any, ...] = ()
+
+
+@dataclass
+class Definition:
+    """A single parsed schema definition node (a ``[types.*]`` or
+    ``[elements.*]`` entry, or one of its nested child definitions).
+
+    Public accessors mirror the other reference implementations:
+    ``description``, ``deprecated``, ``default()``, and ``child(name)``.
+    Internal validator state (references, constraints, sibling rules) is
+    consumed by the schema/validator modules within this package.
+    """
+
+    name: str
+    type_name: Optional[SchemaType] = None
+    reference: str = ""
+    description: str = ""
+    item_reference: str = ""
+    items: Tuple[str, ...] = ()
+    optional: bool = False
+    allowed_values: Tuple[Any, ...] = ()
+    pattern: Optional[Pattern[str]] = None
+    key_pattern: Optional[Pattern[str]] = None
+    min: Any = None
+    max: Any = None
+    min_length: Optional[int] = None
+    max_length: Optional[int] = None
+    one_of: Tuple[str, ...] = ()
+    any_of: Tuple[str, ...] = ()
+    condition: Optional[Condition] = None
+    then_reference: str = ""
+    else_reference: str = ""
+    all_of: Tuple[str, ...] = ()
+    dependent_required: Dict[str, Tuple[str, ...]] = field(default_factory=dict)
+    mutually_exclusive: Tuple[Tuple[str, ...], ...] = ()
+    exactly_one: Tuple[Tuple[str, ...], ...] = ()
+    unique_items: Optional[bool] = None
+    default_value: Any = None
+    has_default: bool = False
+    deprecated: bool = False
+    has_deprecated: bool = False
+    children: Dict[str, "Definition"] = field(default_factory=dict)
+
+    def default(self) -> Tuple[Any, bool]:
+        """Returns the effective, non-materializing default annotation as
+        ``(value, has_default)``."""
+        return self.default_value, self.has_default
+
+    def child(self, name: str) -> Optional["Definition"]:
+        return self.children.get(name)
+
+    def child_names(self) -> List[str]:
+        return list(self.children.keys())

--- a/reference-implementations/python/src/toml_schema/_discovery.py
+++ b/reference-implementations/python/src/toml_schema/_discovery.py
@@ -1,0 +1,159 @@
+"""Schema discovery from a document's ``[toml-schema].location`` metadata.
+
+Mirrors Go's ``SchemaFromDocument``/``resolveSchemaLocation``: a document may
+declare where its own schema lives, either as a local filesystem path or as a
+(possibly relative) ``file://`` URI resolved against the document's own path.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any, Tuple
+from urllib.parse import quote, urljoin, urlsplit, unquote
+
+from ._errors import DiscoveryError, SchemaError
+from ._schema import Schema, load_document, load_schema, SEMVER_PATTERN
+from ._types import Diagnostic, Severity, ValidationResult
+
+_INVALID_URI_REFERENCE_CHARS = set('\\"<>^`{|}')
+
+
+def _has_invalid_uri_reference_character(reference: str) -> bool:
+    for character in reference:
+        if character <= " " or character == "\x7f":
+            return True
+        if character in _INVALID_URI_REFERENCE_CHARS:
+            return True
+    return False
+
+
+def _is_schema_reference_scalar(value: Any) -> bool:
+    # Every TOML value that is not an array or table is a scalar (string,
+    # integer, float, boolean, or one of the three date/time kinds).
+    return not isinstance(value, (list, dict))
+
+
+def _local_path_from_file_uri(parts) -> str:
+    if parts.fragment or parts.query:
+        raise DiscoveryError("file URI contains unsupported components")
+    netloc = parts.netloc
+    if "@" in netloc:
+        raise DiscoveryError("file URI contains unsupported components")
+    if netloc and netloc.lower() != "localhost":
+        raise DiscoveryError("file URI has a non-local host")
+    escaped_path = parts.path.lower()
+    if "%2f" in escaped_path or "%5c" in escaped_path:
+        raise DiscoveryError("file URI contains an encoded path separator")
+    path = unquote(parts.path)
+    if not path or "\x00" in path:
+        raise DiscoveryError("file URI does not contain a safe path")
+    if sys.platform.startswith("win") and len(path) >= 3 and path[0] == "/" and path[2] == ":":
+        path = path[1:]
+    if os.sep != "/":
+        path = path.replace("/", os.sep)
+    if not os.path.isabs(path):
+        raise DiscoveryError("file URI path is not absolute")
+    return path
+
+
+def resolve_schema_location(document_path: str, location: str) -> str:
+    if os.path.isabs(location):
+        return os.path.normpath(location)
+    if _has_invalid_uri_reference_character(location):
+        raise DiscoveryError(f"invalid [toml-schema].location URI: {location}")
+    try:
+        parts = urlsplit(location)
+        if parts.scheme:
+            # `location` is itself an absolute URI reference: per RFC 3986
+            # section 5.3, the base is ignored entirely (mirrors Go's
+            # url.URL.ResolveReference short-circuit for absolute
+            # references). A reference with no authority and a path that
+            # does not start with "/" is opaque (e.g. "file:something") and
+            # is rejected below, same as Go's uri.Opaque != "" check.
+            is_opaque = not parts.netloc and not parts.path.startswith("/")
+        else:
+            absolute_document_path = os.path.abspath(document_path)
+            base = "file://" + quote(absolute_document_path.replace(os.sep, "/"), safe="/")
+            parts = urlsplit(urljoin(base, location))
+            is_opaque = False
+    except ValueError as exc:
+        raise DiscoveryError(f"invalid [toml-schema].location URI: {location}: {exc}") from exc
+    if parts.scheme.lower() != "file":
+        raise DiscoveryError(f"unsupported schema location URI scheme: {parts.scheme}")
+    if is_opaque:
+        raise DiscoveryError(
+            f"invalid file schema location: {location}: file URI contains unsupported components"
+        )
+    try:
+        path = _local_path_from_file_uri(parts)
+    except DiscoveryError as exc:
+        raise DiscoveryError(f"invalid file schema location: {location}: {exc}") from exc
+    return os.path.normpath(path)
+
+
+def compare_document_schema_version(value: Any, actual: str) -> str:
+    """Returns a warning string when versions differ but remain compatible
+    (same major version); raises DiscoveryError on incompatible/invalid
+    versions."""
+    if not isinstance(value, str):
+        raise DiscoveryError("document [toml-schema].version must be a SemVer string")
+    expected_parts = SEMVER_PATTERN.match(value)
+    if not expected_parts:
+        raise DiscoveryError("document [toml-schema].version must use SemVer MAJOR.MINOR.PATCH syntax")
+    actual_parts = SEMVER_PATTERN.match(actual)
+    if expected_parts.group(1) != actual_parts.group(1):
+        raise DiscoveryError(
+            f"document expects TOML Schema major version {value}, but resolved schema uses {actual}"
+        )
+    if value != actual:
+        return f"Warning: document expects TOML Schema version {value}, but resolved schema uses {actual}"
+    return ""
+
+
+def schema_from_document(document_path: str) -> Tuple[Schema, dict]:
+    """Loads a document and discovers+loads its schema via
+    ``[toml-schema].location`` (and, if present, checks
+    ``[toml-schema].version`` compatibility, appending a warning to
+    ``schema.warnings`` on a compatible-but-differing version).
+
+    Raises :class:`toml_schema.SchemaError`/:class:`toml_schema.DiscoveryError`
+    if discovery or schema loading fails.
+    """
+    document = load_document(document_path)
+    metadata = document.get("toml-schema")
+    if not isinstance(metadata, dict):
+        raise DiscoveryError("document does not contain [toml-schema].location")
+    for key, value in metadata.items():
+        if not _is_schema_reference_scalar(value):
+            raise DiscoveryError(f"document [toml-schema].{key} must be a scalar value")
+    location = metadata.get("location")
+    if not isinstance(location, str) or location.strip() == "":
+        raise DiscoveryError("document does not contain [toml-schema].location")
+
+    schema_path = resolve_schema_location(document_path, location)
+    schema = load_schema(schema_path)
+    if "version" in metadata:
+        warning = compare_document_schema_version(metadata["version"], schema.version)
+        if warning:
+            schema.warnings.append(warning)
+    return schema, document
+
+
+def validate_document(document_path: str) -> ValidationResult:
+    """Convenience wrapper combining schema discovery and validation for a
+    single document: loads the document, discovers its schema via
+    ``[toml-schema].location``, and validates the document against it.
+
+    Discovery or schema-load failures are reported as a single structured
+    error diagnostic rather than raised, so callers can treat this the same
+    way as :meth:`Schema.validate_file`.
+    """
+    try:
+        schema, document = schema_from_document(document_path)
+    except (SchemaError, DiscoveryError, OSError) as exc:
+        diagnostic = Diagnostic(
+            severity=Severity.ERROR, code="document-parse-error", path="$", message=str(exc)
+        )
+        return ValidationResult(errors=[diagnostic])
+    return schema.validate(document)

--- a/reference-implementations/python/src/toml_schema/_errors.py
+++ b/reference-implementations/python/src/toml_schema/_errors.py
@@ -1,0 +1,13 @@
+"""Exception types raised while loading or discovering schemas."""
+
+from __future__ import annotations
+
+
+class SchemaError(ValueError):
+    """Raised when a `.tosd` schema document is structurally or semantically
+    invalid."""
+
+
+class DiscoveryError(ValueError):
+    """Raised when a document's ``[toml-schema].location`` cannot be resolved
+    to a schema, or when its metadata is malformed."""

--- a/reference-implementations/python/src/toml_schema/_schema.py
+++ b/reference-implementations/python/src/toml_schema/_schema.py
@@ -1,0 +1,1223 @@
+"""Schema loading: parses a ``.tosd`` document into a validated Definition
+tree and exposes the ``Schema`` public API (``validate``, ``validate_file``,
+``element``, ``type``).
+
+This mirrors the load-time logic in Go's ``schema.go`` (``LoadSchema``,
+``parseDefinition``/``parseDefinitions``, the semantic validation passes, and
+the annotation resolver) as closely as possible.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import re
+import tomllib
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from ._compare import (
+    is_nan,
+    is_numeric,
+    is_range_comparable,
+    is_type,
+    values_equal,
+)
+from ._definition import Condition, Definition
+from ._errors import SchemaError
+from ._source import SchemaSource
+from ._types import (
+    Diagnostic,
+    Severity,
+    SchemaType,
+    ValidationResult,
+    normalize_reference,
+    normalize_references,
+    parse_schema_type,
+)
+from ._validator import Validator
+
+Path = Tuple[str, ...]
+
+# The full TOML Schema vocabulary. Must exactly match the ABNF `schema-key`
+# production (see toml-schema.abnf and tests/test_abnf_conformance.py).
+DEFINITION_KEYS = frozenset(
+    {
+        "type",
+        "description",
+        "itemtype",
+        "items",
+        "allowedvalues",
+        "pattern",
+        "keypattern",
+        "optional",
+        "min",
+        "max",
+        "minlength",
+        "maxlength",
+        "oneof",
+        "anyof",
+        "dependentrequired",
+        "mutuallyexclusive",
+        "exactlyone",
+        "allof",
+        "uniqueitems",
+        "default",
+        "deprecated",
+        "if",
+        "then",
+        "else",
+    }
+)
+
+NAMED_REFERENCE_KEYS = frozenset({"type", "description", "optional", "allof", "default", "deprecated"})
+UNION_KEYS = frozenset({"oneof", "anyof", "description", "optional", "allof", "default", "deprecated"})
+CONDITIONAL_KEYS = frozenset(
+    {"if", "then", "else", "description", "optional", "allof", "default", "deprecated"}
+)
+
+# TOML Schema 1.0.0 has not been released yet; this is the version new
+# schema-language features are developed against ahead of that release. Do
+# not bump this beyond 1.0.0 until the release actually ships.
+CURRENT_TOML_SCHEMA_VERSION = "1.0.0"
+
+SEMVER_PATTERN = re.compile(
+    r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)"
+    r"(?:-((?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)"
+    r"(?:\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?"
+    r"(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$"
+)
+
+
+def validate_schema_version(value: Any) -> None:
+    if not isinstance(value, str):
+        raise SchemaError("[toml-schema].version must be a SemVer string")
+    match = SEMVER_PATTERN.match(value)
+    if not match:
+        raise SchemaError("[toml-schema].version must use SemVer MAJOR.MINOR.PATCH syntax")
+    if match.group(1) != "1":
+        raise SchemaError(f"unsupported TOML Schema major version: {value}")
+    if match.group(2) != "0":
+        raise SchemaError(f"unsupported TOML Schema minor version: {value}")
+
+
+def load_document(path: str) -> dict:
+    """Parses a TOML document file into plain Python values."""
+    with open(path, "rb") as handle:
+        return tomllib.load(handle)
+
+
+def _property_value(table: dict, key: str) -> Any:
+    """Returns table[key] unless it is a table (dict) value, in which case
+    None is returned -- mirrors Go's propertyValue, which only ever looks at
+    *scalar/array* annotation values (table-valued ambiguity is handled
+    separately via the schema source scanner)."""
+    value = table.get(key)
+    if isinstance(value, dict):
+        return None
+    return value
+
+
+def _get_string(table: dict, key: str) -> str:
+    value = _property_value(table, key)
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise SchemaError(f"expected {key} to be a string")
+    return value
+
+
+def _get_bool(table: dict, key: str) -> bool:
+    value = _property_value(table, key)
+    if value is None:
+        return False
+    if not isinstance(value, bool):
+        raise SchemaError(f"expected {key} to be a boolean")
+    return value
+
+
+def _get_optional_bool(table: dict, key: str) -> Optional[bool]:
+    value = _property_value(table, key)
+    if value is None:
+        return None
+    if not isinstance(value, bool):
+        raise SchemaError(f"expected {key} to be a boolean")
+    return value
+
+
+def _get_pattern(name: str, table: dict) -> Optional[re.Pattern]:
+    return _get_pattern_key(name, table, "pattern")
+
+
+def _get_pattern_key(name: str, table: dict, key: str) -> Optional[re.Pattern]:
+    value = _property_value(table, key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise SchemaError(f"expected {key} to be a string")
+    try:
+        return re.compile(value)
+    except re.error as exc:
+        raise SchemaError(f"{name} has invalid {key}: {exc}") from exc
+
+
+def _get_array_values(table: dict, key: str) -> Optional[list]:
+    value = _property_value(table, key)
+    if value is None:
+        return None
+    if not isinstance(value, list):
+        raise SchemaError(f"expected {key} to be an array")
+    return value
+
+
+def _get_string_array_values(table: dict, key: str) -> List[str]:
+    values = _get_array_values(table, key)
+    if values is None:
+        return []
+    result = []
+    for value in values:
+        if not isinstance(value, str):
+            raise SchemaError(f"expected {key} to contain only strings")
+        result.append(value)
+    return result
+
+
+_MAX_INT32 = 2**31 - 1
+
+
+def _get_integer_pointer(table: dict, key: str) -> Optional[int]:
+    value = _property_value(table, key)
+    if value is None:
+        return None
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise SchemaError(f"expected {key} to be an integer")
+    if value < 0 or value > _MAX_INT32:
+        raise SchemaError(f"{key} must be between 0 and {_MAX_INT32}")
+    return value
+
+
+def _get_conditional(
+    name: str, path: Path, table: dict, source: SchemaSource
+) -> Tuple[Optional[Condition], str, str]:
+    has_if = source.is_property(table, path, "if")
+    has_then = source.is_property(table, path, "then")
+    has_else = source.is_property(table, path, "else")
+    if not (has_if or has_then or has_else):
+        return None, "", ""
+    if not (has_if and has_then and has_else):
+        raise SchemaError(f"{name} must define if, then, and else together")
+    raw_condition = table.get("if")
+    if not isinstance(raw_condition, dict):
+        raise SchemaError(f"{name} if must be an inline table")
+    for key in raw_condition:
+        if key not in ("key", "equals", "in"):
+            raise SchemaError(f"{name} if contains unsupported property: {key}")
+    key = raw_condition.get("key")
+    if not isinstance(key, str):
+        raise SchemaError(f"{name} if.key must be a string")
+    has_equals = "equals" in raw_condition
+    has_in = "in" in raw_condition
+    if has_equals == has_in:
+        raise SchemaError(f"{name} if must define exactly one of equals and in")
+    equals_value = raw_condition.get("equals")
+    in_values: Tuple[Any, ...] = ()
+    if has_in:
+        raw_in = raw_condition["in"]
+        if not isinstance(raw_in, list) or len(raw_in) == 0:
+            raise SchemaError(f"{name} if.in must be a non-empty array")
+        in_values = tuple(raw_in)
+    then_reference = table.get("then")
+    if not isinstance(then_reference, str) or then_reference.strip() == "":
+        raise SchemaError(f"{name} then must be a non-blank named type reference")
+    else_reference = table.get("else")
+    if not isinstance(else_reference, str) or else_reference.strip() == "":
+        raise SchemaError(f"{name} else must be a non-blank named type reference")
+    for property_name, reference in (("then", then_reference), ("else", else_reference)):
+        if parse_schema_type(normalize_reference(reference)) is not None:
+            raise SchemaError(f"{name} {property_name} must be a named reusable type reference")
+    return (
+        Condition(key=key, has_equals=has_equals, equals=equals_value, in_values=in_values),
+        then_reference,
+        else_reference,
+    )
+
+
+def _get_dependent_required(
+    name: str, path: Path, table: dict, source: SchemaSource
+) -> Dict[str, Tuple[str, ...]]:
+    if not source.is_property(table, path, "dependentrequired"):
+        return {}
+    dependencies = table.get("dependentrequired")
+    if not isinstance(dependencies, dict):
+        raise SchemaError(f"{name} dependentrequired must be a table")
+    if len(dependencies) == 0:
+        raise SchemaError(f"{name} dependentrequired must not be empty")
+    result: Dict[str, Tuple[str, ...]] = {}
+    for trigger, raw in dependencies.items():
+        if not isinstance(raw, list) or len(raw) == 0:
+            raise SchemaError(f"{name} dependentrequired.{trigger} must be a non-empty string array")
+        seen: Set[str] = set()
+        values: List[str] = []
+        for value in raw:
+            if not isinstance(value, str):
+                raise SchemaError(f"{name} dependentrequired.{trigger} must contain only strings")
+            if value in seen:
+                raise SchemaError(f"{name} dependentrequired.{trigger} contains duplicate {value!r}")
+            seen.add(value)
+            values.append(value)
+        result[trigger] = tuple(values)
+    return result
+
+
+def _get_key_groups(
+    name: str, path: Path, table: dict, key: str, source: SchemaSource
+) -> Tuple[Tuple[str, ...], ...]:
+    if not source.is_property(table, path, key):
+        return ()
+    groups = table.get(key)
+    if not isinstance(groups, list) or len(groups) == 0:
+        raise SchemaError(f"{name} {key} must be a non-empty array")
+    result: List[Tuple[str, ...]] = []
+    for index, raw_group in enumerate(groups):
+        if not isinstance(raw_group, list) or len(raw_group) < 2:
+            raise SchemaError(f"{name} {key}[{index}] must contain at least two strings")
+        seen: Set[str] = set()
+        converted: List[str] = []
+        for raw_name in raw_group:
+            if not isinstance(raw_name, str):
+                raise SchemaError(f"{name} {key}[{index}] must contain only strings")
+            if raw_name in seen:
+                raise SchemaError(f"{name} {key}[{index}] contains duplicate {raw_name!r}")
+            seen.add(raw_name)
+            converted.append(raw_name)
+        result.append(tuple(converted))
+    return tuple(result)
+
+
+def _reject_bare_collection_reference(name: str, property_name: str, reference: str) -> None:
+    if normalize_reference(reference) == SchemaType.COLLECTION.value:
+        raise SchemaError(f"{name} cannot use collection as a bare {property_name} reference")
+
+
+def _reject_bare_collection_references(name: str, property_name: str, references: List[str]) -> None:
+    for reference in references:
+        _reject_bare_collection_reference(name, property_name, normalize_reference(reference))
+
+
+def _validate_alternative_references(name: str, property_name: str, references: List[str]) -> None:
+    for reference in references:
+        normalized = normalize_reference(reference)
+        _reject_bare_collection_reference(name, property_name, normalized)
+        if normalized == SchemaType.ANY.value:
+            raise SchemaError(f"{name} cannot use any directly in {property_name}")
+
+
+def _is_range_boundary(value: Any) -> bool:
+    from ._compare import is_local_date, is_local_date_time, is_local_time, is_offset_date_time
+
+    return (
+        is_numeric(value)
+        or is_offset_date_time(value)
+        or is_local_date_time(value)
+        or is_local_date(value)
+        or is_local_time(value)
+    )
+
+
+def _validate_range_boundary(name: str, key: str, value: Any) -> None:
+    if value is None or _is_range_boundary(value):
+        return
+    raise SchemaError(f"{name} {key} must be an integer, float, or temporal value")
+
+
+def _boundary_matches_type(value: Any, type_name: SchemaType) -> bool:
+    from ._compare import is_local_date, is_local_date_time, is_local_time, is_offset_date_time
+
+    if type_name in (SchemaType.INTEGER, SchemaType.FLOAT):
+        return is_numeric(value)
+    if type_name == SchemaType.OFFSET_DATE_TIME:
+        return is_offset_date_time(value)
+    if type_name == SchemaType.LOCAL_DATE_TIME:
+        return is_local_date_time(value)
+    if type_name == SchemaType.LOCAL_DATE:
+        return is_local_date(value)
+    if type_name == SchemaType.LOCAL_TIME:
+        return is_local_time(value)
+    return False
+
+
+def _validate_boundary_matches_type(name: str, key: str, value: Any, type_name: SchemaType) -> None:
+    if value is None or _boundary_matches_type(value, type_name):
+        return
+    raise SchemaError(f"{name} {key} must be comparable with {type_name}")
+
+
+def _validate_range_constraints(
+    name: str, type_name: Optional[SchemaType], min_value: Any, max_value: Any
+) -> None:
+    if min_value is None and max_value is None:
+        return
+    _validate_range_boundary(name, "min", min_value)
+    _validate_range_boundary(name, "max", max_value)
+    if is_nan(min_value):
+        raise SchemaError(f"{name} cannot use NaN as min")
+    if is_nan(max_value):
+        raise SchemaError(f"{name} cannot use NaN as max")
+    if type_name == SchemaType.ANY:
+        raise SchemaError(f"{name} cannot define min or max when type is any")
+    if type_name == SchemaType.ARRAY:
+        return
+    if type_name is not None and not is_range_comparable(type_name):
+        raise SchemaError(
+            f"{name} can only define min or max for integer, float, date/time, or compatible array types"
+        )
+    if type_name is not None:
+        _validate_boundary_matches_type(name, "min", min_value, type_name)
+        _validate_boundary_matches_type(name, "max", max_value, type_name)
+
+
+def _validate_allowed_values_constraints(
+    name: str,
+    type_name: Optional[SchemaType],
+    allowed_values: List[Any],
+    pattern: Optional[re.Pattern],
+    min_value: Any,
+    max_value: Any,
+    min_length: Optional[int],
+    max_length: Optional[int],
+) -> None:
+    from ._compare import IncomparableError, compare
+
+    if not allowed_values or type_name == SchemaType.ARRAY:
+        return
+    for index, allowed in enumerate(allowed_values):
+        entry = f"{name} allowedvalues[{index}]"
+        if pattern is not None:
+            if not isinstance(allowed, str) or not pattern.search(allowed):
+                raise SchemaError(f"{entry} does not satisfy pattern")
+        if (min_value is not None or max_value is not None) and is_nan(allowed):
+            raise SchemaError(f"{entry} does not satisfy min or max")
+        if min_value is not None:
+            try:
+                comparison = compare(allowed, min_value)
+            except IncomparableError as exc:
+                raise SchemaError(f"{entry} cannot be compared with min: {exc}") from exc
+            if comparison < 0:
+                raise SchemaError(f"{entry} is less than min")
+        if max_value is not None:
+            try:
+                comparison = compare(allowed, max_value)
+            except IncomparableError as exc:
+                raise SchemaError(f"{entry} cannot be compared with max: {exc}") from exc
+            if comparison > 0:
+                raise SchemaError(f"{entry} is greater than max")
+        if min_length is not None or max_length is not None:
+            if not isinstance(allowed, str):
+                raise SchemaError(f"{entry} does not satisfy string length constraints")
+            length = len(allowed)
+            if min_length is not None and length < min_length:
+                raise SchemaError(f"{entry} is shorter than minlength")
+            if max_length is not None and length > max_length:
+                raise SchemaError(f"{entry} is longer than maxlength")
+
+
+def parse_definitions(
+    prefix: str, table: Optional[dict], required: bool, source: SchemaSource
+) -> Dict[str, Definition]:
+    if table is None:
+        if required:
+            raise SchemaError(f"missing required [{prefix}] table")
+        return {}
+    definitions: Dict[str, Definition] = {}
+    for key, value in table.items():
+        if prefix == "types":
+            if parse_schema_type(key) is not None:
+                raise SchemaError(f"[types.{key}] uses a reserved built-in type name")
+            if key.startswith("types."):
+                raise SchemaError(f"[types.{key}] uses the reserved type-reference prefix")
+        if not isinstance(value, dict):
+            raise SchemaError(f"[{prefix}] entry must be a table: {key}")
+        definition = parse_definition(f"{prefix}.{key}", (prefix, key), value, source)
+        definitions[key] = definition
+    return definitions
+
+
+def parse_definition(name: str, path: Path, table: dict, source: SchemaSource) -> Definition:
+    type_selector = _get_string(table, "type")
+    if _property_value(table, "type") is not None and type_selector == "":
+        raise SchemaError(f"{name} type must not be blank")
+    type_name: Optional[SchemaType] = None
+    reference = ""
+    if type_selector:
+        builtin = parse_schema_type(type_selector)
+        if builtin is not None:
+            type_name = builtin
+        else:
+            reference = normalize_reference(type_selector)
+    if reference:
+        for key in table:
+            if key not in NAMED_REFERENCE_KEYS:
+                raise SchemaError(f"{name} named type reference cannot define {key}")
+
+    description = _get_string(table, "description")
+    item_reference = _get_string(table, "itemtype")
+    if _property_value(table, "itemtype") is not None and item_reference == "":
+        raise SchemaError(f"{name} itemtype must not be blank")
+    items = _get_string_array_values(table, "items")
+    if _property_value(table, "items") is not None and len(items) == 0:
+        raise SchemaError(f"{name} items must contain at least one type reference")
+    optional = _get_bool(table, "optional")
+    pattern = _get_pattern(name, table)
+    key_pattern = _get_pattern_key(name, table, "keypattern")
+    min_length = _get_integer_pointer(table, "minlength")
+    max_length = _get_integer_pointer(table, "maxlength")
+    allowed_values = _get_array_values(table, "allowedvalues") or []
+    has_allowed_values = _property_value(table, "allowedvalues") is not None
+    if has_allowed_values and len(allowed_values) == 0:
+        raise SchemaError(f"{name} allowedvalues must contain at least one entry")
+    has_one_of = _property_value(table, "oneof") is not None
+    has_any_of = _property_value(table, "anyof") is not None
+    one_of = _get_string_array_values(table, "oneof")
+    any_of = _get_string_array_values(table, "anyof")
+    all_of = _get_string_array_values(table, "allof")
+    condition, then_reference, else_reference = _get_conditional(name, path, table, source)
+
+    for property_name, references in (
+        ("items", items),
+        ("oneof", one_of),
+        ("anyof", any_of),
+        ("allof", all_of),
+    ):
+        for reference_value in references:
+            if reference_value == "":
+                raise SchemaError(f"{name} {property_name} references must not be blank")
+
+    if has_one_of and len(one_of) == 0:
+        raise SchemaError(f"{name} oneof must contain at least one type reference")
+    if has_any_of and len(any_of) == 0:
+        raise SchemaError(f"{name} anyof must contain at least one type reference")
+    if _property_value(table, "allof") is not None and len(all_of) == 0:
+        raise SchemaError(f"{name} allof must contain at least one type reference")
+
+    _reject_bare_collection_reference(name, "itemtype", item_reference)
+    _reject_bare_collection_references(name, "items", items)
+    _validate_alternative_references(name, "oneof", one_of)
+    _validate_alternative_references(name, "anyof", any_of)
+    _validate_alternative_references(name, "allof", all_of)
+
+    if (
+        type_selector
+        and type_name != SchemaType.COLLECTION
+        and normalize_reference(type_selector) == SchemaType.COLLECTION.value
+    ):
+        raise SchemaError(f"{name} cannot use collection as a bare type reference")
+
+    type_selectors = 0
+    if type_selector:
+        type_selectors += 1
+    if has_one_of:
+        type_selectors += 1
+    if has_any_of:
+        type_selectors += 1
+    if condition is not None:
+        type_selectors += 1
+    if type_selectors > 1:
+        raise SchemaError(f"{name} cannot define more than one of type, oneof, anyof, and if")
+
+    children: Dict[str, Definition] = {}
+    for key, value in table.items():
+        if key in DEFINITION_KEYS and source.is_property(table, path, key):
+            continue
+        if isinstance(value, dict):
+            if key in children:
+                raise SchemaError(f"{name} defines child {key} more than once")
+            child = parse_definition(f"{name}.{key}", path + (key,), value, source)
+            children[key] = child
+        elif key not in DEFINITION_KEYS:
+            raise SchemaError(f"{name} contains unsupported property: {key}")
+
+    if has_one_of or has_any_of:
+        for key in table:
+            if key not in UNION_KEYS:
+                raise SchemaError(f"{name} union cannot define {key}")
+
+    if condition is not None:
+        for key in table:
+            if key not in CONDITIONAL_KEYS:
+                raise SchemaError(f"{name} conditional selector cannot define {key}")
+        if children:
+            raise SchemaError(f"{name} conditional selector cannot define child definitions")
+
+    if type_name is None and not reference and not has_one_of and not has_any_of and condition is None:
+        if not children:
+            raise SchemaError(f"{name} must define type, oneof, anyof, or child definitions")
+        type_name = SchemaType.TABLE
+
+    if children and type_name not in (SchemaType.TABLE, SchemaType.COLLECTION):
+        raise SchemaError(f"{name} can only define children when type is table or collection")
+    if type_name not in (SchemaType.ARRAY, SchemaType.COLLECTION) and item_reference:
+        raise SchemaError(f"{name} can only define itemtype when type is array or collection")
+    if type_name != SchemaType.ARRAY and items:
+        raise SchemaError(f"{name} can only define items when type is array")
+
+    if items:
+        if item_reference:
+            raise SchemaError(f"{name} cannot define both items and itemtype")
+        if min_length is not None or max_length is not None:
+            raise SchemaError(f"{name} cannot define minlength or maxlength together with items")
+        if has_allowed_values:
+            raise SchemaError(f"{name} cannot define allowedvalues together with items")
+        if _property_value(table, "min") is not None or _property_value(table, "max") is not None:
+            raise SchemaError(f"{name} cannot define min or max together with items")
+
+    min_value = _property_value(table, "min")
+    max_value = _property_value(table, "max")
+    if min_length is not None and max_length is not None and min_length > max_length:
+        raise SchemaError(f"{name} minlength must not be greater than maxlength")
+    if key_pattern is not None and type_name != SchemaType.COLLECTION:
+        raise SchemaError(f"{name} can only define keypattern when type is collection")
+    if pattern is not None and type_name != SchemaType.STRING:
+        raise SchemaError(f"{name} can only define pattern when type is string")
+    if has_allowed_values and type_name in (SchemaType.TABLE, SchemaType.COLLECTION):
+        raise SchemaError(f"{name} can only define allowedvalues for scalar, unconstrained, or array types")
+    if (min_length is not None or max_length is not None) and type_name not in (
+        SchemaType.STRING,
+        SchemaType.ARRAY,
+        SchemaType.COLLECTION,
+    ):
+        raise SchemaError(
+            f"{name} can only define minlength or maxlength when type is string, array, or collection"
+        )
+    if type_name == SchemaType.COLLECTION and not item_reference and not all_of:
+        raise SchemaError(f"{name} must define itemtype when type is collection")
+
+    _validate_range_constraints(name, type_name, min_value, max_value)
+    _validate_allowed_values_constraints(
+        name, type_name, allowed_values, pattern, min_value, max_value, min_length, max_length
+    )
+
+    dependent_required = _get_dependent_required(name, path, table, source)
+    mutually_exclusive = _get_key_groups(name, path, table, "mutuallyexclusive", source)
+    exactly_one = _get_key_groups(name, path, table, "exactlyone", source)
+    unique_items = _get_optional_bool(table, "uniqueitems")
+    deprecated_ptr = _get_optional_bool(table, "deprecated")
+
+    has_default = source.is_property(table, path, "default")
+    default_value = table.get("default") if has_default else None
+
+    return Definition(
+        name=name,
+        type_name=type_name,
+        reference=reference,
+        description=description,
+        item_reference=normalize_reference(item_reference),
+        items=tuple(normalize_references(items)),
+        optional=optional,
+        allowed_values=tuple(allowed_values),
+        pattern=pattern,
+        key_pattern=key_pattern,
+        min=min_value,
+        max=max_value,
+        min_length=min_length,
+        max_length=max_length,
+        one_of=tuple(normalize_references(one_of)),
+        any_of=tuple(normalize_references(any_of)),
+        condition=condition,
+        then_reference=normalize_reference(then_reference),
+        else_reference=normalize_reference(else_reference),
+        all_of=tuple(normalize_references(all_of)),
+        dependent_required=dependent_required,
+        mutually_exclusive=mutually_exclusive,
+        exactly_one=exactly_one,
+        unique_items=unique_items,
+        default_value=default_value,
+        has_default=has_default,
+        deprecated=bool(deprecated_ptr) if deprecated_ptr is not None else False,
+        has_deprecated=deprecated_ptr is not None,
+        children=children,
+    )
+
+
+class Schema:
+    """A parsed, validated TOML Schema document.
+
+    Construct via :func:`load_schema`. Public accessors: :meth:`validate`,
+    :meth:`validate_file`, :meth:`element`, :meth:`type`, and
+    :attr:`warnings` (non-fatal discovery warnings, e.g. schema-language
+    version mismatches).
+    """
+
+    def __init__(
+        self, source: str, version: str, types: Dict[str, Definition], elements: Dict[str, Definition]
+    ) -> None:
+        self.source = source
+        self.version = version
+        self.warnings: List[str] = []
+        self.types = types
+        self.elements = elements
+
+    # -- public API -----------------------------------------------------------
+
+    def element(self, name: str) -> Optional[Definition]:
+        """Returns an element definition with inherited annotations resolved."""
+        definition = self.elements.get(name)
+        if definition is None:
+            return None
+        return self._with_effective_annotations(definition)
+
+    def type(self, name: str) -> Optional[Definition]:
+        """Returns a named type definition with inherited annotations resolved."""
+        definition = self.types.get(normalize_reference(name))
+        if definition is None:
+            return None
+        return self._with_effective_annotations(definition)
+
+    def validate(self, document: dict) -> ValidationResult:
+        validator = Validator(self)
+        validator.validate_table("$", document, self.elements)
+        for key in document:
+            if key not in self.elements and key != "toml-schema":
+                validator.add(f"$.{_encode_root_key(key)}", "unexpected key")
+        return ValidationResult(errors=validator.errors, warnings=validator.warnings)
+
+    def validate_file(self, path: str) -> ValidationResult:
+        try:
+            document = load_document(path)
+        except Exception as exc:  # noqa: BLE001 - surfaced as a structured diagnostic
+            diagnostic = Diagnostic(
+                severity=Severity.ERROR, code="document-parse-error", path="$", message=str(exc)
+            )
+            return ValidationResult(errors=[diagnostic])
+        return self.validate(document)
+
+    # -- annotation resolution -------------------------------------------------
+
+    def _with_effective_annotations(self, definition: Definition) -> Definition:
+        resolver = _AnnotationResolver(self)
+        effective, _ = resolver.resolve(definition)
+        return effective
+
+    def effective_description(self, definition: Definition, visiting: Set[str]) -> str:
+        if definition.description:
+            return definition.description
+        reference = definition.reference
+        if not reference:
+            return ""
+        if parse_schema_type(reference) is not None or reference in visiting:
+            return ""
+        target = self.types.get(reference)
+        if target is None:
+            return ""
+        visiting.add(reference)
+        try:
+            return self.effective_description(target, visiting)
+        finally:
+            visiting.discard(reference)
+
+    def effective_deprecated(self, definition: Definition, visiting: Set[str]) -> bool:
+        if definition.deprecated:
+            return True
+        references = list(definition.all_of)
+        if definition.reference:
+            references.append(definition.reference)
+        for reference in references:
+            if parse_schema_type(reference) is not None or reference in visiting:
+                continue
+            target = self.types.get(reference)
+            if target is not None:
+                visiting.add(reference)
+                try:
+                    if self.effective_deprecated(target, visiting):
+                        return True
+                finally:
+                    visiting.discard(reference)
+        return False
+
+    def effective_default(self, definition: Definition, visiting: Set[str]) -> Tuple[Any, bool]:
+        if definition.has_default:
+            return definition.default_value, True
+        value: Any = None
+        found = False
+        references = list(definition.all_of)
+        if definition.reference:
+            references = [definition.reference] + references
+        for reference in references:
+            if parse_schema_type(reference) is not None:
+                continue
+            if reference in visiting:
+                raise SchemaError(f"cyclic default reference: {reference}")
+            target = self.types.get(reference)
+            if target is None:
+                continue
+            visiting.add(reference)
+            try:
+                candidate, has_candidate = self.effective_default(target, visiting)
+            finally:
+                visiting.discard(reference)
+            if not has_candidate:
+                continue
+            if found and not values_equal(value, candidate):
+                raise SchemaError(f"{definition.name} has conflicting inherited defaults")
+            value, found = candidate, True
+        return value, found
+
+    # -- composition/effective-kind resolution ---------------------------------
+
+    def definition_for_reference(self, reference: str) -> Definition:
+        normalized = normalize_reference(reference)
+        builtin = parse_schema_type(normalized)
+        if builtin is not None:
+            return Definition(name=normalized, type_name=builtin)
+        definition = self.types.get(normalized)
+        if definition is None:
+            raise SchemaError(f"unknown type reference: {reference}")
+        return definition
+
+    def effective_kind(
+        self, definition: Definition, visiting: Set[str]
+    ) -> Tuple[Optional[SchemaType], bool]:
+        kind: Optional[SchemaType] = None
+        resolved = False
+        if definition.reference:
+            target = self.types.get(definition.reference)
+            if target is None:
+                raise SchemaError(f"unknown type reference: {definition.reference}")
+            if definition.reference in visiting:
+                raise SchemaError(f"cyclic type reference: {definition.reference}")
+            visiting.add(definition.reference)
+            try:
+                kind, resolved = self.effective_kind(target, visiting)
+            finally:
+                visiting.discard(definition.reference)
+        elif definition.one_of or definition.any_of:
+            alternatives = definition.one_of if definition.one_of else definition.any_of
+            for reference in alternatives:
+                alternative = self.definition_for_reference(reference)
+                alternative_kind, ok = self.effective_kind(alternative, visiting)
+                if not ok or (resolved and alternative_kind != kind):
+                    resolved = False
+                    kind = None
+                    break
+                kind, resolved = alternative_kind, True
+        elif definition.condition is not None:
+            for reference in (definition.then_reference, definition.else_reference):
+                branch = self.definition_for_reference(reference)
+                branch_kind, ok = self.effective_kind(branch, visiting)
+                if not ok or (resolved and branch_kind != kind):
+                    raise SchemaError("conditional branches have incompatible effective kinds")
+                kind, resolved = branch_kind, True
+        else:
+            kind, resolved = definition.type_name, definition.type_name is not None
+
+        if not definition.all_of:
+            return kind, resolved
+        if not resolved or kind == SchemaType.ANY:
+            raise SchemaError("allof requires a determinate effective kind")
+        for reference in definition.all_of:
+            component = self.definition_for_reference(reference)
+            component_kind, ok = self.effective_kind(component, visiting)
+            if not ok or component_kind == SchemaType.ANY or component_kind != kind:
+                raise SchemaError(f"allof component {reference} has incompatible effective kind")
+        return kind, True
+
+    def effective_fixed_children(self, definition: Definition, visiting: Set[str]) -> Set[str]:
+        fixed: Set[str] = set(definition.children.keys())
+        references = list(definition.all_of)
+        if definition.reference:
+            references.append(definition.reference)
+        references += list(definition.one_of)
+        references += list(definition.any_of)
+        if definition.condition is not None:
+            references += [definition.then_reference, definition.else_reference]
+        for reference in references:
+            if parse_schema_type(reference) is not None:
+                continue
+            if reference in visiting:
+                raise SchemaError(f"cyclic composition reference: {reference}")
+            target = self.types.get(reference)
+            if target is None:
+                raise SchemaError(f"unknown type reference: {reference}")
+            visiting.add(reference)
+            try:
+                target_fixed = self.effective_fixed_children(target, visiting)
+            finally:
+                visiting.discard(reference)
+            fixed.update(target_fixed)
+        return fixed
+
+    def has_collection_item_constraint(self, definition: Definition, visiting: Set[str]) -> bool:
+        if definition.item_reference:
+            return True
+        references: List[str] = []
+        if definition.reference:
+            references.append(definition.reference)
+        references += list(definition.one_of)
+        references += list(definition.any_of)
+        if definition.condition is not None:
+            references += [definition.then_reference, definition.else_reference]
+        references += list(definition.all_of)
+        for reference in references:
+            if parse_schema_type(reference) is not None:
+                continue
+            if reference in visiting:
+                raise SchemaError(f"cyclic composition reference: {reference}")
+            target = self.types.get(reference)
+            if target is None:
+                raise SchemaError(f"unknown type reference: {reference}")
+            visiting.add(reference)
+            try:
+                found = self.has_collection_item_constraint(target, visiting)
+            finally:
+                visiting.discard(reference)
+            if found:
+                return True
+        return False
+
+    def resolve_item_kind(self, reference: str, seen: Set[str]) -> Tuple[Optional[SchemaType], bool]:
+        normalized = normalize_reference(reference)
+        if not normalized:
+            return None, False
+        builtin = parse_schema_type(normalized)
+        if builtin is not None:
+            return builtin, True
+        if normalized in seen:
+            raise SchemaError(f"cyclic type reference: {normalized}")
+        definition = self.types.get(normalized)
+        if definition is None:
+            raise SchemaError(f"unknown type reference: {reference}")
+        seen.add(normalized)
+        try:
+            if definition.reference:
+                return self.resolve_item_kind(definition.reference, seen)
+            if definition.condition is not None:
+                kind: Optional[SchemaType] = None
+                for candidate_reference in (definition.then_reference, definition.else_reference):
+                    branch_kind, resolved = self.resolve_item_kind(candidate_reference, seen)
+                    if not resolved or (kind is not None and branch_kind != kind):
+                        return None, False
+                    kind = branch_kind
+                return kind, kind is not None
+            alternatives = definition.one_of if definition.one_of else definition.any_of
+            if not alternatives:
+                return definition.type_name, definition.type_name is not None
+            resolved_type: Optional[SchemaType] = None
+            for alternative in alternatives:
+                alternative_type, ok = self.resolve_item_kind(alternative, seen)
+                if not ok or (resolved_type is not None and alternative_type != resolved_type):
+                    return None, False
+                resolved_type = alternative_type
+            return resolved_type, resolved_type is not None
+        finally:
+            seen.discard(normalized)
+
+    def collect_reference_types(self, reference: str, seen: Set[str], types: Set[SchemaType]) -> None:
+        normalized = normalize_reference(reference)
+        builtin = parse_schema_type(normalized)
+        if builtin is not None:
+            types.add(builtin)
+            return
+        if normalized in seen:
+            raise SchemaError(f"cyclic type reference: {normalized}")
+        definition = self.types.get(normalized)
+        if definition is None:
+            raise SchemaError(f"unknown type reference: {reference}")
+        seen.add(normalized)
+        try:
+            if definition.reference:
+                self.collect_reference_types(definition.reference, seen, types)
+                return
+            if definition.condition is not None:
+                for candidate_reference in (definition.then_reference, definition.else_reference):
+                    self.collect_reference_types(candidate_reference, seen, types)
+                return
+            alternatives = definition.one_of if definition.one_of else definition.any_of
+            if not alternatives:
+                if definition.type_name is not None:
+                    types.add(definition.type_name)
+                return
+            for alternative in alternatives:
+                self.collect_reference_types(alternative, seen, types)
+        finally:
+            seen.discard(normalized)
+
+    # -- schema-load-time validation passes -------------------------------------
+
+    def validate_references(self, definitions: Dict[str, Definition]) -> None:
+        for definition in definitions.values():
+            references = [definition.reference, definition.item_reference]
+            references += list(definition.items)
+            references += list(definition.one_of)
+            references += list(definition.any_of)
+            if definition.condition is not None:
+                references += [definition.then_reference, definition.else_reference]
+            references += list(definition.all_of)
+            for reference in references:
+                if not reference:
+                    continue
+                if parse_schema_type(reference) is not None:
+                    continue
+                if reference not in self.types:
+                    raise SchemaError(f"{definition.name} contains unknown type reference: {reference}")
+            self.validate_references(definition.children)
+
+    def validate_selector_cycles(self) -> None:
+        visited: Set[str] = set()
+        for type_name in self.types:
+            self.validate_selector_cycle(type_name, set(), visited)
+
+    def validate_selector_cycle(self, type_name: str, visiting: Set[str], visited: Set[str]) -> None:
+        if parse_schema_type(type_name) is not None or type_name in visited:
+            return
+        if type_name in visiting:
+            raise SchemaError(f"cyclic type selector reference involving types.{type_name}")
+        definition = self.types.get(type_name)
+        if definition is None:
+            return
+        visiting.add(type_name)
+        references = [definition.reference]
+        references += list(definition.one_of)
+        references += list(definition.any_of)
+        if definition.condition is not None:
+            references += [definition.then_reference, definition.else_reference]
+        references += list(definition.all_of)
+        for reference in references:
+            if reference:
+                self.validate_selector_cycle(reference, visiting, visited)
+        visiting.discard(type_name)
+        visited.add(type_name)
+
+    def validate_allowed_value_types(self) -> None:
+        def validate_definition(definition: Definition) -> None:
+            permitted: Set[SchemaType] = set()
+            if definition.allowed_values:
+                if definition.type_name == SchemaType.ARRAY:
+                    if definition.item_reference:
+                        self.collect_reference_types(definition.item_reference, set(), permitted)
+                elif definition.type_name is not None:
+                    permitted.add(definition.type_name)
+                for index, value in enumerate(definition.allowed_values):
+                    matches = len(permitted) == 0
+                    for candidate_type in permitted:
+                        if is_type(value, candidate_type):
+                            matches = True
+                            break
+                    if not matches:
+                        raise SchemaError(
+                            f"{definition.name} allowedvalues[{index}] does not match the permitted TOML type"
+                        )
+            for child in definition.children.values():
+                validate_definition(child)
+
+        for definitions in (self.types, self.elements):
+            for definition in definitions.values():
+                validate_definition(definition)
+
+    def validate_semantics(self) -> None:
+        for definitions in (self.types, self.elements):
+            for definition in definitions.values():
+                self.validate_definition_semantics(definition)
+
+    def validate_definition_semantics(self, definition: Definition) -> None:
+        try:
+            kind, resolved = self.effective_kind(definition, set())
+        except SchemaError as exc:
+            raise SchemaError(f"{definition.name}: {exc}") from exc
+        has_sibling_rules = bool(definition.dependent_required) or bool(
+            definition.mutually_exclusive
+        ) or bool(definition.exactly_one)
+        if has_sibling_rules:
+            if not resolved or kind not in (SchemaType.TABLE, SchemaType.COLLECTION):
+                raise SchemaError(f"{definition.name} sibling rules require an effective table or collection")
+            try:
+                fixed = self.effective_fixed_children(definition, set())
+            except SchemaError as exc:
+                raise SchemaError(f"{definition.name}: {exc}") from exc
+
+            def check_name(property_name: str, operand: str) -> None:
+                if operand not in fixed:
+                    raise SchemaError(
+                        f"{definition.name} {property_name} contains unknown fixed child {operand!r}"
+                    )
+
+            for trigger, dependencies in definition.dependent_required.items():
+                check_name("dependentrequired", trigger)
+                for dependency in dependencies:
+                    check_name("dependentrequired", dependency)
+            for property_name, groups in (
+                ("mutuallyexclusive", definition.mutually_exclusive),
+                ("exactlyone", definition.exactly_one),
+            ):
+                for group in groups:
+                    for operand in group:
+                        check_name(property_name, operand)
+        if definition.unique_items is not None and (not resolved or kind != SchemaType.ARRAY):
+            raise SchemaError(f"{definition.name} uniqueitems requires an effective array")
+        if resolved and kind == SchemaType.COLLECTION:
+            try:
+                has_constraint = self.has_collection_item_constraint(definition, set())
+            except SchemaError as exc:
+                raise SchemaError(f"{definition.name}: {exc}") from exc
+            if not has_constraint:
+                raise SchemaError(f"{definition.name} effective collection must define at least one itemtype")
+        if definition.condition is not None:
+            if not resolved or kind not in (SchemaType.TABLE, SchemaType.COLLECTION):
+                raise SchemaError(
+                    f"{definition.name} conditional selector requires compatible table or collection branches"
+                )
+        for child in definition.children.values():
+            self.validate_definition_semantics(child)
+
+    def validate_array_ranges(self) -> None:
+        def validate_definition(definition: Definition) -> None:
+            if definition.type_name == SchemaType.ARRAY and (
+                definition.min is not None or definition.max is not None
+            ):
+                try:
+                    item_type, ok = self.resolve_item_kind(definition.item_reference, set())
+                except SchemaError as exc:
+                    raise SchemaError(f"{definition.name} has invalid itemtype: {exc}") from exc
+                if not ok or not is_range_comparable(item_type):
+                    raise SchemaError(
+                        f"{definition.name} can only define min or max when itemtype resolves to one comparable built-in type"
+                    )
+                _validate_boundary_matches_type(definition.name, "min", definition.min, item_type)
+                _validate_boundary_matches_type(definition.name, "max", definition.max, item_type)
+            for child in definition.children.values():
+                validate_definition(child)
+
+        for definitions in (self.types, self.elements):
+            for definition in definitions.values():
+                validate_definition(definition)
+
+    def validate_defaults(self) -> None:
+        def validate_definition(definition: Definition) -> None:
+            value, has_default = self.effective_default(definition, set())
+            if has_default:
+                candidate = Validator(self, suppress_warnings=True)
+                candidate.validate_value(definition.name, value, definition)
+                if candidate.errors:
+                    raise SchemaError(f"{definition.name} default is invalid: {candidate.errors[0].message}")
+            for child in definition.children.values():
+                validate_definition(child)
+
+        for definitions in (self.types, self.elements):
+            for definition in definitions.values():
+                validate_definition(definition)
+
+
+class _AnnotationResolver:
+    """Materializes effective annotations (default/deprecated/description and
+    reference-merged children) for a definition tree.
+
+    Schemas may legally recurse through child definitions that reference an
+    enclosing named type, so resolution is guarded against re-entering a
+    definition it is already expanding and memoizes fully expanded results --
+    mirrors Go's ``annotationResolver``.
+    """
+
+    def __init__(self, schema: Schema) -> None:
+        self.schema = schema
+        self.visiting: Set[str] = set()
+        self.resolved: Dict[str, Definition] = {}
+
+    def resolve(self, definition: Definition) -> Tuple[Definition, bool]:
+        key = definition.name + "\x00" + definition.reference
+        if key in self.resolved:
+            return self.resolved[key], True
+        effective = self._annotate(definition)
+        if key in self.visiting:
+            return effective, False
+        self.visiting.add(key)
+        try:
+            complete = True
+            children: Dict[str, Definition] = {}
+            for name, child in effective.children.items():
+                resolved_child, child_complete = self.resolve(child)
+                complete = complete and child_complete
+                children[name] = resolved_child
+            effective = dataclasses.replace(effective, children=children)
+            if complete:
+                self.resolved[key] = effective
+            return effective, complete
+        finally:
+            self.visiting.discard(key)
+
+    def _annotate(self, definition: Definition) -> Definition:
+        original = definition
+        try:
+            resolved = Validator(self.schema).resolve(definition, set())
+            definition = resolved
+        except SchemaError:
+            pass
+        try:
+            value, has_value = self.schema.effective_default(original, set())
+        except SchemaError:
+            has_value = False
+            value = None
+        if has_value:
+            definition = dataclasses.replace(definition, default_value=value, has_default=True)
+        deprecated = self.schema.effective_deprecated(original, set())
+        definition = dataclasses.replace(definition, deprecated=deprecated)
+        if not definition.description:
+            description = self.schema.effective_description(original, set())
+            if description:
+                definition = dataclasses.replace(definition, description=description)
+        return definition
+
+
+_PLAIN_ROOT_KEY_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def _encode_root_key(key: str) -> str:
+    if key and _PLAIN_ROOT_KEY_RE.match(key):
+        return key
+    import json
+
+    return json.dumps(key)
+
+
+def load_schema(path: str) -> Schema:
+    """Loads and fully validates a ``.tosd`` schema document.
+
+    Raises :class:`toml_schema.SchemaError` if the schema is structurally or
+    semantically invalid.
+    """
+    try:
+        with open(path, "rb") as handle:
+            content_bytes = handle.read()
+    except OSError as exc:
+        raise SchemaError(f"unable to parse schema {path}: {exc}") from exc
+    try:
+        content_text = content_bytes.decode("utf-8")
+        parsed = tomllib.loads(content_text)
+    except (tomllib.TOMLDecodeError, UnicodeDecodeError) as exc:
+        raise SchemaError(f"unable to parse schema {path}: {exc}") from exc
+
+    source = SchemaSource(content_text)
+
+    metadata = parsed.get("toml-schema")
+    if not isinstance(metadata, dict):
+        raise SchemaError("schema must contain a [toml-schema] table")
+    if not isinstance(parsed.get("elements"), dict):
+        raise SchemaError("schema must contain an [elements] table")
+    for key in parsed:
+        if key not in ("toml-schema", "types", "elements"):
+            raise SchemaError(f"unsupported top-level schema key: {key}")
+    if "version" not in metadata:
+        raise SchemaError("[toml-schema] must contain version")
+    version = metadata["version"]
+    validate_schema_version(version)
+    for key in metadata:
+        if key not in ("version", "meta"):
+            raise SchemaError(f"unsupported [toml-schema] key: {key}")
+
+    types = parse_definitions("types", parsed.get("types"), False, source)
+    elements = parse_definitions("elements", parsed.get("elements"), True, source)
+
+    schema = Schema(source=str(path), version=version, types=types, elements=elements)
+    schema.validate_references(types)
+    schema.validate_references(elements)
+    schema.validate_selector_cycles()
+    schema.validate_allowed_value_types()
+    schema.validate_semantics()
+    schema.validate_array_ranges()
+    schema.validate_defaults()
+    return schema

--- a/reference-implementations/python/src/toml_schema/_source.py
+++ b/reference-implementations/python/src/toml_schema/_source.py
@@ -1,0 +1,248 @@
+"""Schema-source syntax recovery.
+
+TOML Schema disambiguates an annotation property from a child definition by
+syntax rather than by member name: ``default = { ... }`` is always the
+annotation, while a ``[elements.options.default]`` table header is always a
+child definition named ``default``. Once TOML is parsed into plain Python
+values that distinction is lost, so this module re-scans the original schema
+source text to record which table-valued keys were written using inline-table
+syntax.
+
+Python's standard-library ``tomllib`` does not expose a syntax tree, so this
+module implements a small purpose-built scanner. It only needs to recover
+enough structure to answer one question for a given dotted key path: was the
+value at this path written as ``key = { ... }`` (an inline table)? Inline
+tables in TOML 1.0 always appear on a single logical value span (they cannot
+contain top-level newlines), and this implementation never needs to look
+inside arrays (annotations such as ``default`` are never disambiguated through
+array elements), which keeps the scanner intentionally narrow.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import FrozenSet, List, Tuple
+
+Path = Tuple[str, ...]
+
+
+class SchemaSource:
+    """Tracks which schema keys were written as inline tables."""
+
+    __slots__ = ("_inline_tables",)
+
+    def __init__(self, content: str = "") -> None:
+        self._inline_tables: FrozenSet[Path] = _scan_inline_table_paths(content)
+
+    def is_property(self, table: dict, path: Path, key: str) -> bool:
+        """Whether ``key`` in ``table`` (located at ``path``) is an annotation
+        property rather than a nested child definition.
+
+        A non-table value is always a property. A table value is a property
+        only when the schema source wrote it as an inline table.
+        """
+        if key not in table:
+            return False
+        value = table[key]
+        if not isinstance(value, dict):
+            return True
+        return (path + (key,)) in self._inline_tables
+
+
+def _normalize_newlines(text: str) -> str:
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def _scan_inline_table_paths(content: str) -> FrozenSet[Path]:
+    text = _normalize_newlines(content)
+    inline_paths: set[Path] = set()
+    try:
+        _scan_document(text, inline_paths)
+    except Exception:
+        # Best-effort recovery: a scanner mishap must never break schema
+        # loading. Falling back to "nothing is an inline table" only means
+        # ambiguous definition-key/child-definition collisions are resolved
+        # as child definitions, which is safe (parsing continues and simply
+        # cannot special-case those inline annotations).
+        return frozenset()
+    return frozenset(inline_paths)
+
+
+def _skip_ws(text: str, i: int) -> int:
+    n = len(text)
+    while i < n and text[i] in " \t":
+        i += 1
+    return i
+
+
+def _skip_ws_and_newlines(text: str, i: int) -> int:
+    n = len(text)
+    while i < n and text[i] in " \t\n":
+        i += 1
+    return i
+
+
+def _skip_blank_and_comment_lines(text: str, i: int) -> int:
+    n = len(text)
+    while True:
+        i = _skip_ws_and_newlines(text, i)
+        if i < n and text[i] == "#":
+            while i < n and text[i] != "\n":
+                i += 1
+            continue
+        return i
+
+
+def _skip_string(text: str, i: int) -> int:
+    """text[i] is an opening quote character; returns the index after the
+    matching closing quote."""
+    n = len(text)
+    quote = text[i]
+    if text[i : i + 3] == quote * 3:
+        closing = quote * 3
+        j = i + 3
+        while j < n:
+            if quote == '"' and text[j] == "\\":
+                j += 2
+                continue
+            if text[j : j + 3] == closing:
+                return j + 3
+            j += 1
+        return j
+    j = i + 1
+    while j < n:
+        if quote == '"' and text[j] == "\\":
+            j += 2
+            continue
+        if text[j] == quote:
+            return j + 1
+        if text[j] == "\n":
+            return j
+        j += 1
+    return j
+
+
+def _scan_value(text: str, i: int, stop_chars: str) -> int:
+    """Scans a value starting at i; returns the index of the first stop
+    character reached at nesting depth 0 (relative to i), or of an unmatched
+    closing bracket/brace that belongs to an enclosing structure, or EOF."""
+    n = len(text)
+    depth = 0
+    j = i
+    while j < n:
+        c = text[j]
+        if c in "\"'":
+            j = _skip_string(text, j)
+            continue
+        if depth == 0 and c in stop_chars:
+            break
+        if c in "[{":
+            depth += 1
+        elif c in "]}":
+            if depth == 0:
+                break
+            depth -= 1
+        j += 1
+    return j
+
+
+def _read_quoted_key(text: str, i: int) -> Tuple[str, int]:
+    end = _skip_string(text, i)
+    raw = text[i:end]
+    if raw[0] == '"':
+        return json.loads(raw), end
+    return raw[1:-1], end
+
+
+def _read_key_path(text: str, i: int) -> Tuple[List[str], int]:
+    keys: List[str] = []
+    j = _skip_ws(text, i)
+    n = len(text)
+    while True:
+        if j < n and text[j] in "\"'":
+            key, j = _read_quoted_key(text, j)
+        else:
+            start = j
+            while j < n and (text[j].isalnum() or text[j] in "_-"):
+                j += 1
+            key = text[start:j]
+        keys.append(key)
+        save = j
+        j = _skip_ws(text, j)
+        if j < n and text[j] == ".":
+            j = _skip_ws(text, j + 1)
+            continue
+        j = save
+        break
+    return keys, j
+
+
+def _record_inline_table(text: str, brace_index: int, path: Path, inline_paths: set) -> int:
+    n = len(text)
+    j = brace_index + 1
+    while True:
+        j = _skip_ws_and_newlines(text, j)
+        if j >= n or text[j] == "}":
+            return j + 1 if j < n else j
+        keys, j = _read_key_path(text, j)
+        j = _skip_ws(text, j)
+        if j >= n or text[j] != "=":
+            return j
+        j = _skip_ws(text, j + 1)
+        child_path = path + tuple(keys)
+        if j < n and text[j] == "{":
+            inline_paths.add(child_path)
+            j = _record_inline_table(text, j, child_path, inline_paths)
+        else:
+            j = _scan_value(text, j, ",")
+        j = _skip_ws_and_newlines(text, j)
+        if j < n and text[j] == ",":
+            j += 1
+            continue
+        if j < n and text[j] == "}":
+            return j + 1
+        return j
+
+
+def _scan_document(text: str, inline_paths: set) -> None:
+    n = len(text)
+    i = 0
+    prefix: Path = ()
+    while True:
+        i = _skip_blank_and_comment_lines(text, i)
+        if i >= n:
+            return
+        if text[i] == "[":
+            is_array_table = i + 1 < n and text[i + 1] == "["
+            j = i + (2 if is_array_table else 1)
+            j = _skip_ws(text, j)
+            keys, j = _read_key_path(text, j)
+            j = _skip_ws(text, j)
+            if is_array_table and text[j : j + 2] == "]]":
+                j += 2
+            elif not is_array_table and j < n and text[j] == "]":
+                j += 1
+            while j < n and text[j] != "\n":
+                j += 1
+            prefix = tuple(keys)
+            i = j
+            continue
+        keys, j = _read_key_path(text, i)
+        j = _skip_ws(text, j)
+        if j >= n or text[j] != "=":
+            # Malformed for our purposes; skip forward defensively.
+            i = j + 1 if j >= i else i + 1
+            continue
+        j = _skip_ws(text, j + 1)
+        full_path = prefix + tuple(keys)
+        if j < n and text[j] == "{":
+            inline_paths.add(full_path)
+            j = _record_inline_table(text, j, full_path, inline_paths)
+            while j < n and text[j] != "\n":
+                j += 1
+        else:
+            j = _scan_value(text, j, "\n#")
+            if j < n and text[j] == "#":
+                while j < n and text[j] != "\n":
+                    j += 1
+        i = j

--- a/reference-implementations/python/src/toml_schema/_types.py
+++ b/reference-implementations/python/src/toml_schema/_types.py
@@ -1,0 +1,94 @@
+"""Core public types: schema type names, diagnostics, and validation results."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import List, Sequence
+
+
+class SchemaType(str, Enum):
+    """The built-in TOML Schema type names."""
+
+    ANY = "any"
+    STRING = "string"
+    INTEGER = "integer"
+    FLOAT = "float"
+    BOOLEAN = "boolean"
+    OFFSET_DATE_TIME = "offset-date-time"
+    LOCAL_DATE_TIME = "local-date-time"
+    LOCAL_DATE = "local-date"
+    LOCAL_TIME = "local-time"
+    ARRAY = "array"
+    TABLE = "table"
+    COLLECTION = "collection"
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return self.value
+
+
+_BUILT_IN_TYPES = {member.value: member for member in SchemaType}
+
+
+def parse_schema_type(value: str) -> SchemaType | None:
+    return _BUILT_IN_TYPES.get(value)
+
+
+_TYPES_PREFIX = "types."
+
+
+def normalize_reference(reference: str) -> str:
+    """Strips a leading ``types.`` prefix, mirroring Go's
+    ``strings.TrimPrefix(reference, "types.")``."""
+    if reference.startswith(_TYPES_PREFIX):
+        return reference[len(_TYPES_PREFIX) :]
+    return reference
+
+
+def normalize_references(references: Sequence[str]) -> List[str]:
+    return [normalize_reference(reference) for reference in references]
+
+
+class Severity(str, Enum):
+    """The severity of a validation diagnostic."""
+
+    ERROR = "error"
+    WARNING = "warning"
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return self.value
+
+
+@dataclass(frozen=True)
+class Diagnostic:
+    """A single structured validation diagnostic (error or warning)."""
+
+    severity: Severity
+    code: str
+    path: str
+    message: str
+
+
+# ValidationError is an alias for Diagnostic, mirroring the other reference
+# implementations (which use one structured diagnostic type for both errors
+# and warnings).
+ValidationError = Diagnostic
+
+
+@dataclass
+class ValidationResult:
+    """The outcome of validating a document against a Schema."""
+
+    errors: List[Diagnostic] = field(default_factory=list)
+    warnings: List[Diagnostic] = field(default_factory=list)
+
+    @property
+    def diagnostics(self) -> List[Diagnostic]:
+        return [*self.errors, *self.warnings]
+
+    @property
+    def valid(self) -> bool:
+        return len(self.errors) == 0
+
+    def __bool__(self) -> bool:
+        return self.valid

--- a/reference-implementations/python/src/toml_schema/_validator.py
+++ b/reference-implementations/python/src/toml_schema/_validator.py
@@ -1,0 +1,677 @@
+"""The document validator: applies a resolved Definition tree to a parsed TOML
+document and produces structured errors/warnings.
+
+This mirrors the Go ``validator`` type in ``schema.go`` closely, including its
+reference-resolution/merge semantics (``resolve``/``resolve_reference``) and
+its composed table/collection validation for ``allof`` (structural + union +
+conditional contributors).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from ._compare import IncomparableError, compare, is_type, type_name_of, values_equal
+from ._definition import Condition, Definition
+from ._errors import SchemaError
+from ._types import Diagnostic, Severity, SchemaType, normalize_reference, parse_schema_type
+
+_PLAIN_KEY_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def _encode_path_key(key: str) -> str:
+    if key and _PLAIN_KEY_RE.match(key):
+        return key
+    return json.dumps(key)
+
+
+def append_path(path: str, key: str) -> str:
+    return f"{path}.{_encode_path_key(key)}"
+
+
+def _condition_matches(table: dict, condition: Condition) -> bool:
+    if condition.key not in table:
+        return False
+    value = table[condition.key]
+    if condition.has_equals:
+        return values_equal(condition.equals, value)
+    return any(values_equal(candidate, value) for candidate in condition.in_values)
+
+
+def _merge_dependencies(
+    left: Dict[str, Tuple[str, ...]], right: Dict[str, Tuple[str, ...]]
+) -> Dict[str, Tuple[str, ...]]:
+    if not left and not right:
+        return {}
+    merged: Dict[str, Tuple[str, ...]] = {}
+    for trigger, dependencies in left.items():
+        merged[trigger] = merged.get(trigger, ()) + tuple(dependencies)
+    for trigger, dependencies in right.items():
+        merged[trigger] = merged.get(trigger, ()) + tuple(dependencies)
+    return merged
+
+
+def _present_group_members(table: dict, group: Tuple[str, ...]) -> List[str]:
+    return [name for name in group if name in table]
+
+
+@dataclass
+class CompositionParts:
+    structural: List[Definition] = field(default_factory=list)
+    unions: List[Definition] = field(default_factory=list)
+    conditionals: List[Definition] = field(default_factory=list)
+
+
+class Validator:
+    """A single validation pass. Instances are cheap and disposable: unions,
+    allof alternatives, and default validation each run against isolated
+    sub-validators so a failed branch's diagnostics never leak into the
+    aggregate result."""
+
+    def __init__(self, schema: Any, suppress_warnings: bool = False) -> None:
+        self.schema = schema
+        self.errors: List[Diagnostic] = []
+        self.warnings: List[Diagnostic] = []
+        self.suppress_warnings = suppress_warnings
+
+    # -- table/value dispatch -------------------------------------------------
+
+    def validate_table(self, path: str, table: dict, definitions: Dict[str, Definition]) -> None:
+        for key, definition in definitions.items():
+            try:
+                resolved = self.resolve(definition, set())
+            except SchemaError as exc:
+                self.add(append_path(path, key), str(exc))
+                continue
+            child_path = append_path(path, key)
+            if key not in table:
+                if not resolved.optional:
+                    self.add(child_path, "required value is missing")
+                continue
+            self.validate_value(child_path, table[key], resolved)
+
+    def validate_value(self, path: str, value: Any, definition: Definition) -> None:
+        candidate = Validator(self.schema, suppress_warnings=self.suppress_warnings)
+        candidate._validate_value_internal(path, value, definition)
+        self.errors.extend(candidate.errors)
+        if not candidate.errors:
+            self.append_warnings(candidate.warnings)
+
+    def _validate_value_internal(self, path: str, value: Any, definition: Definition) -> None:
+        try:
+            resolved = self.resolve(definition, set())
+        except SchemaError as exc:
+            self.add(path, str(exc))
+            return
+        if resolved.condition is not None:
+            self.validate_conditional(path, value, resolved)
+        elif resolved.one_of or resolved.any_of:
+            self.validate_union(path, value, resolved)
+        elif resolved.all_of:
+            self.validate_all_of(path, value, resolved)
+        else:
+            self.validate_plain_value(path, value, resolved)
+        if not self.errors and resolved.deprecated:
+            self.warn(path, "deprecated", "value is deprecated")
+
+    def validate_conditional(self, path: str, value: Any, definition: Definition) -> None:
+        reference = definition.else_reference
+        if isinstance(value, dict) and _condition_matches(value, definition.condition):
+            reference = definition.then_reference
+        try:
+            branch = self.resolve_reference(reference, set())
+        except SchemaError as exc:
+            self.add(path, str(exc))
+            return
+        branch = dataclasses.replace(branch, all_of=branch.all_of + definition.all_of)
+        self.validate_value(path, value, branch)
+
+    def validate_plain_value(self, path: str, value: Any, definition: Definition) -> None:
+        type_name = definition.type_name if definition.type_name is not None else SchemaType.ANY
+        self.validate_type(path, value, type_name)
+        if not is_type(value, type_name):
+            return
+        self.validate_common_constraints(path, value, definition)
+        if type_name == SchemaType.TABLE:
+            self.validate_table_value(path, value, definition)
+        elif type_name == SchemaType.COLLECTION:
+            self.validate_collection(path, value, definition)
+        elif type_name == SchemaType.ARRAY:
+            self.validate_array(path, value, definition)
+
+    def validate_union(self, path: str, value: Any, definition: Definition) -> None:
+        alternatives = definition.one_of if definition.one_of else definition.any_of
+        matches = 0
+        successes: List[Validator] = []
+        for reference in alternatives:
+            try:
+                referenced = self.resolve_reference(reference, set())
+            except SchemaError as exc:
+                self.add(path, str(exc))
+                return
+            referenced = dataclasses.replace(
+                referenced,
+                all_of=referenced.all_of + definition.all_of,
+                dependent_required=_merge_dependencies(
+                    referenced.dependent_required, definition.dependent_required
+                ),
+                mutually_exclusive=referenced.mutually_exclusive + definition.mutually_exclusive,
+                exactly_one=referenced.exactly_one + definition.exactly_one,
+                unique_items=(
+                    definition.unique_items
+                    if definition.unique_items is not None
+                    else referenced.unique_items
+                ),
+            )
+            candidate = Validator(self.schema, suppress_warnings=self.suppress_warnings)
+            candidate.validate_value(path, value, referenced)
+            if not candidate.errors:
+                matches += 1
+                successes.append(candidate)
+        if definition.one_of and matches != 1:
+            self.add(path, f"expected exactly one matching type from oneof but found {matches}")
+        elif definition.one_of:
+            self.append_warnings(successes[0].warnings)
+        if definition.any_of and matches == 0:
+            self.add(path, "expected at least one matching type from anyof")
+        elif definition.any_of:
+            for candidate in successes:
+                self.append_warnings(candidate.warnings)
+
+    def validate_all_of(self, path: str, value: Any, definition: Definition) -> None:
+        try:
+            kind, resolved = self.schema.effective_kind(definition, set())
+        except SchemaError as exc:
+            self.add(path, str(exc))
+            return
+        if not resolved:
+            self.add(path, "allof has no determinate effective kind")
+            return
+        if kind in (SchemaType.TABLE, SchemaType.COLLECTION):
+            self.validate_composed_structure(path, value, kind, definition, None)
+            return
+        local = dataclasses.replace(definition, all_of=())
+        self.validate_plain_value(path, value, local)
+        for reference in definition.all_of:
+            try:
+                component = self.resolve_reference(reference, set())
+            except SchemaError as exc:
+                self.add(path, str(exc))
+                continue
+            self.validate_value(path, value, component)
+
+    # -- composition (allof over table/collection) ---------------------------
+
+    def composition_parts(self, definition: Definition, visiting: Set[str]) -> CompositionParts:
+        resolved = self.resolve(definition, set())
+        references = list(resolved.all_of)
+        resolved = dataclasses.replace(resolved, all_of=())
+        parts = CompositionParts()
+        if resolved.condition is not None:
+            parts.conditionals.append(resolved)
+        elif resolved.one_of or resolved.any_of:
+            parts.unions.append(resolved)
+        else:
+            parts.structural.append(resolved)
+        for reference in references:
+            if reference in visiting:
+                raise SchemaError(f"cyclic composition reference: {reference}")
+            visiting.add(reference)
+            try:
+                component = self.resolve_reference(reference, set())
+                nested = self.composition_parts(component, visiting)
+            finally:
+                visiting.discard(reference)
+            parts.structural.extend(nested.structural)
+            parts.unions.extend(nested.unions)
+            parts.conditionals.extend(nested.conditionals)
+        return parts
+
+    def validate_composed_structure(
+        self,
+        path: str,
+        value: Any,
+        kind: SchemaType,
+        definition: Definition,
+        inherited_keys: Optional[Set[str]],
+    ) -> None:
+        try:
+            parts = self.composition_parts(definition, set())
+        except SchemaError as exc:
+            self.add(path, str(exc))
+            return
+        self.validate_composed_parts(path, value, kind, parts, inherited_keys)
+
+    def validate_composed_parts(
+        self,
+        path: str,
+        value: Any,
+        kind: SchemaType,
+        parts: CompositionParts,
+        inherited_keys: Optional[Set[str]],
+    ) -> None:
+        if not isinstance(value, dict):
+            self.validate_type(path, value, kind)
+            return
+        table = value
+        children: Dict[str, List[Definition]] = {}
+        has_fixed_structure = bool(inherited_keys)
+        for component in parts.structural:
+            if component.type_name != kind:
+                self.add(path, f"expected {kind} component but found {component.type_name}")
+                continue
+            if component.children:
+                has_fixed_structure = True
+            for name, child in component.children.items():
+                children.setdefault(name, []).append(child)
+        known_keys: Set[str] = set(inherited_keys) if inherited_keys else set()
+        known_keys.update(children.keys())
+        unions: List[Definition] = []
+        union_keys: List[Set[str]] = []
+        for union in parts.unions:
+            try:
+                alternative_keys = self.schema.effective_fixed_children(union, set())
+            except SchemaError as exc:
+                self.add(path, str(exc))
+                continue
+            if alternative_keys:
+                has_fixed_structure = True
+            known_keys.update(alternative_keys)
+            unions.append(union)
+            union_keys.append(alternative_keys)
+        conditionals: List[Definition] = []
+        conditional_keys: List[Set[str]] = []
+        for conditional in parts.conditionals:
+            try:
+                branch_keys = self.schema.effective_fixed_children(conditional, set())
+            except SchemaError as exc:
+                self.add(path, str(exc))
+                continue
+            if branch_keys:
+                has_fixed_structure = True
+            known_keys.update(branch_keys)
+            conditionals.append(conditional)
+            conditional_keys.append(branch_keys)
+        selector_keys: List[Set[str]] = union_keys + conditional_keys
+        for name, definitions in children.items():
+            child_path = append_path(path, name)
+            present = name in table
+            child_value = table.get(name)
+            for child in definitions:
+                try:
+                    resolved = self.resolve(child, set())
+                except SchemaError as exc:
+                    self.add(child_path, str(exc))
+                    continue
+                if not present:
+                    if not resolved.optional:
+                        self.add(child_path, "required value is missing")
+                    continue
+                self.validate_value(child_path, child_value, child)
+        for index, union in enumerate(unions):
+            branch_keys: Set[str] = set(inherited_keys) if inherited_keys else set()
+            branch_keys.update(children.keys())
+            for other_index, keys in enumerate(selector_keys):
+                if other_index == index:
+                    continue
+                branch_keys.update(keys)
+            self.validate_composed_union(path, value, kind, union, branch_keys)
+        for index, conditional in enumerate(conditionals):
+            branch_keys = set(inherited_keys) if inherited_keys else set()
+            branch_keys.update(children.keys())
+            selector_index = len(unions) + index
+            for other_index, keys in enumerate(selector_keys):
+                if other_index == selector_index:
+                    continue
+                branch_keys.update(keys)
+            self.validate_composed_conditional(path, value, kind, conditional, branch_keys)
+        for component in parts.structural:
+            self.validate_sibling_rules(path, table, component)
+        for union in unions:
+            self.validate_sibling_rules(path, table, union)
+        if kind == SchemaType.TABLE:
+            if has_fixed_structure:
+                for key in table:
+                    if key not in known_keys:
+                        self.add(append_path(path, key), "unexpected key")
+        else:
+            for component in parts.structural:
+                dynamic_entries = 0
+                for key, entry in table.items():
+                    if key in known_keys:
+                        continue
+                    dynamic_entries += 1
+                    child_path = append_path(path, key)
+                    if component.key_pattern is not None and not component.key_pattern.search(key):
+                        self.add(
+                            child_path,
+                            f"key does not match keypattern {component.key_pattern.pattern}",
+                        )
+                    if not component.item_reference:
+                        continue
+                    try:
+                        item = self.resolve_reference(component.item_reference, set())
+                    except SchemaError as exc:
+                        self.add(child_path, str(exc))
+                    else:
+                        self.validate_value(child_path, entry, item)
+                self.validate_length(path, dynamic_entries, component)
+        for component in parts.structural:
+            if component.deprecated:
+                self.warn(path, "deprecated", "value is deprecated")
+        for union in unions:
+            if union.deprecated:
+                self.warn(path, "deprecated", "value is deprecated")
+        for conditional in conditionals:
+            if conditional.deprecated:
+                self.warn(path, "deprecated", "value is deprecated")
+
+    def validate_composed_union(
+        self,
+        path: str,
+        value: Any,
+        kind: SchemaType,
+        definition: Definition,
+        known_keys: Set[str],
+    ) -> None:
+        alternatives = definition.one_of if definition.one_of else definition.any_of
+        matches = 0
+        successes: List[Validator] = []
+        for reference in alternatives:
+            try:
+                alternative = self.resolve_reference(reference, set())
+            except SchemaError as exc:
+                self.add(path, str(exc))
+                return
+            candidate = Validator(self.schema, suppress_warnings=self.suppress_warnings)
+            try:
+                alternative_kind, resolved = self.schema.effective_kind(alternative, set())
+            except SchemaError as exc:
+                candidate.add(path, str(exc))
+            else:
+                if not resolved or alternative_kind != kind:
+                    candidate.add(path, f"expected {kind} alternative but found {alternative_kind}")
+                else:
+                    candidate.validate_composed_structure(path, value, kind, alternative, known_keys)
+            if not candidate.errors:
+                matches += 1
+                successes.append(candidate)
+        if definition.one_of:
+            if matches != 1:
+                self.add(path, f"expected exactly one matching type from oneof but found {matches}")
+                return
+            self.append_warnings(successes[0].warnings)
+            return
+        if matches == 0:
+            self.add(path, "expected at least one matching type from anyof")
+            return
+        for candidate in successes:
+            self.append_warnings(candidate.warnings)
+
+    def validate_composed_conditional(
+        self,
+        path: str,
+        value: Any,
+        kind: SchemaType,
+        definition: Definition,
+        known_keys: Set[str],
+    ) -> None:
+        reference = definition.else_reference
+        if isinstance(value, dict) and _condition_matches(value, definition.condition):
+            reference = definition.then_reference
+        try:
+            branch = self.resolve_reference(reference, set())
+        except SchemaError as exc:
+            self.add(path, str(exc))
+            return
+        try:
+            branch_kind, resolved = self.schema.effective_kind(branch, set())
+        except SchemaError as exc:
+            self.add(path, str(exc))
+            return
+        if not resolved or branch_kind != kind:
+            self.add(path, f"expected {kind} conditional branch but found {branch_kind}")
+            return
+        self.validate_composed_structure(path, value, kind, branch, known_keys)
+
+    # -- plain table/collection/array validation ------------------------------
+
+    def validate_table_value(self, path: str, table: dict, definition: Definition) -> None:
+        if not definition.children:
+            return
+        self.validate_table(path, table, definition.children)
+        for key in table:
+            if key not in definition.children:
+                self.add(append_path(path, key), "unexpected key")
+        self.validate_sibling_rules(path, table, definition)
+
+    def validate_collection(self, path: str, table: dict, definition: Definition) -> None:
+        dynamic_entries = 0
+        for key, value in table.items():
+            child_path = append_path(path, key)
+            fixed_child = definition.children.get(key)
+            if fixed_child is not None:
+                self.validate_value(child_path, value, fixed_child)
+                continue
+            dynamic_entries += 1
+            if definition.key_pattern is not None and not definition.key_pattern.search(key):
+                self.add(child_path, f"key does not match keypattern {definition.key_pattern.pattern}")
+            if not definition.item_reference:
+                self.add(child_path, "collection entry has no itemtype reference")
+                continue
+            try:
+                referenced = self.resolve_reference(definition.item_reference, set())
+            except SchemaError as exc:
+                self.add(child_path, str(exc))
+                continue
+            self.validate_value(child_path, value, referenced)
+        self.validate_length(path, dynamic_entries, definition)
+        for key, child in definition.children.items():
+            try:
+                resolved = self.resolve(child, set())
+            except SchemaError as exc:
+                self.add(append_path(path, key), str(exc))
+                continue
+            if key not in table and not resolved.optional:
+                self.add(append_path(path, key), "required value is missing")
+        self.validate_sibling_rules(path, table, definition)
+
+    def validate_array(self, path: str, array: list, definition: Definition) -> None:
+        self.validate_length(path, len(array), definition)
+        if definition.unique_items:
+            for index in range(len(array)):
+                for previous in range(index):
+                    if values_equal(array[previous], array[index]):
+                        self.add(
+                            f"{path}[{index}]",
+                            f"duplicate item equals item at index {previous}",
+                        )
+                        break
+        if definition.items:
+            self.validate_tuple_array(path, array, definition)
+            return
+        if not definition.item_reference:
+            if not definition.allowed_values:
+                return
+            for i, item in enumerate(array):
+                self.validate_allowed_values(f"{path}[{i}]", item, definition)
+            return
+        try:
+            item_definition = self.resolve_reference(definition.item_reference, set())
+        except SchemaError as exc:
+            self.add(path, str(exc))
+            return
+        try:
+            range_type, has_range_type = self.schema.resolve_item_kind(definition.item_reference, set())
+        except SchemaError:
+            range_type, has_range_type = None, False
+        for i, item in enumerate(array):
+            item_path = f"{path}[{i}]"
+            self.validate_value(item_path, item, item_definition)
+            if definition.allowed_values:
+                self.validate_allowed_values(item_path, item, definition)
+            if has_range_type and is_type(item, range_type):
+                self.validate_range(item_path, item, definition)
+
+    def validate_sibling_rules(self, path: str, table: dict, definition: Definition) -> None:
+        # dependentrequired is evaluated on direct presence only: a mapping
+        # whose trigger is absent never fires.
+        for trigger, dependencies in definition.dependent_required.items():
+            if trigger not in table:
+                continue
+            for dependency in dependencies:
+                if dependency not in table:
+                    self.add(
+                        append_path(path, dependency),
+                        f'required by dependentrequired triggered by sibling "{trigger}"',
+                    )
+        for group in definition.mutually_exclusive:
+            present = _present_group_members(table, group)
+            if len(present) > 1:
+                self.add(
+                    path,
+                    "mutuallyexclusive group has multiple present members: " + ", ".join(present),
+                )
+        for group in definition.exactly_one:
+            present = _present_group_members(table, group)
+            if len(present) != 1:
+                self.add(
+                    path,
+                    "exactlyone group requires exactly one present member from: " + ", ".join(group),
+                )
+
+    def validate_tuple_array(self, path: str, array: list, definition: Definition) -> None:
+        if len(array) != len(definition.items):
+            self.add(
+                path, f"expected array length {len(definition.items)} but found {len(array)}"
+            )
+        upper_bound = min(len(array), len(definition.items))
+        for i in range(upper_bound):
+            item_path = f"{path}[{i}]"
+            try:
+                item_definition = self.resolve_reference(definition.items[i], set())
+            except SchemaError as exc:
+                self.add(item_path, str(exc))
+                continue
+            self.validate_value(item_path, array[i], item_definition)
+
+    # -- scalar/common constraint validation -----------------------------------
+
+    def validate_type(self, path: str, value: Any, type_name: SchemaType) -> None:
+        if not is_type(value, type_name):
+            self.add(path, f"expected {type_name} but found {type_name_of(value)}")
+
+    def validate_common_constraints(self, path: str, value: Any, definition: Definition) -> None:
+        if isinstance(value, list):
+            self.validate_length(path, len(value), definition)
+            return
+        self.validate_allowed_values(path, value, definition)
+        if definition.allowed_values:
+            return
+        self.validate_range(path, value, definition)
+        if isinstance(value, str):
+            self.validate_length(path, len(value), definition)
+            if definition.pattern is not None and not definition.pattern.search(value):
+                self.add(path, f"does not match pattern {definition.pattern.pattern}")
+
+    def validate_allowed_values(self, path: str, value: Any, definition: Definition) -> None:
+        if not definition.allowed_values:
+            return
+        for allowed in definition.allowed_values:
+            if values_equal(allowed, value):
+                return
+        self.add(path, "value is not in allowedvalues")
+
+    def validate_range(self, path: str, value: Any, definition: Definition) -> None:
+        if definition.min is not None:
+            try:
+                comparison = compare(value, definition.min)
+            except IncomparableError as exc:
+                self.add(path, str(exc))
+            else:
+                if comparison < 0:
+                    self.add(path, "value is less than min")
+        if definition.max is not None:
+            try:
+                comparison = compare(value, definition.max)
+            except IncomparableError as exc:
+                self.add(path, str(exc))
+            else:
+                if comparison > 0:
+                    self.add(path, "value is greater than max")
+
+    def validate_length(self, path: str, length: int, definition: Definition) -> None:
+        if definition.min_length is not None and length < definition.min_length:
+            self.add(path, "length is less than minlength")
+        if definition.max_length is not None and length > definition.max_length:
+            self.add(path, "length is greater than maxlength")
+
+    # -- reference resolution ---------------------------------------------------
+
+    def resolve(self, definition: Definition, seen_references: Set[str]) -> Definition:
+        if not definition.reference:
+            return definition
+        referenced = self.resolve_reference(definition.reference, seen_references)
+        referenced = dataclasses.replace(
+            referenced,
+            name=definition.name,
+            description=definition.description if definition.description else referenced.description,
+            optional=definition.optional or referenced.optional,
+            all_of=referenced.all_of + definition.all_of,
+            dependent_required=_merge_dependencies(
+                referenced.dependent_required, definition.dependent_required
+            ),
+            mutually_exclusive=referenced.mutually_exclusive + definition.mutually_exclusive,
+            exactly_one=referenced.exactly_one + definition.exactly_one,
+            unique_items=(
+                definition.unique_items if definition.unique_items is not None else referenced.unique_items
+            ),
+        )
+        if definition.has_default:
+            referenced = dataclasses.replace(
+                referenced, default_value=definition.default_value, has_default=True
+            )
+        referenced = dataclasses.replace(
+            referenced, deprecated=definition.deprecated or referenced.deprecated
+        )
+        return referenced
+
+    def resolve_reference(self, reference: str, seen_references: Set[str]) -> Definition:
+        normalized = normalize_reference(reference)
+        builtin = parse_schema_type(normalized)
+        if builtin is not None:
+            return Definition(name=normalized, type_name=builtin)
+        if normalized in seen_references:
+            raise SchemaError(f"cyclic type reference: {normalized}")
+        definition = self.schema.types.get(normalized)
+        if definition is None:
+            raise SchemaError(f"unknown type reference: {reference}")
+        seen_references = seen_references | {normalized}
+        return self.resolve(definition, seen_references)
+
+    # -- diagnostics --------------------------------------------------------
+
+    def add(self, path: str, message: str) -> None:
+        self.errors.append(
+            Diagnostic(severity=Severity.ERROR, code="validation-error", path=path, message=message)
+        )
+
+    def warn(self, path: str, code: str, message: str) -> None:
+        if self.suppress_warnings:
+            return
+        self.append_warnings([Diagnostic(severity=Severity.WARNING, code=code, path=path, message=message)])
+
+    def append_warnings(self, warnings: List[Diagnostic]) -> None:
+        for warning in warnings:
+            duplicate = any(
+                existing.code == warning.code
+                and existing.path == warning.path
+                and existing.message == warning.message
+                for existing in self.warnings
+            )
+            if not duplicate:
+                self.warnings.append(warning)

--- a/reference-implementations/python/tests/helpers.py
+++ b/reference-implementations/python/tests/helpers.py
@@ -1,0 +1,56 @@
+"""Shared test helpers for the toml_schema test suite.
+
+Adds ``src/`` to ``sys.path`` so tests can ``import toml_schema`` without the
+package being installed, and provides small utilities mirroring the Go test
+suite's ``write``, ``fixture``, ``hasPath``, ``containsDiagnostic``, and
+``diagnosticPaths`` helpers.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+_THIS_DIR = pathlib.Path(__file__).resolve().parent
+_PYTHON_PACKAGE_ROOT = _THIS_DIR.parent
+_SRC = _PYTHON_PACKAGE_ROOT / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+# reference-implementations/python/tests -> reference-implementations/python
+# -> reference-implementations -> repo root
+REPO_ROOT = _PYTHON_PACKAGE_ROOT.parent.parent
+
+
+def repo_path(*parts: str) -> str:
+    """Returns an absolute path to a repo-root-relative fixture file."""
+    return str(REPO_ROOT.joinpath(*parts))
+
+
+def write_file(directory, name: str, content: str) -> str:
+    """Writes ``content`` to ``directory/name`` and returns the path as a str."""
+    path = pathlib.Path(directory) / name
+    path.write_text(content, encoding="utf-8")
+    return str(path)
+
+
+def load_semantics_schema(tmp_dir, definitions: str):
+    """Loads a schema from ``[toml-schema]\\nversion = "1.0.0"\\n`` plus the
+    given definitions body, mirroring Go's ``loadSemanticsSchema`` helper."""
+    from toml_schema import load_schema
+
+    content = '[toml-schema]\nversion = "1.0.0"\n' + definitions
+    path = write_file(tmp_dir, "schema.tosd", content)
+    return load_schema(path)
+
+
+def has_path(result, path: str) -> bool:
+    return any(error.path == path for error in result.errors)
+
+
+def contains_diagnostic(diagnostics, path: str, message: str) -> bool:
+    return any(d.path == path and d.message == message for d in diagnostics)
+
+
+def diagnostic_paths(diagnostics):
+    return sorted(d.path for d in diagnostics)

--- a/reference-implementations/python/tests/test_abnf_conformance.py
+++ b/reference-implementations/python/tests/test_abnf_conformance.py
@@ -1,0 +1,80 @@
+"""ABNF vocabulary-alignment conformance test.
+
+Ports Go's abnf_conformance_test.go: the Python schema loader's definition-key
+vocabulary must exactly match the ABNF ``schema-key`` production, and the
+implementation's built-in ``SchemaType`` values must exactly match the
+built-in-type name tokens documented in ``toml-schema.abnf`` (excluding
+schema-key tokens themselves).
+"""
+
+import re
+import unittest
+
+import helpers
+from toml_schema import SchemaType
+from toml_schema._schema import DEFINITION_KEYS
+
+_TOKEN_COMMENT_PATTERN = re.compile(r';\s*"([^"]+)"')
+
+
+def _read_abnf() -> str:
+    with open(helpers.repo_path("toml-schema.abnf"), encoding="utf-8") as handle:
+        return handle.read()
+
+
+def _rule_expression(rule_name: str, abnf: str) -> str:
+    lines = abnf.split("\n")
+    expression_parts = []
+    in_rule = False
+    for line in lines:
+        if line.startswith(rule_name + " ="):
+            _, _, value = line.partition("=")
+            expression_parts.append(value.strip())
+            in_rule = True
+            continue
+        if in_rule:
+            if line.startswith(" ") or line.startswith("\t"):
+                expression_parts.append(line.strip())
+                continue
+            break
+    return " ".join(expression_parts)
+
+
+def _alternatives_for(rule_name: str, abnf: str):
+    expression = _rule_expression(rule_name, abnf)
+    tokens = []
+    for token in expression.split("/"):
+        token = token.strip()
+        if not token or token == "version":
+            continue
+        tokens.append(token)
+    return tokens
+
+
+def _built_in_type_tokens(abnf: str):
+    tokens = []
+    for line in abnf.split("\n"):
+        match = _TOKEN_COMMENT_PATTERN.search(line)
+        if not match:
+            continue
+        token = match.group(1)
+        if token in DEFINITION_KEYS:
+            continue
+        tokens.append(token)
+    return tokens
+
+
+class AbnfConformanceTests(unittest.TestCase):
+    def test_schema_loader_definition_keys_match_abnf_schema_keys(self):
+        abnf = _read_abnf()
+        expected = _alternatives_for("schema-key", abnf)
+        self.assertEqual(sorted(DEFINITION_KEYS), sorted(expected))
+
+    def test_schema_types_match_abnf_built_in_types(self):
+        abnf = _read_abnf()
+        implementation_types = [member.value for member in SchemaType]
+        self.assertEqual(sorted(implementation_types), sorted(_built_in_type_tokens(abnf)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/reference-implementations/python/tests/test_composition.py
+++ b/reference-implementations/python/tests/test_composition.py
@@ -1,0 +1,448 @@
+"""Composition and annotation-resolution tests: allof/oneof/anyof closure
+rules, effective annotation resolution across recursive/mutually-recursive
+named types, and collection itemtype composition. Ports Go's
+schema_review_test.go."""
+
+import tempfile
+import unittest
+
+import helpers
+from toml_schema import SchemaError, load_schema
+
+
+class AnnotationResolutionTests(unittest.TestCase):
+    def test_effective_annotations_terminate_on_recursive_named_types(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema = helpers.load_semantics_schema(
+                tmp,
+                """
+[types.node]
+type = "table"
+description = "A tree node."
+
+[types.node.name]
+type = "string"
+default = "root"
+
+[types.node.child]
+type = "types.node"
+optional = true
+
+[elements.tree]
+type = "types.node"
+""",
+            )
+            element = schema.element("tree")
+            self.assertIsNotNone(element)
+            self.assertEqual(element.description, "A tree node.")
+
+            named = schema.type("types.node")
+            self.assertIsNotNone(named)
+            self.assertEqual(named.description, "A tree node.")
+
+            current = element
+            for depth in range(3):
+                name_child = current.child("name")
+                self.assertIsNotNone(name_child, msg=depth)
+                value, has_default = name_child.default()
+                self.assertTrue(has_default, msg=depth)
+                self.assertEqual(value, "root", msg=depth)
+                child = current.child("child")
+                self.assertIsNotNone(child, msg=depth)
+                current = child
+
+            document = {
+                "tree": {
+                    "name": "a",
+                    "child": {"name": "b", "child": {"name": "c"}},
+                }
+            }
+            result = schema.validate(document)
+            self.assertTrue(result.valid, msg=result.errors)
+
+    def test_effective_annotations_terminate_on_mutually_recursive_types(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema = helpers.load_semantics_schema(
+                tmp,
+                """
+[types.left]
+type = "table"
+description = "Left."
+
+[types.left.right]
+type = "types.right"
+optional = true
+
+[types.right]
+type = "table"
+description = "Right."
+
+[types.right.left]
+type = "types.left"
+optional = true
+
+[elements.root]
+type = "types.left"
+""",
+            )
+            root = schema.element("root")
+            self.assertIsNotNone(root)
+            right = root.child("right")
+            self.assertIsNotNone(right)
+            self.assertEqual(right.description, "Right.")
+            self.assertIsNotNone(right.child("left"))
+
+
+class AllOfUnionCompositionTests(unittest.TestCase):
+    def test_allof_accepts_union_components_with_unambiguous_kind(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema = helpers.load_semantics_schema(
+                tmp,
+                """
+[types.base]
+type = "table"
+[types.base.id]
+type = "integer"
+
+[types.named]
+type = "table"
+[types.named.name]
+type = "string"
+
+[types.labelled]
+type = "table"
+[types.labelled.label]
+type = "string"
+
+[types.identity]
+oneof = ["types.named", "types.labelled"]
+
+[elements.item]
+type = "table"
+allof = ["types.base", "types.identity"]
+
+[elements.item.enabled]
+type = "boolean"
+optional = true
+""",
+            )
+            valid = [
+                {"id": 1, "name": "a"},
+                {"id": 1, "label": "a"},
+                {"id": 1, "name": "a", "enabled": True},
+            ]
+            for item in valid:
+                result = schema.validate({"item": item})
+                self.assertTrue(result.valid, msg=(item, result.errors))
+
+            both = schema.validate({"item": {"id": 1, "name": "a", "label": "b"}})
+            self.assertEqual(len(both.errors), 1)
+            self.assertEqual(both.errors[0].path, "$.item")
+            self.assertIn("but found 0", both.errors[0].message)
+
+            none = schema.validate({"item": {"id": 1}})
+            self.assertEqual(len(none.errors), 1)
+            self.assertEqual(none.errors[0].path, "$.item")
+            self.assertIn("but found 0", none.errors[0].message)
+
+            unknown = schema.validate({"item": {"id": 1, "name": "a", "bogus": True}})
+            self.assertFalse(unknown.valid)
+            for diagnostic in unknown.errors:
+                self.assertIn(diagnostic.path, ("$.item.bogus", "$.item"))
+            self.assertTrue(
+                helpers.contains_diagnostic(unknown.errors, "$.item.bogus", "unexpected key")
+            )
+
+            missing = schema.validate({"item": {"name": "a"}})
+            self.assertEqual(len(missing.errors), 1)
+            self.assertEqual(missing.errors[0].path, "$.item.id")
+
+    def test_allof_union_closure_preserves_overlapping_structural_children(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema = helpers.load_semantics_schema(
+                tmp,
+                """
+[types.base]
+type = "table"
+[types.base.name]
+type = "string"
+
+[types.withName]
+type = "table"
+[types.withName.name]
+type = "string"
+[types.withName.git]
+type = "string"
+optional = true
+
+[types.plain]
+type = "table"
+[types.plain.path]
+type = "string"
+
+[types.identity]
+oneof = ["types.withName", "types.plain"]
+
+[elements.item]
+type = "table"
+allof = ["types.base", "types.identity"]
+""",
+            )
+            valid = schema.validate({"item": {"name": "a", "path": "p"}})
+            self.assertTrue(valid.valid, msg=valid.errors)
+
+            both = schema.validate(
+                {"item": {"name": "a", "path": "p", "git": "https://example.invalid/repo"}}
+            )
+            self.assertFalse(both.valid)
+            self.assertEqual(len(both.errors), 1)
+            self.assertIn("but found 0", both.errors[0].message)
+
+    def test_allof_closes_open_union_alternatives_when_composition_defines_children(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema = helpers.load_semantics_schema(
+                tmp,
+                """
+[types.base]
+type = "table"
+[types.base.name]
+type = "string"
+
+[types.open]
+type = "table"
+
+[types.closed]
+type = "table"
+[types.closed.known]
+type = "string"
+
+[types.identity]
+oneof = ["types.open", "types.closed"]
+
+[elements.element]
+type = "table"
+allof = ["types.base", "types.identity"]
+""",
+            )
+            valid = schema.validate({"element": {"name": "alpha", "known": "value"}})
+            self.assertTrue(valid.valid, msg=valid.errors)
+
+            invalid = schema.validate({"element": {"name": "alpha", "arbitrary": True}})
+            self.assertFalse(invalid.valid)
+            has_union_failure = any(
+                d.path == "$.element" and "found 0" in d.message for d in invalid.errors
+            )
+            self.assertTrue(has_union_failure, msg=invalid.errors)
+
+    def test_allof_accepts_anyof_components_for_scalars_and_collections(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema = helpers.load_semantics_schema(
+                tmp,
+                """
+[types.low]
+type = "integer"
+max = 10
+
+[types.high]
+type = "integer"
+min = 100
+
+[types.bounded]
+anyof = ["types.low", "types.high"]
+
+[elements.count]
+type = "integer"
+min = 0
+allof = ["types.bounded"]
+
+[types.shortEntry]
+type = "string"
+maxlength = 4
+
+[types.longEntry]
+type = "string"
+minlength = 8
+
+[types.shortCollection]
+type = "collection"
+itemtype = "types.shortEntry"
+
+[types.longCollection]
+type = "collection"
+itemtype = "types.longEntry"
+
+[types.entries]
+anyof = ["types.shortCollection", "types.longCollection"]
+
+[elements.registry]
+type = "collection"
+itemtype = "string"
+allof = ["types.entries"]
+""",
+            )
+            result = schema.validate({"count": 5, "registry": {"a": "abcd"}})
+            self.assertTrue(result.valid, msg=result.errors)
+
+            result = schema.validate({"count": 500, "registry": {"a": "abcdefgh"}})
+            self.assertTrue(result.valid, msg=result.errors)
+
+            result = schema.validate({"count": 50, "registry": {"a": "abcdef"}})
+            paths = helpers.diagnostic_paths(result.errors)
+            self.assertEqual(paths, ["$.count", "$.registry"])
+            for diagnostic in result.errors:
+                self.assertIn("at least one matching type from anyof", diagnostic.message)
+
+    def test_collection_itemtype_may_come_from_allof_component(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema = helpers.load_semantics_schema(
+                tmp,
+                """
+[types.entry]
+type = "string"
+minlength = 2
+
+[types.baseRegistry]
+type = "collection"
+itemtype = "types.entry"
+
+[elements.registry]
+type = "collection"
+keypattern = "^[a-z]+$"
+allof = ["types.baseRegistry"]
+
+[elements.registry.fixed]
+type = "boolean"
+optional = true
+""",
+            )
+            result = schema.validate({"registry": {"alpha": "ok", "fixed": True}})
+            self.assertTrue(result.valid, msg=result.errors)
+
+            short = schema.validate({"registry": {"alpha": "x"}})
+            self.assertEqual(len(short.errors), 1)
+            self.assertEqual(short.errors[0].path, "$.registry.alpha")
+
+            bad_key = schema.validate({"registry": {"ALPHA": "ok"}})
+            self.assertEqual(len(bad_key.errors), 1)
+            self.assertIn("keypattern", bad_key.errors[0].message)
+
+    def test_rejects_collection_without_any_item_constraint(self):
+        cases = {
+            "no-itemtype": (
+                """
+[elements.registry]
+type = "collection"
+""",
+                "must define itemtype when type is collection",
+            ),
+            "incompatible-component": (
+                """
+[types.plain]
+type = "table"
+
+[types.plain.name]
+type = "string"
+
+[elements.registry]
+type = "collection"
+allof = ["types.plain"]
+""",
+                "incompatible effective kind",
+            ),
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            for name, (definitions, message) in cases.items():
+                with self.subTest(name=name):
+                    path = helpers.write_file(
+                        tmp,
+                        f"collection-{name}.tosd",
+                        '[toml-schema]\nversion = "1.0.0"\n' + definitions,
+                    )
+                    with self.assertRaisesRegex(SchemaError, message):
+                        load_schema(path)
+
+
+class DefaultDisambiguationTests(unittest.TestCase):
+    def test_default_disambiguation_follows_toml_syntax(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema = helpers.load_semantics_schema(
+                tmp,
+                """
+[elements]
+inline = { type = "table", optional = true, default = { keep = true } }
+
+[elements.range]
+type = "table"
+optional = true
+default = { min = 1, max = 10 }
+
+[elements.range.min]
+type = "integer"
+[elements.range.max]
+type = "integer"
+
+[elements.plugin]
+type = "table"
+optional = true
+default = { type = "linter", oneof = "unused", anyof = "unused" }
+
+[elements.options]
+type = "table"
+
+[elements.options.default]
+
+[elements.options.default.min]
+type = "integer"
+
+[elements.entry]
+type = "table"
+
+[elements.entry.dependentrequired]
+type = "string"
+optional = true
+""",
+            )
+            inline = schema.element("inline")
+            self.assertIsNotNone(inline)
+            value, ok = inline.default()
+            self.assertTrue(ok)
+            self.assertEqual(value, {"keep": True})
+            self.assertIsNone(inline.child("default"))
+
+            range_element = schema.element("range")
+            value, ok = range_element.default()
+            self.assertTrue(ok)
+            self.assertEqual(value, {"min": 1, "max": 10})
+            self.assertIsNone(range_element.child("default"))
+            self.assertIsNotNone(range_element.child("min"))
+
+            plugin = schema.element("plugin")
+            value, ok = plugin.default()
+            self.assertTrue(ok)
+            self.assertEqual(value, {"type": "linter", "oneof": "unused", "anyof": "unused"})
+
+            options = schema.element("options")
+            _, ok = options.default()
+            self.assertFalse(ok)
+            child = options.child("default")
+            self.assertIsNotNone(child)
+            self.assertIsNotNone(child.child("min"))
+
+            entry = schema.element("entry")
+            self.assertIsNotNone(entry.child("dependentrequired"))
+
+            result = schema.validate(
+                {
+                    "options": {"default": {"min": 1}},
+                    "entry": {"dependentrequired": "x"},
+                }
+            )
+            self.assertTrue(result.valid, msg=result.errors)
+
+            missing = schema.validate({"options": {}, "entry": {}})
+            self.assertEqual(len(missing.errors), 1)
+            self.assertEqual(missing.errors[0].path, "$.options.default")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/reference-implementations/python/tests/test_conditional.py
+++ b/reference-implementations/python/tests/test_conditional.py
@@ -1,0 +1,344 @@
+"""Conditional (``if``/``then``/``else``) selector tests.
+
+Ports Go's schema_conditional_test.go.
+"""
+
+import tempfile
+import unittest
+
+import helpers
+from toml_schema import SchemaError, load_schema
+
+
+class ConditionalSelectorTests(unittest.TestCase):
+    def test_conditional_selectors_choose_and_validate_branch(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema = helpers.load_semantics_schema(
+                tmp,
+                """
+[types.sqlite]
+type = "table"
+[types.sqlite.engine]
+type = "string"
+allowedvalues = ["sqlite"]
+optional = true
+[types.sqlite.file]
+type = "string"
+
+[types.server]
+type = "table"
+[types.server.engine]
+type = "string"
+allowedvalues = ["postgresql", "mysql"]
+optional = true
+[types.server.host]
+type = "string"
+
+[elements.byEquals]
+if = { key = "engine", equals = "sqlite" }
+then = "types.sqlite"
+else = "types.server"
+
+[elements.byIn]
+if = { key = "engine", in = ["postgresql", "mysql"] }
+then = "types.server"
+else = "types.sqlite"
+""",
+            )
+
+            cases = {
+                "equals": {
+                    "byEquals": {"engine": "sqlite", "file": "db.sqlite"},
+                    "byIn": {"engine": "sqlite", "file": "db.sqlite"},
+                },
+                "in": {
+                    "byEquals": {"engine": "mysql", "host": "db.internal"},
+                    "byIn": {"engine": "postgresql", "host": "db.internal"},
+                },
+                "missing-chooses-else": {
+                    "byEquals": {"host": "db.internal"},
+                    "byIn": {"file": "db.sqlite"},
+                },
+            }
+            for name, document in cases.items():
+                with self.subTest(name=name):
+                    result = schema.validate(document)
+                    self.assertTrue(result.valid, msg=result.errors)
+
+            required = schema.validate(
+                {"byEquals": {"engine": "sqlite"}, "byIn": {"engine": "mysql"}}
+            )
+            self.assertFalse(required.valid)
+            self.assertTrue(helpers.has_path(required, "$.byEquals.file"))
+            self.assertTrue(helpers.has_path(required, "$.byIn.host"))
+
+            unknown = schema.validate(
+                {
+                    "byEquals": {"engine": "sqlite", "file": "db.sqlite", "host": "wrong-branch"},
+                    "byIn": {"engine": "sqlite", "file": "db.sqlite", "host": "wrong-branch"},
+                }
+            )
+            self.assertFalse(unknown.valid)
+            self.assertTrue(helpers.has_path(unknown, "$.byEquals.host"))
+            self.assertTrue(helpers.has_path(unknown, "$.byIn.host"))
+
+    def test_conditional_selector_uses_toml_equality(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema = helpers.load_semantics_schema(
+                tmp,
+                """
+[types.one]
+type = "table"
+[types.one.mode]
+type = "float"
+[types.one.selected]
+type = "boolean"
+
+[types.other]
+type = "table"
+[types.other.mode]
+type = "integer"
+[types.other.fallback]
+type = "boolean"
+
+[elements.value]
+if = { key = "mode", equals = 1 }
+then = "types.one"
+else = "types.other"
+""",
+            )
+            result = schema.validate({"value": {"mode": 1.0, "selected": True}})
+            self.assertTrue(result.valid, msg=result.errors)
+
+    def test_conditional_key_is_one_literal_direct_child(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema = helpers.load_semantics_schema(
+                tmp,
+                """
+[types.selected]
+type = "table"
+deprecated = true
+
+[types.fallback]
+type = "table"
+
+[elements.value]
+if = { key = "engine.kind", equals = "sqlite" }
+then = "types.selected"
+else = "types.fallback"
+""",
+            )
+            nested_only = schema.validate({"value": {"engine": {"kind": "sqlite"}}})
+            self.assertTrue(nested_only.valid, msg=nested_only.errors)
+            self.assertEqual(len(nested_only.warnings), 0)
+
+            literal = schema.validate({"value": {"engine.kind": "sqlite"}})
+            self.assertTrue(literal.valid, msg=literal.errors)
+            self.assertEqual(len(literal.warnings), 1)
+
+    def test_schema_property_names_remain_legal_implicit_table_children(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema = helpers.load_semantics_schema(
+                tmp,
+                """
+[elements.value.if]
+type = "string"
+
+[elements.value.then]
+type = "integer"
+
+[elements.value.else]
+type = "boolean"
+""",
+            )
+            result = schema.validate({"value": {"if": "condition", "then": 1, "else": True}})
+            self.assertTrue(result.valid, msg=result.errors)
+
+    def test_conditional_discriminator_does_not_become_known_branch_key(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema = helpers.load_semantics_schema(
+                tmp,
+                """
+[types.selected]
+type = "table"
+[types.selected.value]
+type = "string"
+
+[types.fallback]
+type = "table"
+[types.fallback.other]
+type = "string"
+
+[elements.item]
+if = { key = "engine", equals = "sqlite" }
+then = "types.selected"
+else = "types.fallback"
+""",
+            )
+            result = schema.validate({"item": {"engine": "sqlite", "value": "ok"}})
+            self.assertFalse(result.valid)
+            self.assertTrue(helpers.has_path(result, "$.item.engine"))
+
+    def test_conditional_selector_composes_with_allof(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema = helpers.load_semantics_schema(
+                tmp,
+                """
+[types.common]
+type = "table"
+[types.common.id]
+type = "integer"
+
+[types.sqlite]
+type = "table"
+[types.sqlite.engine]
+type = "string"
+[types.sqlite.file]
+type = "string"
+
+[types.server]
+type = "table"
+[types.server.engine]
+type = "string"
+[types.server.host]
+type = "string"
+
+[types.database]
+if = { key = "engine", equals = "sqlite" }
+then = "types.sqlite"
+else = "types.server"
+allof = ["types.common"]
+
+[elements.database]
+type = "types.database"
+
+[elements.composed]
+type = "table"
+allof = ["types.database"]
+""",
+            )
+            valid = {
+                "database": {"id": 1, "engine": "sqlite", "file": "db.sqlite"},
+                "composed": {"id": 2, "engine": "postgresql", "host": "db.internal"},
+            }
+            result = schema.validate(valid)
+            self.assertTrue(result.valid, msg=result.errors)
+
+            invalid = schema.validate(
+                {
+                    "database": {"engine": "sqlite", "file": "db.sqlite"},
+                    "composed": {"id": 2, "engine": "sqlite", "host": "wrong-branch"},
+                }
+            )
+            self.assertFalse(invalid.valid)
+            self.assertTrue(helpers.has_path(invalid, "$.database.id"))
+            self.assertTrue(helpers.has_path(invalid, "$.composed.file"))
+            self.assertTrue(helpers.has_path(invalid, "$.composed.host"))
+
+    def test_rejects_malformed_conditional_selectors(self):
+        table_branch = """
+[types.left]
+type = "table"
+[types.left.engine]
+type = "string"
+[types.right]
+type = "table"
+[types.right.engine]
+type = "string"
+"""
+        cases = {
+            "missing-else": 'if = { key = "engine", equals = "x" }\nthen = "types.left"',
+            "neither-predicate": 'if = { key = "engine" }\nthen = "types.left"\nelse = "types.right"',
+            "both-predicates": (
+                'if = { key = "engine", equals = "x", in = ["x"] }\n'
+                'then = "types.left"\nelse = "types.right"'
+            ),
+            "empty-in": 'if = { key = "engine", in = [] }\nthen = "types.left"\nelse = "types.right"',
+            "non-string-key": 'if = { key = 1, equals = "x" }\nthen = "types.left"\nelse = "types.right"',
+            "unknown-if-property": (
+                'if = { key = "engine", equals = "x", other = true }\n'
+                'then = "types.left"\nelse = "types.right"'
+            ),
+            "builtin-branch": 'if = { key = "engine", equals = "x" }\nthen = "table"\nelse = "types.right"',
+            "unknown-branch": (
+                'if = { key = "engine", equals = "x" }\nthen = "types.missing"\nelse = "types.right"'
+            ),
+            "other-selector": (
+                'type = "table"\nif = { key = "engine", equals = "x" }\n'
+                'then = "types.left"\nelse = "types.right"'
+            ),
+            "ordinary-constraint": (
+                'if = { key = "engine", equals = "x" }\nthen = "types.left"\n'
+                'else = "types.right"\nminlength = 1'
+            ),
+            "nested-child": (
+                'if = { key = "engine", equals = "x" }\nthen = "types.left"\n'
+                'else = "types.right"\n[elements.value.child]\ntype = "string"'
+            ),
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            for name, definition in cases.items():
+                with self.subTest(name=name):
+                    content = f"""
+[toml-schema]
+version = "1.0.0"
+{table_branch}
+[elements.value]
+{definition}
+"""
+                    path = helpers.write_file(tmp, f"invalid-{name}.tosd", content)
+                    with self.assertRaises(SchemaError):
+                        load_schema(path)
+
+    def test_rejects_conditional_kind_and_reference_cycles(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            incompatible = helpers.write_file(
+                tmp,
+                "incompatible.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+[types.tableBranch]
+type = "table"
+[types.tableBranch.engine]
+type = "string"
+[types.collectionBranch]
+type = "collection"
+itemtype = "string"
+[types.collectionBranch.engine]
+type = "string"
+[elements.value]
+if = { key = "engine", equals = "x" }
+then = "types.tableBranch"
+else = "types.collectionBranch"
+""",
+            )
+            with self.assertRaisesRegex(SchemaError, "incompatible"):
+                load_schema(incompatible)
+
+            cycle = helpers.write_file(
+                tmp,
+                "cycle.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+[types.fallback]
+type = "table"
+[types.fallback.engine]
+type = "string"
+[types.first]
+if = { key = "engine", equals = "x" }
+then = "types.second"
+else = "types.fallback"
+[types.second]
+type = "types.first"
+[elements.value]
+type = "types.fallback"
+""",
+            )
+            with self.assertRaisesRegex(SchemaError, "cyclic"):
+                load_schema(cycle)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/reference-implementations/python/tests/test_diagnostics.py
+++ b/reference-implementations/python/tests/test_diagnostics.py
@@ -1,0 +1,608 @@
+"""Diagnostics, range/length/pattern/tuple/collection validation, numeric and
+temporal precision, and value-container tests. Ports representative coverage
+from Go's schema_test.go."""
+
+import tempfile
+import unittest
+
+import helpers
+from toml_schema import SchemaError, load_schema
+
+
+class ValidationErrorReportingTests(unittest.TestCase):
+    def test_reports_validation_errors(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema_path = helpers.write_file(
+                tmp,
+                "schema.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+
+[elements.name]
+type = "string"
+minlength = 2
+pattern = "^[a-z]+$"
+
+[elements.port]
+type = "integer"
+min = 1
+max = 65535
+""",
+            )
+            document_path = helpers.write_file(
+                tmp,
+                "document.toml",
+                """
+name = "A"
+port = 70000
+""",
+            )
+            schema = load_schema(schema_path)
+            result = schema.validate_file(document_path)
+            self.assertFalse(result.valid)
+            self.assertEqual(len(result.errors), 3)
+            self.assertTrue(helpers.has_path(result, "$.name"))
+            self.assertTrue(helpers.has_path(result, "$.port"))
+
+    def test_rejects_malformed_boundary_schemas(self):
+        cases = {
+            "any-min": """
+[toml-schema]
+version = "1.0.0"
+
+[elements.payload]
+type = "any"
+min = 1
+""",
+            "nan-min": """
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "float"
+min = nan
+""",
+            "string-min": """
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "integer"
+min = "1"
+""",
+            "date-time-min": """
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "local-date"
+min = 2026-01-01T00:00:00Z
+""",
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            for name, content in cases.items():
+                with self.subTest(name=name):
+                    path = helpers.write_file(tmp, f"{name}.tosd", content)
+                    with self.assertRaises(SchemaError):
+                        load_schema(path)
+
+    def test_rejects_malformed_length_schemas(self):
+        cases = {
+            "negative-minlength": """
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "string"
+minlength = -1
+""",
+            "negative-maxlength": """
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "string"
+maxlength = -1
+""",
+            "inverted-length": """
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "string"
+minlength = 5
+maxlength = 2
+""",
+            "incompatible-length": """
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "boolean"
+minlength = 1
+""",
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            for name, content in cases.items():
+                with self.subTest(name=name):
+                    path = helpers.write_file(tmp, f"{name}.tosd", content)
+                    with self.assertRaises(SchemaError):
+                        load_schema(path)
+
+
+class ArrayRangeTests(unittest.TestCase):
+    def test_validates_array_ranges_through_itemtype(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema_path = helpers.write_file(
+                tmp,
+                "array-ranges.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+
+[types.boundedInteger]
+type = "integer"
+min = 10
+max = 20
+
+[types.smallInteger]
+type = "integer"
+max = 5
+
+[types.largeInteger]
+type = "integer"
+min = 6
+
+[types.integerAlternative]
+oneof = [ "types.smallInteger", "types.largeInteger" ]
+
+[elements.direct]
+type = "array"
+itemtype = "integer"
+min = 2
+max = 4
+
+[elements.named]
+type = "array"
+itemtype = "types.boundedInteger"
+min = 5
+max = 25
+
+[elements.alternatives]
+type = "array"
+itemtype = "types.integerAlternative"
+min = 1
+max = 10
+""",
+            )
+            valid_path = helpers.write_file(
+                tmp,
+                "valid-array-ranges.toml",
+                """
+direct = [2, 3, 4]
+named = [10, 20]
+alternatives = [2, 8]
+""",
+            )
+            invalid_path = helpers.write_file(
+                tmp,
+                "invalid-array-ranges.toml",
+                """
+direct = [1, 5]
+named = [7, 21]
+alternatives = [0, 11]
+""",
+            )
+            schema = load_schema(schema_path)
+            result = schema.validate_file(valid_path)
+            self.assertTrue(result.valid, msg=result.errors)
+
+            result = schema.validate_file(invalid_path)
+            for path in [
+                "$.direct[0]", "$.direct[1]",
+                "$.named[0]", "$.named[1]",
+                "$.alternatives[0]", "$.alternatives[1]",
+            ]:
+                with self.subTest(path=path):
+                    self.assertTrue(helpers.has_path(result, path))
+
+    def test_rejects_array_ranges_for_mixed_itemtype_alternatives(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema_path = helpers.write_file(
+                tmp,
+                "mixed-array-range.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+
+[types.mixed]
+oneof = [ "integer", "string" ]
+
+[elements.values]
+type = "array"
+itemtype = "types.mixed"
+min = 1
+""",
+            )
+            with self.assertRaisesRegex(SchemaError, "one comparable built-in type"):
+                load_schema(schema_path)
+
+
+class TupleArrayTests(unittest.TestCase):
+    def test_validates_tuple_arrays_by_position(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema_path = helpers.write_file(
+                tmp,
+                "schema.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+
+[types.coordinate]
+type = "float"
+
+[types.label]
+type = "string"
+
+[types.coordinateLabel]
+type = "array"
+items = [ "types.coordinate", "types.label" ]
+
+[elements.value]
+type = "array"
+items = [ "types.coordinateLabel", "types.coordinate" ]
+""",
+            )
+            document_path = helpers.write_file(
+                tmp, "document.toml", "value = [ [ 1.5, \"Hello\" ], 2.0 ]\n"
+            )
+            schema = load_schema(schema_path)
+            result = schema.validate_file(document_path)
+            self.assertTrue(result.valid, msg=result.errors)
+
+    def test_rejects_invalid_tuple_arrays(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema_path = helpers.write_file(
+                tmp,
+                "schema.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+
+[types.coordinate]
+type = "float"
+
+[types.label]
+type = "string"
+
+[elements.value]
+type = "array"
+items = [ "types.coordinate", "types.label" ]
+""",
+            )
+            wrong_order_path = helpers.write_file(
+                tmp, "wrong-order.toml", 'value = [ "Hello", 1.5 ]\n'
+            )
+            too_short_path = helpers.write_file(tmp, "too-short.toml", "value = [ 1.5 ]\n")
+            too_long_path = helpers.write_file(
+                tmp, "too-long.toml", 'value = [ 1.5, "Hello", true ]\n'
+            )
+            schema = load_schema(schema_path)
+
+            wrong_order = schema.validate_file(wrong_order_path)
+            self.assertFalse(wrong_order.valid)
+            self.assertTrue(helpers.has_path(wrong_order, "$.value[0]"))
+            self.assertTrue(helpers.has_path(wrong_order, "$.value[1]"))
+
+            too_short = schema.validate_file(too_short_path)
+            self.assertFalse(too_short.valid)
+            self.assertTrue(helpers.has_path(too_short, "$.value"))
+
+            too_long = schema.validate_file(too_long_path)
+            self.assertFalse(too_long.valid)
+            self.assertTrue(helpers.has_path(too_long, "$.value"))
+
+    def test_rejects_tuple_schema_with_conflicting_properties(self):
+        conflicts = [
+            """
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "array"
+items = [ "types.coordinate", "types.label" ]
+itemtype = "string"
+""",
+            """
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "array"
+items = [ "types.coordinate", "types.label" ]
+minlength = 2
+""",
+            """
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "array"
+items = [ "string", "integer" ]
+allowedvalues = [ 1 ]
+""",
+            """
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "array"
+items = [ "string", "integer" ]
+min = 1
+""",
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            for index, content in enumerate(conflicts):
+                with self.subTest(index=index):
+                    path = helpers.write_file(tmp, f"schema-{index}.tosd", content)
+                    with self.assertRaises(SchemaError):
+                        load_schema(path)
+
+
+class CollectionKeyPatternTests(unittest.TestCase):
+    def test_validates_collection_keys_against_keypattern(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema_path = helpers.write_file(
+                tmp,
+                "keypattern.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+
+[types.serverType]
+type = "table"
+
+    [types.serverType.ip]
+    type = "string"
+
+[elements.servers]
+type = "collection"
+itemtype = "types.serverType"
+keypattern = "^server_[0-9]+$"
+""",
+            )
+            valid_document = helpers.write_file(
+                tmp,
+                "valid.toml",
+                """
+[servers.server_01]
+ip = "10.0.0.1"
+
+[servers.server_02]
+ip = "10.0.0.2"
+""",
+            )
+            invalid_document = helpers.write_file(
+                tmp,
+                "invalid.toml",
+                """
+[servers.server_01]
+ip = "10.0.0.1"
+
+[servers.alpha]
+ip = "10.0.0.2"
+""",
+            )
+            schema = load_schema(schema_path)
+            result = schema.validate_file(valid_document)
+            self.assertTrue(result.valid, msg=result.errors)
+
+            result = schema.validate_file(invalid_document)
+            self.assertFalse(result.valid)
+            self.assertTrue(helpers.has_path(result, "$.servers.alpha"))
+            self.assertFalse(helpers.has_path(result, "$.servers.server_01"))
+
+    def test_allows_itemtype_on_collection_with_union(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema_path = helpers.write_file(
+                tmp,
+                "collection-itemtype.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+
+[types.stringItem]
+type = "string"
+
+[types.integerItem]
+type = "integer"
+
+[types.itemType]
+oneof = [ "types.stringItem", "types.integerItem" ]
+
+[elements.items]
+type = "collection"
+itemtype = "types.itemType"
+""",
+            )
+            document_path = helpers.write_file(
+                tmp,
+                "collection-itemtype.toml",
+                """
+[items]
+name = "example"
+port = 8080
+""",
+            )
+            schema = load_schema(schema_path)
+            result = schema.validate_file(document_path)
+            self.assertTrue(result.valid, msg=result.errors)
+
+
+class QuotedAndKeywordKeyTests(unittest.TestCase):
+    def test_supports_quoted_dotted_empty_and_schema_keyword_keys(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema_path = helpers.write_file(
+                tmp,
+                "schema.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+
+[elements.""]
+type = "string"
+
+[elements.children]
+type = "string"
+
+[elements.site."google.com"]
+type = "boolean"
+
+[elements.plugin.type]
+type = "string"
+""",
+            )
+            document_path = helpers.write_file(
+                tmp,
+                "document.toml",
+                """
+"" = "blank"
+children = "literal"
+
+[site]
+"google.com" = true
+
+[plugin]
+type = "npm"
+""",
+            )
+            schema = load_schema(schema_path)
+            result = schema.validate_file(document_path)
+            self.assertTrue(result.valid, msg=result.errors)
+
+
+class PrecisionAndOrderingTests(unittest.TestCase):
+    def test_preserves_numeric_precision_and_defines_temporal_ordering(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema_path = helpers.write_file(
+                tmp,
+                "value-semantics.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+
+[elements.precise]
+type = "integer"
+allowedvalues = [ 9007199254740992 ]
+
+[elements.mixed]
+type = "integer"
+max = 9007199254740992.0
+
+[elements.nanValue]
+type = "float"
+allowedvalues = [ nan ]
+
+[elements.nanRange]
+type = "float"
+min = 0.0
+
+[elements.zero]
+type = "float"
+allowedvalues = [ -0.0 ]
+
+[elements.instant]
+type = "offset-date-time"
+min = 2024-01-01T00:00:00Z
+max = 2024-01-01T00:00:00Z
+
+[elements.instantMember]
+type = "offset-date-time"
+allowedvalues = [ 2024-01-01T00:00:00Z ]
+
+[elements.localMember]
+type = "local-time"
+allowedvalues = [ 12:00:00.1 ]
+
+[elements.localDateTime]
+type = "local-date-time"
+max = 2024-01-01T00:00:00.100
+
+[elements.localDate]
+type = "local-date"
+max = 2024-01-01
+
+[elements.localTime]
+type = "local-time"
+max = 12:00:00.100
+""",
+            )
+            valid_path = helpers.write_file(
+                tmp,
+                "value-semantics-valid.toml",
+                """
+precise = 9007199254740992
+mixed = 9007199254740992
+nanValue = nan
+nanRange = 0.0
+zero = 0.0
+instant = 2023-12-31T19:00:00-05:00
+instantMember = 2024-01-01T00:00:00+00:00
+localMember = 12:00:00.100
+localDateTime = 2024-01-01T00:00:00.100
+localDate = 2024-01-01
+localTime = 12:00:00.100
+""",
+            )
+            invalid_path = helpers.write_file(
+                tmp,
+                "value-semantics-invalid.toml",
+                """
+precise = 9007199254740993
+mixed = 9007199254740993
+nanValue = 0.0
+nanRange = nan
+zero = 1.0
+instant = 2024-01-01T00:00:00.001Z
+instantMember = 2023-12-31T19:00:00-05:00
+localMember = 12:00:00.101
+localDateTime = 2024-01-01T00:00:00.101
+localDate = 2024-01-02
+localTime = 12:00:00.101
+""",
+            )
+            schema = load_schema(schema_path)
+            result = schema.validate_file(valid_path)
+            self.assertTrue(result.valid, msg=result.errors)
+
+            invalid = schema.validate_file(invalid_path)
+            for path in [
+                "$.precise", "$.mixed", "$.nanValue", "$.nanRange", "$.zero",
+                "$.instant", "$.instantMember", "$.localMember",
+                "$.localDateTime", "$.localDate", "$.localTime",
+            ]:
+                with self.subTest(path=path):
+                    self.assertTrue(helpers.has_path(invalid, path))
+
+    def test_rejects_imprecise_allowed_value_comparison_at_load_time(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = helpers.write_file(
+                tmp,
+                "malformed.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "integer"
+allowedvalues = [ 9007199254740993 ]
+max = 9007199254740992.0
+""",
+            )
+            with self.assertRaises(SchemaError):
+                load_schema(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/reference-implementations/python/tests/test_discovery.py
+++ b/reference-implementations/python/tests/test_discovery.py
@@ -1,0 +1,288 @@
+"""Schema discovery tests: locating a schema via a document's
+``[toml-schema].location`` metadata, version-compatibility warnings, and
+error handling for malformed metadata. Ports Go's
+``TestLocatesSchemaFromDocumentMetadata`` and
+``TestRejectsNonScalarSchemaReferenceMetadata`` (schema_test.go), plus
+additional coverage for absolute paths and version mismatches."""
+
+import os
+import tempfile
+import unittest
+
+import helpers
+from toml_schema import DiscoveryError, schema_from_document, validate_document
+
+
+class SchemaFromDocumentTests(unittest.TestCase):
+    def test_locates_schema_from_document_metadata(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            helpers.write_file(
+                tmp,
+                "schema.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+
+[elements.title]
+type = "string"
+""",
+            )
+            document_path = helpers.write_file(
+                tmp,
+                "document.toml",
+                """
+title = "Example"
+
+[toml-schema]
+version = "1.0.0"
+location = "schema.tosd"
+""",
+            )
+            schema, document = schema_from_document(document_path)
+            result = schema.validate(document)
+            self.assertTrue(result.valid, msg=result.errors)
+            self.assertEqual(schema.warnings, [])
+
+    def test_rejects_non_scalar_schema_reference_metadata(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            document_path = helpers.write_file(
+                tmp,
+                "document.toml",
+                """
+[toml-schema]
+location = ["schema.tosd"]
+""",
+            )
+            with self.assertRaisesRegex(DiscoveryError, "must be a scalar value"):
+                schema_from_document(document_path)
+
+    def test_locates_schema_using_absolute_path_location(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema_path = helpers.write_file(
+                tmp,
+                "schema.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+
+[elements.title]
+type = "string"
+""",
+            )
+            document_path = helpers.write_file(
+                tmp,
+                "document.toml",
+                f"""
+title = "Example"
+
+[toml-schema]
+version = "1.0.0"
+location = "{os.path.abspath(schema_path)}"
+""",
+            )
+            schema, document = schema_from_document(document_path)
+            result = schema.validate(document)
+            self.assertTrue(result.valid, msg=result.errors)
+
+    def test_locates_schema_using_file_uri_location(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            helpers.write_file(
+                tmp,
+                "nested",
+                "",
+            )
+            os.makedirs(os.path.join(tmp, "sub"), exist_ok=True)
+            helpers.write_file(
+                os.path.join(tmp, "sub"),
+                "schema.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+
+[elements.title]
+type = "string"
+""",
+            )
+            document_path = helpers.write_file(
+                tmp,
+                "document.toml",
+                """
+title = "Example"
+
+[toml-schema]
+version = "1.0.0"
+location = "sub/schema.tosd"
+""",
+            )
+            schema, document = schema_from_document(document_path)
+            result = schema.validate(document)
+            self.assertTrue(result.valid, msg=result.errors)
+
+    def test_warns_on_compatible_but_differing_document_schema_version(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            helpers.write_file(
+                tmp,
+                "schema.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+
+[elements.title]
+type = "string"
+""",
+            )
+            document_path = helpers.write_file(
+                tmp,
+                "document.toml",
+                """
+title = "Example"
+
+[toml-schema]
+version = "1.0.1"
+location = "schema.tosd"
+""",
+            )
+            schema, document = schema_from_document(document_path)
+            self.assertEqual(len(schema.warnings), 1)
+            self.assertIn("1.0.1", schema.warnings[0])
+            self.assertIn("1.0.0", schema.warnings[0])
+
+    def test_rejects_incompatible_major_document_schema_version(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            helpers.write_file(
+                tmp,
+                "schema.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+
+[elements.title]
+type = "string"
+""",
+            )
+            document_path = helpers.write_file(
+                tmp,
+                "document.toml",
+                """
+title = "Example"
+
+[toml-schema]
+version = "2.0.0"
+location = "schema.tosd"
+""",
+            )
+            with self.assertRaises(DiscoveryError):
+                schema_from_document(document_path)
+
+    def test_rejects_opaque_file_uri_location(self):
+        from toml_schema import resolve_schema_location
+
+        with tempfile.TemporaryDirectory() as tmp:
+            document_path = helpers.write_file(tmp, "document.toml", "")
+            with self.assertRaises(DiscoveryError):
+                resolve_schema_location(document_path, "file:something")
+
+    def test_rejects_non_local_host_file_uri_location(self):
+        from toml_schema import resolve_schema_location
+
+        with tempfile.TemporaryDirectory() as tmp:
+            document_path = helpers.write_file(tmp, "document.toml", "")
+            with self.assertRaisesRegex(DiscoveryError, "non-local host"):
+                resolve_schema_location(document_path, "file://evil.example/etc/passwd")
+
+    def test_rejects_query_and_fragment_file_uri_location(self):
+        from toml_schema import resolve_schema_location
+
+        with tempfile.TemporaryDirectory() as tmp:
+            document_path = helpers.write_file(tmp, "document.toml", "")
+            for location in ["file:///a/b?x=1", "file:///a/b#frag"]:
+                with self.subTest(location=location):
+                    with self.assertRaises(DiscoveryError):
+                        resolve_schema_location(document_path, location)
+
+    def test_rejects_unsupported_scheme_location(self):
+        from toml_schema import resolve_schema_location
+
+        with tempfile.TemporaryDirectory() as tmp:
+            document_path = helpers.write_file(tmp, "document.toml", "")
+            with self.assertRaisesRegex(DiscoveryError, "unsupported schema location URI scheme"):
+                resolve_schema_location(document_path, "http://example.com/schema.tosd")
+
+    def test_resolves_absolute_hierarchical_file_uri_location(self):
+        from toml_schema import resolve_schema_location
+
+        with tempfile.TemporaryDirectory() as tmp:
+            document_path = helpers.write_file(tmp, "document.toml", "")
+            schema_path = helpers.write_file(
+                tmp,
+                "schema.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+
+[elements.title]
+type = "string"
+""",
+            )
+            import urllib.parse
+
+            uri = "file://" + urllib.parse.quote(schema_path)
+            resolved = resolve_schema_location(document_path, uri)
+            self.assertEqual(os.path.normpath(resolved), os.path.normpath(schema_path))
+
+    def test_rejects_document_missing_location(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            document_path = helpers.write_file(
+                tmp,
+                "document.toml",
+                """
+title = "Example"
+""",
+            )
+            with self.assertRaises(DiscoveryError):
+                schema_from_document(document_path)
+
+
+class ValidateDocumentConvenienceTests(unittest.TestCase):
+    def test_validate_document_end_to_end(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            helpers.write_file(
+                tmp,
+                "schema.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+
+[elements.title]
+type = "string"
+""",
+            )
+            document_path = helpers.write_file(
+                tmp,
+                "document.toml",
+                """
+title = "Example"
+
+[toml-schema]
+version = "1.0.0"
+location = "schema.tosd"
+""",
+            )
+            result = validate_document(document_path)
+            self.assertTrue(result.valid, msg=result.errors)
+
+    def test_validate_document_reports_discovery_failure_as_diagnostic(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            document_path = helpers.write_file(tmp, "document.toml", 'title = "Example"\n')
+            result = validate_document(document_path)
+            self.assertFalse(result.valid)
+            self.assertEqual(len(result.errors), 1)
+            self.assertEqual(result.errors[0].path, "$")
+
+    def test_validate_document_using_checked_in_config_example(self):
+        result = validate_document(helpers.repo_path("config.toml"))
+        self.assertTrue(result.valid, msg=result.errors)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/reference-implementations/python/tests/test_examples.py
+++ b/reference-implementations/python/tests/test_examples.py
@@ -1,0 +1,175 @@
+"""Checked-in example and self-schema conformance tests.
+
+Ports the core coverage of Go's ``TestValidatesCheckedInExample``,
+``TestLoadsCheckedInExamples``, ``TestValidatesCargoManifestExample``, and
+``TestEnforcesClosedRootElementSemantics`` (schema_test.go).
+"""
+
+import unittest
+
+import helpers
+from toml_schema import SchemaError, load_schema
+
+
+class CheckedInExampleTests(unittest.TestCase):
+    def test_validates_checked_in_config_example(self):
+        schema = load_schema(helpers.repo_path("config.tosd"))
+        result = schema.validate_file(helpers.repo_path("config.toml"))
+        self.assertTrue(result.valid, msg=result.errors)
+
+    def test_loads_all_checked_in_example_schemas(self):
+        for name in [
+            "cargo.tosd",
+            "database-conditional.tosd",
+            "gitlab-runner.tosd",
+            "hugo.tosd",
+            "netlify.tosd",
+            "pyproject.tosd",
+            "wrangler.tosd",
+        ]:
+            with self.subTest(name=name):
+                load_schema(helpers.repo_path("examples", name))
+
+    def test_validates_cargo_manifest_example(self):
+        schema = load_schema(helpers.repo_path("examples", "cargo.tosd"))
+        result = schema.validate_file(
+            helpers.repo_path("reference-implementations", "rust", "Cargo.toml")
+        )
+        self.assertTrue(result.valid, msg=result.errors)
+
+    def test_validates_database_conditional_examples(self):
+        schema = load_schema(helpers.repo_path("examples", "database-conditional.tosd"))
+        for name in ["database-postgresql.toml", "database-sqlite.toml"]:
+            with self.subTest(name=name):
+                result = schema.validate_file(helpers.repo_path("examples", name))
+                self.assertTrue(result.valid, msg=result.errors)
+
+
+class SelfSchemaTests(unittest.TestCase):
+    """The TOML Schema self-schema (toml-schema.tosd) must load and must
+    validate both itself and the checked-in config.tosd example."""
+
+    def test_self_schema_loads(self):
+        load_schema(helpers.repo_path("toml-schema.tosd"))
+
+    def test_self_schema_validates_itself(self):
+        schema = load_schema(helpers.repo_path("toml-schema.tosd"))
+        result = schema.validate_file(helpers.repo_path("toml-schema.tosd"))
+        self.assertTrue(result.valid, msg=result.errors)
+
+    def test_self_schema_validates_config_tosd(self):
+        schema = load_schema(helpers.repo_path("toml-schema.tosd"))
+        result = schema.validate_file(helpers.repo_path("config.tosd"))
+        self.assertTrue(result.valid, msg=result.errors)
+
+
+class ClosedRootElementTests(unittest.TestCase):
+    def test_closed_root_element_semantics(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            schema_path = helpers.write_file(
+                tmp,
+                "closed-root.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+
+[elements]
+""",
+            )
+            empty_document = helpers.write_file(tmp, "empty.toml", "")
+            metadata_only_document = helpers.write_file(
+                tmp,
+                "metadata-only.toml",
+                """
+[toml-schema]
+location = "closed-root.tosd"
+""",
+            )
+            application_document = helpers.write_file(tmp, "application.toml", "extra = true")
+            defined_root_schema = helpers.write_file(
+                tmp,
+                "defined-root.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+
+[elements.allowed]
+type = "string"
+""",
+            )
+            document_with_extra_key = helpers.write_file(
+                tmp,
+                "extra-key.toml",
+                """
+allowed = "value"
+extra = true
+""",
+            )
+
+            schema = load_schema(schema_path)
+            for document in [empty_document, metadata_only_document]:
+                result = schema.validate_file(document)
+                self.assertTrue(result.valid, msg=(document, result.errors))
+
+            result = schema.validate_file(application_document)
+            self.assertFalse(result.valid)
+            self.assertTrue(helpers.has_path(result, "$.extra"))
+
+            defined_schema = load_schema(defined_root_schema)
+            result = defined_schema.validate_file(document_with_extra_key)
+            self.assertFalse(result.valid)
+            self.assertTrue(helpers.has_path(result, "$.extra"))
+
+            schema_schema = load_schema(helpers.repo_path("toml-schema.tosd"))
+            result = schema_schema.validate_file(schema_path)
+            self.assertTrue(result.valid, msg=result.errors)
+
+
+class DescriptionTests(unittest.TestCase):
+    def test_accepts_string_descriptions_and_rejects_other_values(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            described_schema = helpers.write_file(
+                tmp,
+                "described.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+
+[types.game]
+type = "table"
+description = "A game object."
+
+[types.game.id]
+type = "string"
+description = "Unique identifier for the game."
+
+[elements.game]
+type = "array"
+description = "A list of games."
+itemtype = "types.game"
+""",
+            )
+            load_schema(described_schema)  # must not raise
+
+            invalid_schema = helpers.write_file(
+                tmp,
+                "invalid-description.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+
+[elements.game]
+type = "string"
+description = 42
+""",
+            )
+            with self.assertRaises(SchemaError):
+                load_schema(invalid_schema)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/reference-implementations/python/tests/test_references.py
+++ b/reference-implementations/python/tests/test_references.py
@@ -1,0 +1,397 @@
+"""Reference resolution, type-selector cardinality, named-type-name
+vocabulary, and union structural validation tests. Ports representative
+coverage from Go's schema_test.go."""
+
+import tempfile
+import unittest
+
+import helpers
+from toml_schema import SchemaError, load_schema
+
+
+class BuiltInAndUnionReferenceTests(unittest.TestCase):
+    def test_supports_built_in_type_references(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema_path = helpers.write_file(
+                tmp,
+                "schema.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+
+[elements.name]
+type = "string"
+
+[elements.flags]
+type = "array"
+itemtype = "boolean"
+
+[elements.tuple]
+type = "array"
+items = [ "string", "integer" ]
+
+[elements.identity]
+oneof = [ "string", "integer" ]
+
+[elements.flex]
+anyof = [ "string", "integer" ]
+""",
+            )
+            document_path = helpers.write_file(
+                tmp,
+                "document.toml",
+                """
+name = "Alice"
+flags = [ true, false ]
+tuple = [ "port", 8080 ]
+identity = 42
+flex = "abc"
+""",
+            )
+            schema = load_schema(schema_path)
+            result = schema.validate_file(document_path)
+            self.assertTrue(result.valid, msg=result.errors)
+
+    def test_rejects_invalid_union_structure_and_child_placement(self):
+        invalid_definitions = [
+            "oneof = []",
+            "anyof = []",
+            'oneof = [ "string" ]\npattern = "x"',
+            'oneof = [ "string" ]\ndependentrequired = { a = ["b"] }',
+            'oneof = [ "string" ]\nmutuallyexclusive = [["a", "b"]]',
+            'anyof = [ "string" ]\nexactlyone = [["a", "b"]]',
+            'anyof = [ "array" ]\nuniqueitems = true',
+            'oneof = [ "string" ]\n\n[elements.value.child]\ntype = "string"',
+            'type = "string"\n\n[elements.value.child]\ntype = "string"',
+            'type = "array"\n\n[elements.value.child]\ntype = "string"',
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            for index, definition in enumerate(invalid_definitions):
+                with self.subTest(index=index):
+                    content = f"""
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+{definition}
+"""
+                    path = helpers.write_file(tmp, f"invalid-structure-{index}.tosd", content)
+                    with self.assertRaises(SchemaError):
+                        load_schema(path)
+
+    def test_validates_allowed_values_for_array_without_itemtype(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema_path = helpers.write_file(
+                tmp,
+                "array-allowedvalues.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+
+[elements.colors]
+type = "array"
+allowedvalues = [ "red", "blue" ]
+""",
+            )
+            valid_path = helpers.write_file(
+                tmp, "valid-array-allowedvalues.toml", 'colors = [ "red", "blue" ]\n'
+            )
+            invalid_path = helpers.write_file(
+                tmp, "invalid-array-allowedvalues.toml", 'colors = [ "red", "green" ]\n'
+            )
+            schema = load_schema(schema_path)
+            result = schema.validate_file(valid_path)
+            self.assertTrue(result.valid, msg=result.errors)
+
+            result = schema.validate_file(invalid_path)
+            self.assertFalse(result.valid)
+            self.assertTrue(helpers.has_path(result, "$.colors[1]"))
+
+
+class ReferenceGraphValidationTests(unittest.TestCase):
+    def test_validates_reference_graph_at_schema_load_time(self):
+        invalid_references = [
+            'type = ""',
+            'type = "types.missing"',
+            'type = "array"\nitemtype = ""',
+            'type = "array"\nitemtype = "types.missing"',
+            'type = "array"\nitems = [ "" ]',
+            'type = "array"\nitems = [ "types.missing" ]',
+            'oneof = [ "" ]',
+            'oneof = [ "types.missing" ]',
+            'anyof = [ "" ]',
+            'anyof = [ "types.missing" ]',
+            'type = "table"\n\n[elements.value.child]\ntype = "types.missing"',
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            for index, definition in enumerate(invalid_references):
+                with self.subTest(index=index):
+                    content = f"""
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+{definition}
+"""
+                    path = helpers.write_file(tmp, f"dangling-reference-{index}.tosd", content)
+                    with self.assertRaises(SchemaError):
+                        load_schema(path)
+
+            cycles = [
+                '[types.first]\ntype = "types.second"\n\n[types.second]\ntype = "types.first"',
+                (
+                    '[types.first]\noneof = [ "types.second" ]\n\n'
+                    '[types.second]\nanyof = [ "types.first" ]'
+                ),
+            ]
+            for index, cycle in enumerate(cycles):
+                with self.subTest(cycle=index):
+                    content = f"""
+[toml-schema]
+version = "1.0.0"
+
+{cycle}
+
+[elements.value]
+type = "string"
+"""
+                    path = helpers.write_file(tmp, f"selector-cycle-{index}.tosd", content)
+                    with self.assertRaises(SchemaError):
+                        load_schema(path)
+
+            recursive = helpers.write_file(
+                tmp,
+                "recursive-structure.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+
+[types.node]
+type = "table"
+
+    [types.node.children]
+    type = "array"
+    itemtype = "types.node"
+
+[elements.root]
+type = "types.node"
+""",
+            )
+            load_schema(recursive)  # must not raise: structural recursion is allowed
+
+    def test_rejects_unknown_property(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = helpers.write_file(
+                tmp,
+                "unknown-property.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+
+[elements.values]
+type = "array"
+unknownproperty = "string"
+""",
+            )
+            with self.assertRaisesRegex(SchemaError, "unsupported property: unknownproperty"):
+                load_schema(path)
+
+    def test_rejects_removed_table_collection_alias_as_unknown_reference(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = helpers.write_file(
+                tmp,
+                "schema.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+
+[elements.items]
+type = "table-collection"
+""",
+            )
+            with self.assertRaises(SchemaError):
+                load_schema(path)
+
+
+class NamedTypeNameVocabularyTests(unittest.TestCase):
+    def test_rejects_types_named_after_built_ins(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = helpers.write_file(
+                tmp,
+                "schema.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+
+[types.string]
+type = "integer"
+
+[elements.value]
+type = "string"
+""",
+            )
+            with self.assertRaises(SchemaError):
+                load_schema(path)
+
+    def test_rejects_types_named_with_reference_prefix(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = helpers.write_file(
+                tmp,
+                "schema.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+
+[types."types.name"]
+type = "string"
+
+[elements.value]
+type = "name"
+""",
+            )
+            with self.assertRaises(SchemaError):
+                load_schema(path)
+
+    def test_resolves_quoted_dotted_type_names_in_both_reference_forms(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema_path = helpers.write_file(
+                tmp,
+                "schema.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+
+[types."network.endpoint"]
+type = "string"
+
+[elements.short]
+type = "network.endpoint"
+
+[elements.qualified]
+type = "types.network.endpoint"
+""",
+            )
+            document_path = helpers.write_file(
+                tmp,
+                "document.toml",
+                """
+short = "one"
+qualified = "two"
+""",
+            )
+            schema = load_schema(schema_path)
+            result = schema.validate_file(document_path)
+            self.assertTrue(result.valid, msg=result.errors)
+
+
+class NamedTypeReferenceSiblingTests(unittest.TestCase):
+    def test_allows_optional_and_description_on_named_type_reference(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema_path = helpers.write_file(
+                tmp,
+                "named-reference-metadata.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+
+[types.nameType]
+type = "string"
+pattern = "^[a-z]+$"
+
+[types.inheritedOptional]
+type = "string"
+optional = true
+
+[elements.name]
+type = "types.nameType"
+description = "Optional display name."
+optional = true
+
+[elements.inherited]
+type = "types.inheritedOptional"
+optional = false
+""",
+            )
+            document_path = helpers.write_file(
+                tmp, "named-reference-metadata.toml", "# name is optional\n"
+            )
+            schema = load_schema(schema_path)
+            result = schema.validate_file(document_path)
+            self.assertTrue(result.valid, msg=result.errors)
+
+    def test_rejects_constraints_and_children_on_named_type_reference(self):
+        invalid_siblings = [
+            'itemtype = "string"',
+            'items = [ "string" ]',
+            'allowedvalues = [ "name" ]',
+            'pattern = "^[a-z]+$"',
+            'keypattern = "^[a-z]+$"',
+            "min = 1",
+            "max = 1",
+            "minlength = 1",
+            "maxlength = 1",
+            'dependentrequired = { a = ["b"] }',
+            'mutuallyexclusive = [["a", "b"]]',
+            'exactlyone = [["a", "b"]]',
+            "uniqueitems = true",
+            '[elements.name.child]\ntype = "string"',
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            for index, invalid_sibling in enumerate(invalid_siblings):
+                with self.subTest(index=index):
+                    content = f"""
+[toml-schema]
+version = "1.0.0"
+
+[types.nameType]
+type = "string"
+
+[elements.name]
+type = "types.nameType"
+{invalid_sibling}
+"""
+                    path = helpers.write_file(
+                        tmp, f"named-reference-constraint-{index}.tosd", content
+                    )
+                    with self.assertRaisesRegex(SchemaError, "named type reference"):
+                        load_schema(path)
+
+    def test_allows_itemtype_on_collection(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema_path = helpers.write_file(
+                tmp,
+                "collection-itemtype.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+
+[types.stringItem]
+type = "string"
+
+[types.integerItem]
+type = "integer"
+
+[types.itemType]
+oneof = [ "types.stringItem", "types.integerItem" ]
+
+[elements.items]
+type = "collection"
+itemtype = "types.itemType"
+""",
+            )
+            document_path = helpers.write_file(
+                tmp,
+                "collection-itemtype.toml",
+                """
+[items]
+name = "example"
+port = 8080
+""",
+            )
+            schema = load_schema(schema_path)
+            result = schema.validate_file(document_path)
+            self.assertTrue(result.valid, msg=result.errors)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/reference-implementations/python/tests/test_semantics.py
+++ b/reference-implementations/python/tests/test_semantics.py
@@ -1,0 +1,431 @@
+"""Sibling rule, allof/anyof/oneof composition, uniqueitems, and default
+annotation tests. Ports Go's schema_semantics_test.go."""
+
+import math
+import tempfile
+import unittest
+
+import helpers
+from toml_schema import SchemaError, load_schema
+
+
+class SiblingPresenceRuleTests(unittest.TestCase):
+    def test_sibling_presence_rules(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema = helpers.load_semantics_schema(
+                tmp,
+                """
+[types.settings]
+type = "table"
+dependentrequired = { branch = ["git"], tag = ["git"], git = ["url"] }
+mutuallyexclusive = [["git", "path"], ["branch", "tag"]]
+exactlyone = [["file", "text"]]
+
+[types.settings.git]
+type = "string"
+optional = true
+[types.settings.url]
+type = "string"
+optional = true
+[types.settings.path]
+type = "string"
+optional = true
+[types.settings.branch]
+type = "string"
+optional = true
+[types.settings.tag]
+type = "string"
+optional = true
+[types.settings.file]
+type = "string"
+optional = true
+[types.settings.text]
+type = "string"
+optional = true
+
+[elements.settings]
+type = "types.settings"
+""",
+            )
+            valid = {
+                "settings": {
+                    "branch": "main",
+                    "git": "repo",
+                    "url": "origin",
+                    "file": "README.md",
+                }
+            }
+            result = schema.validate(valid)
+            self.assertTrue(result.valid, msg=result.errors)
+
+            cases = {
+                "dependency": {"branch": "main", "file": "README.md"},
+                "transitive": {"git": "repo", "file": "README.md"},
+                "exclusive": {"git": "repo", "url": "origin", "path": ".", "file": "README.md"},
+                "none": {},
+                "two": {"file": "README.md", "text": "inline"},
+            }
+            for name, settings in cases.items():
+                with self.subTest(name=name):
+                    result = schema.validate({"settings": settings})
+                    self.assertFalse(result.valid)
+
+    def test_dependent_required_triggers_on_direct_presence_only(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema = helpers.load_semantics_schema(
+                tmp,
+                """
+[types.settings]
+type = "table"
+dependentrequired = { a = ["b"], b = ["c"] }
+
+[types.settings.a]
+type = "string"
+optional = true
+[types.settings.b]
+type = "string"
+optional = true
+[types.settings.c]
+type = "string"
+optional = true
+
+[elements.settings]
+type = "types.settings"
+""",
+            )
+            result = schema.validate({"settings": {"a": "x"}})
+            self.assertEqual(len(result.errors), 1)
+            diagnostic = result.errors[0]
+            self.assertEqual(diagnostic.path, "$.settings.b")
+            self.assertEqual(
+                diagnostic.message, 'required by dependentrequired triggered by sibling "a"'
+            )
+
+            present = schema.validate({"settings": {"a": "x", "b": "y"}})
+            self.assertEqual(len(present.errors), 1)
+            self.assertEqual(present.errors[0].path, "$.settings.c")
+
+            result = schema.validate({"settings": {"a": "x", "b": "y", "c": "z"}})
+            self.assertTrue(result.valid, msg=result.errors)
+
+            result = schema.validate({"settings": {"c": "z"}})
+            self.assertTrue(result.valid, msg=result.errors)
+
+
+class AllOfCompositionTests(unittest.TestCase):
+    def test_allof_is_additive_and_computes_table_closure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema = helpers.load_semantics_schema(
+                tmp,
+                """
+[types.base]
+type = "table"
+[types.base.id]
+type = "integer"
+[types.base.score]
+type = "integer"
+min = 1
+
+[types.extended]
+type = "table"
+allof = ["types.base"]
+[types.extended.name]
+type = "string"
+[types.extended.score]
+type = "integer"
+max = 10
+
+[elements.item]
+type = "types.extended"
+""",
+            )
+            result = schema.validate({"item": {"id": 1, "name": "ok", "score": 5}})
+            self.assertTrue(result.valid, msg=result.errors)
+
+            cases = {
+                "base-required": {"name": "ok", "score": 5},
+                "base-overlap": {"id": 1, "name": "ok", "score": 0},
+                "local-overlap": {"id": 1, "name": "ok", "score": 11},
+                "closed-union": {"id": 1, "name": "ok", "score": 5, "extra": True},
+            }
+            for name, item in cases.items():
+                with self.subTest(name=name):
+                    result = schema.validate({"item": item})
+                    self.assertFalse(result.valid)
+
+    def test_allof_collection_applies_every_dynamic_constraint(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema = helpers.load_semantics_schema(
+                tmp,
+                """
+[types.positive]
+type = "integer"
+min = 1
+
+[types.small]
+type = "integer"
+max = 9
+
+[types.base]
+type = "collection"
+itemtype = "types.positive"
+keypattern = "^x"
+
+[types.composed]
+type = "collection"
+itemtype = "types.small"
+keypattern = "z$"
+allof = ["types.base"]
+
+[types.composed.fixed]
+type = "string"
+
+[elements.values]
+type = "types.composed"
+""",
+            )
+            result = schema.validate({"values": {"fixed": "special", "xyz": 5}})
+            self.assertTrue(result.valid, msg=result.errors)
+
+            cases = {
+                "first-itemtype": {"xyz": 0},
+                "second-itemtype": {"xyz": 10},
+                "first-pattern": {"ayz": 5},
+                "second-pattern": {"xy": 5},
+            }
+            for name, values in cases.items():
+                with self.subTest(name=name):
+                    result = schema.validate({"values": values})
+                    self.assertFalse(result.valid)
+
+    def test_composes_array_constraints_independently(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema_path = helpers.write_file(
+                tmp,
+                "array-allof.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+
+[types.strings]
+type = "array"
+itemtype = "string"
+
+[types.pair]
+type = "array"
+items = ["string", "string"]
+
+[types.unique]
+type = "array"
+uniqueitems = true
+
+[elements.value]
+type = "array"
+allof = ["types.strings", "types.pair", "types.unique"]
+""",
+            )
+            schema = load_schema(schema_path)
+            result = schema.validate({"value": ["a", "b"]})
+            self.assertTrue(result.valid, msg=result.errors)
+
+            cases = {
+                "kind": ["a", 1],
+                "length": ["a"],
+                "unique": ["a", "a"],
+            }
+            for name, value in cases.items():
+                with self.subTest(name=name):
+                    result = schema.validate({"value": value})
+                    self.assertFalse(result.valid)
+
+
+class UniqueItemsTests(unittest.TestCase):
+    def test_unique_items_uses_recursive_toml_equality(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema = helpers.load_semantics_schema(
+                tmp,
+                """
+[elements.values]
+type = "array"
+itemtype = "any"
+uniqueitems = true
+""",
+            )
+            cases = {
+                "numeric": [1, 1.0],
+                "zero": [0.0, math.copysign(0.0, -1)],
+                "nan": [math.nan, math.nan],
+                "arrays": [[1, "x"], [1.0, "x"]],
+                "tables": [{"a": 1, "b": True}, {"b": True, "a": 1.0}],
+            }
+            for name, values in cases.items():
+                with self.subTest(name=name):
+                    result = schema.validate({"values": values})
+                    self.assertFalse(result.valid)
+                    self.assertIn("duplicate item", result.errors[0].message)
+
+            result = schema.validate(
+                {
+                    "values": [
+                        {"id": 1, "value": "a"},
+                        {"id": 1, "value": "b"},
+                    ]
+                }
+            )
+            self.assertTrue(result.valid, msg=result.errors)
+
+
+class DefaultAnnotationTests(unittest.TestCase):
+    def test_defaults_are_validated_inherited_and_non_mutating(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema = helpers.load_semantics_schema(
+                tmp,
+                """
+[types.base]
+type = "integer"
+min = 1
+default = 2
+
+[types.same]
+type = "integer"
+default = 2
+
+[elements.inherited]
+type = "types.base"
+optional = true
+
+[elements.local]
+type = "types.base"
+default = 3
+optional = true
+
+[elements.composed]
+type = "integer"
+allof = ["types.base", "types.same"]
+optional = true
+""",
+            )
+            inherited = schema.element("inherited")
+            value, ok = inherited.default()
+            self.assertTrue(ok)
+            self.assertEqual(value, 2)
+
+            local = schema.element("local")
+            value, ok = local.default()
+            self.assertTrue(ok)
+            self.assertEqual(value, 3)
+
+            document = {}
+            result = schema.validate(document)
+            self.assertTrue(result.valid, msg=result.errors)
+            self.assertEqual(len(document), 0)
+
+            invalid = helpers.write_file(
+                tmp,
+                "invalid-default.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+[elements.count]
+type = "integer"
+min = 2
+default = 1
+""",
+            )
+            with self.assertRaisesRegex(SchemaError, "default is invalid"):
+                load_schema(invalid)
+
+            conflict = helpers.write_file(
+                tmp,
+                "conflicting-default.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+[types.a]
+type = "integer"
+default = 1
+[types.b]
+type = "integer"
+default = 2
+[elements.value]
+type = "integer"
+allof = ["types.a", "types.b"]
+""",
+            )
+            with self.assertRaisesRegex(SchemaError, "conflicting inherited defaults"):
+                load_schema(conflict)
+
+    def test_deprecated_produces_structured_branch_local_warnings(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema = helpers.load_semantics_schema(
+                tmp,
+                """
+[types.legacy]
+type = "string"
+pattern = "^old$"
+deprecated = true
+
+[types.current]
+type = "integer"
+
+[elements.value]
+oneof = ["types.legacy", "types.current"]
+
+[elements.optional]
+type = "types.legacy"
+optional = true
+""",
+            )
+            result = schema.validate({"value": "old"})
+            self.assertTrue(result.valid, msg=result.errors)
+            self.assertEqual(len(result.warnings), 1)
+            warning = result.warnings[0]
+            self.assertEqual(warning.severity.value, "warning")
+            self.assertEqual(warning.code, "deprecated")
+            self.assertEqual(warning.path, "$.value")
+            self.assertTrue(warning.message)
+            self.assertEqual(len(result.diagnostics), 1)
+
+            result = schema.validate({"value": 1})
+            self.assertTrue(result.valid, msg=result.errors)
+            self.assertEqual(len(result.warnings), 0)
+
+
+class MalformedVocabularyTests(unittest.TestCase):
+    def test_rejects_malformed_vocabulary(self):
+        cases = {
+            "dependent-empty": 'type = "table"\ndependentrequired = {}',
+            "dependent-values": (
+                'type = "table"\ndependentrequired = { a = [] }\n'
+                '[elements.value.a]\ntype = "string"\noptional = true'
+            ),
+            "exclusive-small": (
+                'type = "table"\nmutuallyexclusive = [["a"]]\n'
+                '[elements.value.a]\ntype = "string"\noptional = true'
+            ),
+            "exact-duplicate": (
+                'type = "table"\nexactlyone = [["a", "a"]]\n'
+                '[elements.value.a]\ntype = "string"\noptional = true'
+            ),
+            "allof-empty": 'type = "string"\nallof = []',
+            "items-empty": 'type = "array"\nitems = []',
+            "allof-kind": 'type = "string"\nallof = ["integer"]',
+            "unique-kind": 'type = "string"\nuniqueitems = true',
+            "deprecated-type": 'type = "string"\ndeprecated = "yes"',
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            for name, definition in cases.items():
+                with self.subTest(name=name):
+                    content = f"""
+[toml-schema]
+version = "1.0.0"
+[elements.value]
+{definition}
+"""
+                    path = helpers.write_file(tmp, f"invalid-{name}.tosd", content)
+                    with self.assertRaises(SchemaError):
+                        load_schema(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
TOML Schema currently has reference libraries for Java, Go, .NET, and Rust, but Python users do not have a native implementation. This adds a Python 3.11+ library with no runtime dependencies by building on the standard-library `tomllib` parser.

## Approach

- Implement the full TOML Schema 1.0 validation model, including named references, closed tables, collections, arrays and tuples, ranges, unions, conditional selection, `allof` composition, sibling rules, defaults, deprecation warnings, and TOML-aware equality.
- Support document-driven schema discovery through `[toml-schema].location`, including local paths, hierarchical `file` URIs, version compatibility checks, and structured diagnostics.
- Expose an idiomatic Python API for loading schemas and documents, validating files or parsed values, and inspecting effective definition annotations.
- Add 77 standard-library `unittest` cases covering checked-in examples, self-schema validation, semantics, discovery, diagnostics, recursive definitions, and ABNF vocabulary alignment.
- Integrate Python 3.11 into the reference implementation workflow, aggregate build script, project documentation, and status badges.

## Review notes

Python `datetime.time` preserves microseconds rather than nanoseconds. Pattern validation uses Python `re`; repository schemas and tests remain within the shared RE2-compatible syntax profile.