### PR TITLE
Unify website page layouts and navigation

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <title>Page not found - TOML Schema</title>
   <script>
     (() => {
@@ -14,11 +14,45 @@
   </script>
   <link rel="stylesheet" href="/styles.css">
 </head>
-<body class="not-found-page">
-  <main>
-    <h1>Page not found</h1>
-    <p>The TOML Schema page you requested does not exist.</p>
-    <p><a href="/">Return to toml-schema.org</a></p>
-  </main>
+<body>
+  <div class="page">
+    <header>
+      <a class="brand" href="/" aria-label="TOML Schema home">
+        <svg class="brand-logo" viewBox="0 0 420 128" preserveAspectRatio="xMinYMid meet" aria-hidden="true" focusable="false">
+          <polygon class="logo-bracket" points="0 0 34 0 34 14 18 14 18 114 34 114 34 128 0 128" />
+          <polygon class="logo-t" points="42 26 104 26 104 42 80 42 80 110 66 110 66 42 42 42" />
+          <polygon class="logo-bracket" points="112 0 146 0 146 128 112 128 112 114 128 114 128 14 112 14" />
+          <text class="logo-schema" x="160" y="110">Schema</text>
+        </svg>
+        <span class="visually-hidden">TOML Schema</span>
+      </a>
+      <nav aria-label="Primary navigation">
+        <a href="/editor/">Editor</a>
+        <a href="/validation-report/">Evidence</a>
+        <a href="/spec/">Spec</a>
+        <a href="/implementations/">Implementations</a>
+        <a href="https://github.com/brunoborges/toml-schema">GitHub</a>
+      </nav>
+    </header>
+
+    <main class="not-found">
+      <h1>Page not found</h1>
+      <p>The TOML Schema page you requested does not exist.</p>
+      <p><a href="/">Return to toml-schema.org</a></p>
+    </main>
+
+    <footer>
+      <span>TOML Schema is licensed under MIT.</span>
+      <span>
+        <a href="/">Home</a>
+        <span class="muted"> / </span>
+        <a href="/spec/">Spec</a>
+        <span class="muted"> / </span>
+        <a href="/implementations/">Implementations</a>
+        <span class="muted"> / </span>
+        <a href="https://github.com/brunoborges/toml-schema/issues">Feedback</a>
+      </span>
+    </footer>
+  </div>
 </body>
 </html>

--- a/docs/editor/index.html
+++ b/docs/editor/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="description" content="Visually edit TOML Schema .tosd files in the GitHub Copilot App with schema maps, property controls, live TOML preview, inference, and Copilot generation.">
   <link rel="canonical" href="https://toml-schema.org/editor/">
   <title>TOML Schema Editor for GitHub Copilot</title>
@@ -24,7 +24,7 @@
     FIRST VIEWPORT: A compact proposition and action sit above a dominant annotated capture of the real editor.
     FORM: Annotated schema atlas, third grounded structure, staged as one synchronized multi-frame argument; seed d5a951e4.
   -->
-  <div class="page editor-shell">
+  <div class="page">
     <header>
       <a class="brand" href="/" aria-label="TOML Schema home">
         <svg class="brand-logo" viewBox="0 0 420 128" preserveAspectRatio="xMinYMid meet" aria-hidden="true" focusable="false">
@@ -146,6 +146,8 @@
         <a href="/">Home</a>
         <span class="muted"> / </span>
         <a href="/spec/">Spec</a>
+        <span class="muted"> / </span>
+        <a href="/implementations/">Implementations</a>
         <span class="muted"> / </span>
         <a href="https://github.com/brunoborges/toml-schema/issues">Feedback</a>
       </span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -395,6 +395,8 @@ retries = 3</code></pre>
     <footer>
       <span>TOML Schema is licensed under MIT.</span>
       <span>
+        <a href="/">Home</a>
+        <span class="muted"> / </span>
         <a href="/spec/">Spec</a>
         <span class="muted"> / </span>
         <a href="/implementations/">Implementations</a>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -435,9 +435,6 @@ footer {
   width: 100%;
 }
 
-.editor-shell {
-  max-width: 1280px;
-}
 .editor-hero {
   align-items: end;
   display: grid;
@@ -1119,23 +1116,24 @@ footer {
   }
 }
 
-.not-found-page {
+.not-found {
   align-items: center;
-  display: flex;
-  justify-content: center;
-  min-height: 100vh;
-  padding: 24px;
-}
-.not-found-page main {
   background: var(--cp-surface);
   border: 1px solid var(--cp-border);
   border-radius: 16px;
   box-shadow: var(--cp-shadow);
-  max-width: 560px;
-  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-height: min(620px, 70vh);
+  padding: 64px 24px;
   text-align: center;
 }
-.not-found-page a {
+.not-found p {
+  color: var(--cp-text-muted);
+  margin: 16px 0 0;
+}
+.not-found a {
   font-weight: 600;
 }
 

--- a/docs/validation-report/index.html
+++ b/docs/validation-report/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="description" content="A field report validating 18 real-world Cargo, pyproject, Hugo, Netlify, Wrangler, and GitLab Runner files with TOML Schema.">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="TOML Schema">
@@ -270,6 +270,8 @@ cargo run --quiet --manifest-path reference-implementations/rust/Cargo.toml -- \
         <a href="/">Home</a>
         <span class="muted"> / </span>
         <a href="/spec/">Spec</a>
+        <span class="muted"> / </span>
+        <a href="/implementations/">Implementations</a>
         <span class="muted"> / </span>
         <a href="https://github.com/brunoborges/toml-schema/issues">Feedback</a>
       </span>

--- a/scripts/render-docs.mjs
+++ b/scripts/render-docs.mjs
@@ -100,7 +100,7 @@ for (const pageConfig of pages) {
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="description" content="${escapeHtml(pageConfig.description)}">
   <link rel="canonical" href="${pageConfig.canonical}">
   <title>${escapeHtml(pageTitle)} — TOML Schema</title>
@@ -127,9 +127,8 @@ for (const pageConfig of pages) {
         <span class="visually-hidden">TOML Schema</span>
       </a>
       <nav aria-label="Primary navigation">
-        <a href="/#why">Why</a>
+        <a href="/editor/">Editor</a>
         <a href="/validation-report/">Evidence</a>
-        <a href="/#tour">Tour</a>
         <a href="/spec/"${navCurrent("spec")}>Spec</a>
         <a href="/implementations/"${navCurrent("implementations")}>Implementations</a>
         <a href="${repositoryUrl}">GitHub</a>
@@ -145,6 +144,8 @@ ${bodyHtml}
     <footer>
       <span>TOML Schema is licensed under MIT.</span>
       <span>
+        <a href="/">Home</a>
+        <span class="muted"> / </span>
         <a href="/spec/">Spec</a>
         <span class="muted"> / </span>
         <a href="/implementations/">Implementations</a>


### PR DESCRIPTION
The generated Spec and Implementations pages used an older navigation structure, while the Editor page also used a wider outer container than the rest of the site. This made navigation and page alignment shift between routes.

This change standardizes the site shell across hand-authored and generated pages:

- uses the same Editor, Evidence, Spec, Implementations, and GitHub navigation everywhere
- aligns pages on the shared 1120px outer container and preserves route-specific content widths
- applies consistent footer links and safe-area viewport handling
- brings the 404 page into the shared header, navigation, content, and footer structure
- updates the documentation generator so rebuilt Spec and Implementations pages retain the unified shell

The generated documentation pages were rebuilt locally, and the updated routes were checked for matching header bounds and horizontal overflow.