### PR TITLE
Add Node.js TypeScript reference implementation

### DIFF
--- a/.github/workflows/reference-implementations.yml
+++ b/.github/workflows/reference-implementations.yml
@@ -134,3 +134,30 @@ jobs:
 
       - name: Validate checked-in example with extracted schema
         run: reference-implementations/rust/target/release/toml-schema validate /tmp/config.generated.tosd config.toml
+
+  typescript:
+    name: TypeScript reference implementation
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: reference-implementations/typescript/package-lock.json
+
+      - name: Install dependencies
+        run: npm --prefix reference-implementations/typescript ci
+
+      - name: Typecheck
+        run: npm --prefix reference-implementations/typescript run typecheck
+
+      - name: Test
+        run: npm --prefix reference-implementations/typescript test
+
+      - name: Build
+        run: npm --prefix reference-implementations/typescript run build

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ docs/implementations/
 scripts/node_modules/
 reference-implementations/dotnet/**/bin/
 reference-implementations/dotnet/**/obj/
+reference-implementations/typescript/node_modules/
+reference-implementations/typescript/dist/

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![.NET 9](https://img.shields.io/badge/.NET-9.0-512BD4)](REFERENCE_IMPLEMENTATIONS.md#net)
 [![Python 3.11](https://img.shields.io/badge/Python-3.11+-3776AB)](REFERENCE_IMPLEMENTATIONS.md#python)
 [![Rust 1.75](https://img.shields.io/badge/Rust-1.75-dea584)](REFERENCE_IMPLEMENTATIONS.md#rust)
+[![TypeScript 6](https://img.shields.io/badge/TypeScript-6-3178C6)](REFERENCE_IMPLEMENTATIONS.md#nodejs--typescript)
 
 TOML Schema is a TOML-based schema language for describing and validating the structure, names, value types, and common semantic relationships of TOML configuration files.
 
@@ -70,8 +71,9 @@ type = "table"
 
 ## Reference implementations
 
-Java, Go, .NET, Python, and Rust reference libraries live under `reference-implementations/`.
-The Rust implementation provides the canonical `toml-schema` CLI. See
+Java, Go, .NET, Python, Rust, and Node.js/TypeScript reference libraries live
+under `reference-implementations/`. The Rust implementation provides the
+canonical `toml-schema` CLI. See
 [Reference implementations](REFERENCE_IMPLEMENTATIONS.md) for implementation
 status, CLI usage, schema extraction, and conformance expectations.
 

--- a/REFERENCE_IMPLEMENTATIONS.md
+++ b/REFERENCE_IMPLEMENTATIONS.md
@@ -1,8 +1,9 @@
 # Reference Implementations
 
-Build and use the TOML Schema reference libraries in Java, Go, .NET, Python, and Rust. Rust also
-provides the canonical `toml-schema` command-line interface for validation, schema
-discovery through `[toml-schema].location`, and starter-schema extraction.
+Build and use the TOML Schema reference libraries in Java, Go, .NET, Python,
+Rust, and Node.js/TypeScript. Rust also provides the canonical `toml-schema`
+command-line interface for validation, schema discovery through
+`[toml-schema].location`, and starter-schema extraction.
 
 ## Status
 
@@ -13,6 +14,7 @@ discovery through `[toml-schema].location`, and starter-schema extraction.
 | .NET | [`reference-implementations/dotnet`](reference-implementations/dotnet) | .NET 9.0 | Library, schema discovery |
 | Python | [`reference-implementations/python`](reference-implementations/python) | Python 3.11+ | Library, schema discovery |
 | Rust | [`reference-implementations/rust`](reference-implementations/rust) | Rust 1.75 and Cargo | Library, canonical CLI, schema discovery, schema extraction |
+| Node.js / TypeScript | [`reference-implementations/typescript`](reference-implementations/typescript) | Node.js 20.11+ and TypeScript 6 | Library, schema discovery, schema extraction |
 
 The implementations use TOML 1.0 parsers and share the same conformance expectations.
 They are reference-quality implementations rather than separately versioned,
@@ -278,6 +280,37 @@ assert!(result.valid());
 
 The Rust test suite includes an ABNF conformance test (`tests/abnf_conformance.rs`) that reads `toml-schema.abnf` and asserts that the implementation's supported schema keys and built-in type names match the grammar.
 
+## Node.js / TypeScript
+
+The Node.js reference library is written in TypeScript 6 and uses
+[`smol-toml`](https://github.com/squirrelchat/smol-toml) to parse TOML. It
+preserves TOML integer, float, and temporal type distinctions and supports
+document-driven schema discovery and starter-schema extraction.
+
+Install dependencies and run its checks:
+
+```shell
+npm --prefix reference-implementations/typescript ci
+npm --prefix reference-implementations/typescript run typecheck
+npm --prefix reference-implementations/typescript test
+npm --prefix reference-implementations/typescript run build
+```
+
+Use the ESM library API:
+
+```typescript
+import { loadSchema, validateDocument } from "@tomlschema/toml-schema";
+
+const schema = await loadSchema("config.tosd");
+const result = await schema.validateFile("config.toml");
+
+const discoveredResult = await validateDocument("config.toml");
+```
+
+The TypeScript test suite reads `toml-schema.abnf` and checks that the
+implementation's supported schema properties and built-in type names match the
+grammar.
+
 ## Conformance expectations
 
 Every reference implementation should:
@@ -301,8 +334,8 @@ language-version compatibility rules from `SPEC.md`, and expose validation and
 schema extraction commands suitable for automation and editor integration.
 
 The GitHub Actions workflow in `.github/workflows/reference-implementations.yml`
-enforces these expectations for Java, Go, .NET, Python, and Rust. Rust additionally exercises
-the canonical CLI end to end.
+enforces these expectations for Java, Go, .NET, Python, Rust, and TypeScript.
+Rust additionally exercises the canonical CLI end to end.
 
 ## TOML version profile
 
@@ -315,8 +348,12 @@ The current reference implementations parse TOML with libraries that target TOML
 - .NET: [Tomlyn](https://github.com/xoofx/Tomlyn) `2.10.1`, which targets TOML 1.0.
 - Python: [`tomllib`](https://docs.python.org/3/library/tomllib.html), which targets TOML 1.0.
 - Rust: [`toml`](https://crates.io/crates/toml) `1`, which targets TOML 1.0.
+- TypeScript: [`smol-toml`](https://github.com/squirrelchat/smol-toml) `1.8.0`,
+  which supports TOML 1.1 while remaining compatible with TOML 1.0 documents.
 
-For that reason, the reference implementations' current effective parser profile is **TOML 1.0**. TOML 1.1 syntax (for example multi-line inline tables, trailing commas in inline tables, omitted seconds in date-times, or the `\e` and `\xHH` string escapes) is not guaranteed to parse in any reference implementation until the underlying TOML parser declares TOML 1.1 conformance.
+The shared baseline parser profile remains **TOML 1.0**. The TypeScript
+implementation also accepts TOML 1.1 syntax through its parser, but TOML 1.1
+syntax is not yet guaranteed across all reference implementations.
 
 Upgrading a reference implementation to a TOML 1.1-conformant parser is tracked separately. When that happens, the expected follow-up changes are:
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -95,7 +95,7 @@ uniqueitems = true</code></pre>
           <article class="card">
             <span class="badge">Toolable</span>
             <h3>Reference implementations</h3>
-            <p>Java, Go, .NET, and Rust libraries validate examples and self-schema behavior in CI; Rust also exercises the canonical CLI end to end.</p>
+            <p>Java, Go, .NET, Python, Rust, and Node.js/TypeScript libraries validate examples and self-schema behavior in CI; Rust also exercises the canonical CLI end to end.</p>
           </article>
         </div>
       </section>
@@ -381,9 +381,19 @@ retries = 3</code></pre>
             <p>Uses Tomlyn to parse TOML and validates documents against <code>.tosd</code> schemas.</p>
           </article>
           <article class="card">
+            <span class="badge">Python</span>
+            <h3>Library</h3>
+            <p>Uses the standard-library tomllib parser and supports schema validation and schema-location lookup.</p>
+          </article>
+          <article class="card">
             <span class="badge">Rust</span>
             <h3>Library and canonical CLI</h3>
             <p>Uses the Rust <code>toml</code> crate and provides validation, schema discovery, and schema extraction commands.</p>
+          </article>
+          <article class="card">
+            <span class="badge">Node.js</span>
+            <h3>TypeScript 6 library</h3>
+            <p>Uses smol-toml and provides validation, schema discovery, and schema extraction through an ESM API.</p>
           </article>
         </div>
         <div class="actions">

--- a/reference-implementations/build-all.sh
+++ b/reference-implementations/build-all.sh
@@ -28,4 +28,10 @@ run_step "Building Python reference implementation" \
 run_step "Building Rust reference implementation" \
     cargo build --locked --release --manifest-path "$script_dir/rust/Cargo.toml"
 
+run_step "Installing TypeScript reference implementation dependencies" \
+    npm --prefix "$script_dir/typescript" ci
+
+run_step "Building TypeScript reference implementation" \
+    npm --prefix "$script_dir/typescript" run build
+
 printf '\nAll reference implementations built successfully.\n'

--- a/reference-implementations/typescript/.gitignore
+++ b/reference-implementations/typescript/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+test/.scratch/
+*.tsbuildinfo

--- a/reference-implementations/typescript/README.md
+++ b/reference-implementations/typescript/README.md
@@ -1,0 +1,279 @@
+# TOML Schema — Node.js / TypeScript reference implementation
+
+A TOML Schema 1.0 reference library for Node.js, written in TypeScript and
+published as an ESM package (`@tomlschema/toml-schema`). It parses TOML with
+[`smol-toml`](https://github.com/squirrelchat/smol-toml) and validates the
+parsed data model against a `.tosd` schema document, following the same
+behavior as the other reference implementations in this repository (see
+[`../go`](../go), [`../java`](../java), [`../dotnet`](../dotnet), and
+[`../rust`](../rust)).
+
+This package is a **reference implementation**, not a versioned,
+package-registry release: its own `package.json` version
+(`1.0.0-rc.2`) tracks the reference-implementation artifact lifecycle, which
+is independent from the TOML Schema **language** version it implements
+(`1.0.0`, per `[toml-schema].version` in schema documents).
+
+## Requirements
+
+- Node.js >= 20.11 (native `node --test`, `node:fs/promises`, ESM)
+- TypeScript 6.x (the package pins the **exact** version `6.0.3`; TypeScript 7
+  is intentionally out of range until this implementation is verified against
+  it)
+
+## Install
+
+```shell
+cd reference-implementations/typescript
+npm install
+```
+
+## Build, test, typecheck
+
+```shell
+npm run build       # tsc -p tsconfig.build.json -> dist/*.js, *.d.ts
+npm test            # node --import tsx --test test/*.test.ts
+npm run typecheck   # tsc -p tsconfig.test.json --noEmit (src + test)
+```
+
+## Why `smol-toml`
+
+TOML parsing itself is intentionally **not** reimplemented here. `smol-toml`
+is used with two options that matter for TOML Schema's data-model
+distinctions:
+
+- `integersAsBigInt: true` — TOML integers parse to `bigint`, kept distinct
+  from `number`-valued floats. This preserves the integer/float type
+  distinction that TOML Schema's `type = "integer"` vs. `type = "float"` and
+  numeric range/`allowedvalues` comparisons depend on, including integers
+  beyond `2^53` that would otherwise lose precision as `number`.
+- `TomlDate` — offset date-times, local date-times, local dates, and local
+  times parse to a shared `TomlDate` class that preserves which of the four
+  temporal kinds a value is, so schema comparisons (`type`, `min`/`max`) can
+  distinguish them exactly as `SPEC.md` requires. Note `TomlDate` itself
+  represents sub-second precision to the millisecond, not with unbounded
+  fractional-second precision.
+
+## API overview
+
+All entry points are exported from the package root (`src/index.ts`
+-> `dist/index.js`):
+
+```ts
+import {
+  loadSchema,
+  loadDocument,
+  Schema,
+  schemaFromDocument,
+  validateDocument,
+  generateSchema,
+  extractSchemaFile,
+  BUILTIN_TYPES,
+  DEFINITION_KEYS,
+} from "@tomlschema/toml-schema";
+```
+
+### Loading and validating with an explicit schema
+
+```ts
+import { loadSchema, loadDocument } from "@tomlschema/toml-schema";
+
+const schema = await loadSchema("config.tosd");
+const document = await loadDocument("config.toml");
+
+const result = schema.validate(document);
+// or, in one step, reading the document from disk:
+const result2 = await schema.validateFile("config.toml");
+
+if (!result.valid) {
+  for (const error of result.errors) {
+    console.error(`${error.path}: ${error.message}`);
+  }
+}
+```
+
+`Schema.validate`/`validateFile` return a `ValidationResult`:
+
+```ts
+class ValidationResult {
+  readonly errors: readonly ValidationError[];     // fatal — validity failures
+  readonly warnings: readonly Diagnostic[];         // non-fatal — deprecation, version mismatch, etc.
+  readonly diagnostics: readonly Diagnostic[];      // errors ++ warnings, in that order
+  get valid(): boolean;                             // errors.length === 0
+  isValid(): boolean;                                // method form of `.valid`
+}
+```
+
+Each `ValidationError`/`Diagnostic` carries a `severity` (`"error"` |
+`"warning"`), a stable `code`, the offending document `path` (e.g.
+`$.database.port`, with `.` and quoting applied to keys that need it), and a
+human-readable `message`.
+
+### Discovering the schema from the document (`[toml-schema].location`)
+
+```ts
+import { validateDocument, schemaFromDocument } from "@tomlschema/toml-schema";
+
+// one-shot discover + validate
+const result = await validateDocument("config.toml");
+
+// or, to inspect the discovered schema/warnings first:
+const { schema, document } = await schemaFromDocument("config.toml");
+console.log(schema.version, schema.warnings);
+const result2 = schema.validate(document);
+```
+
+`schemaFromDocument` resolves a `[toml-schema].location` value that is either
+a path relative to the document's own directory, an absolute local path, or a
+hierarchical `file:` URI; it rejects unsupported URI schemes, opaque `file:`
+URIs, non-local hosts, and query/fragment components. If the document also
+declares `[toml-schema].version`, discovery rejects a major-version mismatch
+against the schema's own declared version and records other (minor/patch)
+mismatches as a warning on the returned `Schema`.
+
+### Extracting a starter schema from a document
+
+```ts
+import { generateSchema, extractSchemaFile } from "@tomlschema/toml-schema";
+
+const draftSource = generateSchema(document); // string of draft .tosd TOML
+await extractSchemaFile("config.toml", "config.draft.tosd");
+```
+
+Extraction infers `[types]`/`[elements]` structure and built-in types from
+the parsed document, emits homogeneous arrays with an inferred `itemtype`,
+sorts keys deterministically, and quotes keys that are not valid bare TOML
+keys.
+
+### Inspecting a schema's definitions
+
+```ts
+const schema = await loadSchema("config.tosd");
+const element = schema.element("database"); // Definition | undefined
+element?.description;                       // effective, inherited description
+element?.deprecated;                        // effective, inherited deprecated flag
+element?.hasDefault();                      // whether an effective default exists
+element?.default();                         // the effective default value, if any
+element?.child("port");                     // Definition | undefined, for table/collection children
+element?.childNames();                      // string[]
+
+const namedType = schema.type("types.server"); // also accepts "server"
+```
+
+`Definition` accessors always resolve inherited/effective annotations
+(`description`, `deprecated`, `default`) through named-type references and
+`allof` composition, matching the other reference implementations.
+
+### Vocabulary constants
+
+```ts
+import { BUILTIN_TYPES, DEFINITION_KEYS, CURRENT_TOML_SCHEMA_VERSION } from "@tomlschema/toml-schema";
+```
+
+- `BUILTIN_TYPES` — the 12 built-in `type` values (`string`, `integer`,
+  `float`, `boolean`, `offset-date-time`, `local-date-time`, `local-date`,
+  `local-time`, `array`, `table`, `collection`, `any`).
+- `DEFINITION_KEYS` — the full set of recognized schema-vocabulary keys that
+  may appear on a definition (`type`, `optional`, `default`, `if`,
+  `dependentrequired`, etc.), used to disambiguate an inline-table annotation
+  from a colliding child-table name (see below).
+- `CURRENT_TOML_SCHEMA_VERSION` — `"1.0.0"`, the schema-language version this
+  implementation targets.
+
+Both constants are checked in `test/abnf.test.ts` against `toml-schema.abnf`
+so vocabulary drift between the grammar and the implementation is caught in
+CI.
+
+## Implemented semantics
+
+This implementation follows `SPEC.md` and mirrors the Go reference
+implementation's behavior (`../go/schema.go`, `source.go`, `extract.go`) for:
+
+- All built-in types, `[toml-schema]`/`[types]`/`[elements]` top-level shape,
+  and SemVer-validated `[toml-schema].version` (rejecting shorthand forms
+  like `"1"`/`"1.0"`).
+- Required/optional/closed table structure, arrays (`itemtype` for
+  homogeneous arrays, `items` for positional tuples), and dynamic-key
+  `collection`s (`itemtype`/`keypattern`).
+- Numeric/date-time `min`/`max` ranges (inclusive) and Unicode-scalar-value
+  `minlength`/`maxlength` string bounds.
+- `allowedvalues` and RE2-portable-style `pattern`/`keypattern` string
+  constraints.
+- `oneof` (exactly one alternative), `anyof` (at least one alternative), and
+  `allof` (additive composition, including table/collection structural
+  closure over every contributing shape, with an effective-kind conflict
+  check).
+- `if`/`then`/`else` conditional selectors, matched by TOML parsed-value
+  equality (`equals`/`in`) rather than identity, with cycle detection and
+  incompatible-branch-kind rejection.
+- `dependentrequired`, `mutuallyexclusive`, and `exactlyone` sibling-presence
+  rules.
+- `uniqueitems`, compared using TOML/structural equality (including nested
+  tables), not reference identity.
+- `default` values, validated against their own definition at schema-load
+  time but never materialized into a validated document, including
+  inheritance through named-type references and conflict detection across
+  `allof` composition.
+- `deprecated`, producing a structured, branch-local warning without
+  affecting `valid`.
+- Named type references (`types.<name>`), reference-cycle detection, and
+  schema-level semantic validation (performed once at schema-load time, not
+  per document).
+- Reserved root `[toml-schema]` metadata (ignored during document validation
+  unless the schema explicitly defines `[elements.toml-schema]`).
+- Local-path/`file:` URI schema discovery via `[toml-schema].location`, and
+  version-mismatch warnings/errors.
+- Draft-schema extraction with quoted-key encoding for keys that are not
+  valid bare TOML keys.
+- The inline-table-annotation vs. colliding-child-table-name distinction: a
+  raw-source scanner (`src/tomlSource.ts`) records which table-valued schema
+  keys were written as `key = { ... }` (an annotation, e.g. `default = { ... }`
+  or `dependentrequired = { ... }`) versus a `[a.b.key]` table header (a child
+  definition literally named `default`), because a parsed TOML value alone
+  cannot recover this distinction.
+
+## Package layout
+
+```
+src/
+  builtins.ts     BUILTIN_TYPES, DEFINITION_KEYS, and other vocabulary constants
+  values.ts       TOML value model (TomlValue/TomlTable/TomlScalar) and equality/kind helpers
+  errors.ts       SchemaError, DocumentError
+  document.ts     parseToml, loadDocument
+  tomlSource.ts   raw-source scanner recovering inline-table-vs-table-header syntax choices
+  paths.ts        validation-diagnostic path encoding and TOML key quoting
+  definition.ts   RawDefinition (internal) and the public Definition accessor class
+  schemaParser.ts parses [types]/[elements] tables into RawDefinition trees
+  semantics.ts    schema-load-time semantic validation (references, cycles, defaults, ranges, ...)
+  validator.ts    DocumentValidator: validates a parsed document against a loaded schema
+  semver.ts       SemVer 2.0.0 parsing/validation shared by schema loading and discovery
+  schema.ts       the public Schema class, loadSchema, loadSchemaFromSource
+  discovery.ts    schemaFromDocument, validateDocument, [toml-schema].location resolution
+  extract.ts      generateSchema, extractSchemaFile
+  index.ts        public package entry point
+test/
+  helpers.ts           shared test utilities (repo-root/example-path resolution, scratch dir)
+  checked-in.test.ts   validates this repo's checked-in config.toml/config.tosd/toml-schema.tosd
+  abnf.test.ts         BUILTIN_TYPES/DEFINITION_KEYS vs. toml-schema.abnf conformance
+  diagnostics.test.ts  ValidationResult shape (errors/warnings/diagnostics/valid/isValid)
+  discovery.test.ts    schema discovery via [toml-schema].location, version mismatches
+  extract.test.ts      generateSchema/extractSchemaFile
+  composition.test.ts  oneof/anyof/allof
+  conditional.test.ts  if/then/else selectors
+  structure.test.ts    arrays, collections, sibling rules, uniqueitems, defaults, deprecation
+  keys.test.ts         quoted/dotted/colliding schema keys, inline-annotation disambiguation
+  values.test.ts       bigint/float precision and temporal-kind edge cases
+```
+
+Tests run directly against the TypeScript sources via `tsx` (no separate
+compile step is required to run `npm test`); `npm run build` produces the
+published `dist/` output separately.
+
+## Notes and limitations
+
+- `TomlDate`'s fractional-second precision is millisecond-level; documents or
+  schema `min`/`max` boundaries relying on finer sub-millisecond precision
+  are not distinguished beyond that resolution. This is a `smol-toml`
+  characteristic, not a TOML Schema semantic gap.
+- This package targets Node.js's built-in test runner and ESM only; it does
+  not ship a CommonJS build.

--- a/reference-implementations/typescript/package-lock.json
+++ b/reference-implementations/typescript/package-lock.json
@@ -1,0 +1,585 @@
+{
+  "name": "@tomlschema/toml-schema",
+  "version": "1.0.0-rc.2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@tomlschema/toml-schema",
+      "version": "1.0.0-rc.2",
+      "license": "MIT",
+      "dependencies": {
+        "smol-toml": "1.8.0"
+      },
+      "devDependencies": {
+        "@types/node": "^26.2.0",
+        "tsx": "^4.20.6",
+        "typescript": "6.0.3"
+      },
+      "engines": {
+        "node": ">=20.11"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/reference-implementations/typescript/package.json
+++ b/reference-implementations/typescript/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@tomlschema/toml-schema",
+  "version": "1.0.0-rc.2",
+  "description": "TOML Schema 1.0 reference implementation for Node.js (ESM, TypeScript).",
+  "keywords": [
+    "toml",
+    "toml-schema",
+    "schema",
+    "validation",
+    "tosd"
+  ],
+  "homepage": "https://github.com/brunoborges/toml-schema#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/brunoborges/toml-schema.git",
+    "directory": "reference-implementations/typescript"
+  },
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=20.11"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "test": "node --import tsx --test test/*.test.ts",
+    "typecheck": "tsc -p tsconfig.test.json --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "smol-toml": "1.8.0"
+  },
+  "devDependencies": {
+    "@types/node": "^26.2.0",
+    "tsx": "^4.20.6",
+    "typescript": "6.0.3"
+  }
+}

--- a/reference-implementations/typescript/src/builtins.ts
+++ b/reference-implementations/typescript/src/builtins.ts
@@ -1,0 +1,130 @@
+/**
+ * Built-in TOML Schema vocabulary: the scalar/container type names and the
+ * definition-level property names. These lists are exercised directly by the
+ * ABNF conformance test to guard against vocabulary drift.
+ */
+
+/** The complete set of TOML Schema 1.0 built-in type names. */
+export const BUILTIN_TYPES = [
+  "any",
+  "string",
+  "integer",
+  "float",
+  "boolean",
+  "offset-date-time",
+  "local-date-time",
+  "local-date",
+  "local-time",
+  "array",
+  "table",
+  "collection",
+] as const;
+
+/** A TOML Schema built-in type name. */
+export type SchemaType = (typeof BUILTIN_TYPES)[number];
+
+const BUILTIN_TYPE_SET: ReadonlySet<string> = new Set(BUILTIN_TYPES);
+
+/** The complete set of TOML Schema 1.0 definition-level property keys. */
+export const DEFINITION_KEYS = [
+  "type",
+  "description",
+  "itemtype",
+  "items",
+  "allowedvalues",
+  "pattern",
+  "keypattern",
+  "optional",
+  "min",
+  "max",
+  "minlength",
+  "maxlength",
+  "oneof",
+  "anyof",
+  "dependentrequired",
+  "mutuallyexclusive",
+  "exactlyone",
+  "allof",
+  "uniqueitems",
+  "default",
+  "deprecated",
+  "if",
+  "then",
+  "else",
+] as const;
+
+/** A TOML Schema 1.0 definition-level property key. */
+export type DefinitionKey = (typeof DEFINITION_KEYS)[number];
+
+const DEFINITION_KEY_SET: ReadonlySet<string> = new Set(DEFINITION_KEYS);
+
+/** Properties a named `type` reference definition may additionally declare. */
+export const NAMED_REFERENCE_KEYS: ReadonlySet<string> = new Set([
+  "type",
+  "description",
+  "optional",
+  "allof",
+  "default",
+  "deprecated",
+]);
+
+/** Properties a `oneof`/`anyof` union definition may additionally declare. */
+export const UNION_KEYS: ReadonlySet<string> = new Set([
+  "oneof",
+  "anyof",
+  "description",
+  "optional",
+  "allof",
+  "default",
+  "deprecated",
+]);
+
+/** Properties an `if`/`then`/`else` conditional definition may additionally declare. */
+export const CONDITIONAL_KEYS: ReadonlySet<string> = new Set([
+  "if",
+  "then",
+  "else",
+  "description",
+  "optional",
+  "allof",
+  "default",
+  "deprecated",
+]);
+
+/** The TOML Schema language version this implementation targets. */
+export const CURRENT_TOML_SCHEMA_VERSION = "1.0.0";
+
+export function isDefinitionKey(key: string): key is DefinitionKey {
+  return DEFINITION_KEY_SET.has(key);
+}
+
+export function parseSchemaType(value: string): SchemaType | undefined {
+  return BUILTIN_TYPE_SET.has(value) ? (value as SchemaType) : undefined;
+}
+
+export function isRangeComparable(typeName: SchemaType | undefined): boolean {
+  switch (typeName) {
+    case "integer":
+    case "float":
+    case "offset-date-time":
+    case "local-date-time":
+    case "local-date":
+    case "local-time":
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Removes the optional `types.` reference prefix exactly once, so both
+ * `"network.endpoint"` and `"types.network.endpoint"` resolve to the same
+ * `[types."network.endpoint"]` definition.
+ */
+export function normalizeReference(reference: string): string {
+  return reference.startsWith("types.") ? reference.slice("types.".length) : reference;
+}
+
+export function normalizeReferences(references: readonly string[]): string[] {
+  return references.map(normalizeReference);
+}

--- a/reference-implementations/typescript/src/definition.ts
+++ b/reference-implementations/typescript/src/definition.ts
@@ -1,0 +1,142 @@
+import type { SchemaType } from "./builtins.js";
+import type { TomlValue } from "./values.js";
+
+/** A parsed `if` selector: `{ key = "...", equals = ... }` or `{ key = "...", in = [...] }`. */
+export interface Condition {
+  readonly key: string;
+  readonly hasEquals: boolean;
+  readonly equals?: TomlValue | undefined;
+  readonly in: readonly TomlValue[];
+}
+
+/**
+ * The internal, mutable-at-parse-time representation of a single schema
+ * definition node (an element, a named type, or a nested child). This
+ * mirrors the Go reference implementation's `Definition` struct field for
+ * field; the public, read-only `Definition` class wraps a resolved instance
+ * of this shape for consumers.
+ */
+export interface RawDefinition {
+  name: string;
+  typeName?: SchemaType | undefined;
+  reference?: string | undefined;
+  description?: string | undefined;
+  itemReference?: string | undefined;
+  items?: readonly string[] | undefined;
+  optional: boolean;
+  allowedValues?: readonly TomlValue[] | undefined;
+  pattern?: RegExp | undefined;
+  patternSource?: string | undefined;
+  keyPattern?: RegExp | undefined;
+  keyPatternSource?: string | undefined;
+  min?: TomlValue | undefined;
+  max?: TomlValue | undefined;
+  minLength?: number | undefined;
+  maxLength?: number | undefined;
+  oneOf?: readonly string[] | undefined;
+  anyOf?: readonly string[] | undefined;
+  condition?: Condition | undefined;
+  thenReference?: string | undefined;
+  elseReference?: string | undefined;
+  allOf?: readonly string[] | undefined;
+  dependentRequired?: Readonly<Record<string, readonly string[]>> | undefined;
+  mutuallyExclusive?: readonly (readonly string[])[] | undefined;
+  exactlyOne?: readonly (readonly string[])[] | undefined;
+  uniqueItems?: boolean | undefined;
+  defaultValue?: TomlValue | undefined;
+  hasDefault: boolean;
+  deprecated: boolean;
+  children: Readonly<Record<string, RawDefinition>>;
+}
+
+/** Creates a string-keyed record without inherited Object prototype members. */
+export function emptyRecord<T>(): Record<string, T> {
+  return Object.create(null) as Record<string, T>;
+}
+
+/** Returns a shallow clone of `definition` with `overrides` applied. */
+export function cloneDefinition(
+  definition: RawDefinition,
+  overrides: Partial<RawDefinition> = {},
+): RawDefinition {
+  return { ...definition, ...overrides };
+}
+
+/** Merges two dependentrequired maps (used when composing/resolving references). */
+export function mergeDependentRequired(
+  left: Readonly<Record<string, readonly string[]>> | undefined,
+  right: Readonly<Record<string, readonly string[]>> | undefined,
+): Record<string, readonly string[]> | undefined {
+  if (!left && !right) return undefined;
+  const merged = emptyRecord<string[]>();
+  for (const [trigger, dependencies] of Object.entries(left ?? {})) {
+    merged[trigger] = [...(merged[trigger] ?? []), ...dependencies];
+  }
+  for (const [trigger, dependencies] of Object.entries(right ?? {})) {
+    merged[trigger] = [...(merged[trigger] ?? []), ...dependencies];
+  }
+  return merged;
+}
+
+/**
+ * Public, read-only accessor over a resolved schema definition node.
+ *
+ * Instances are returned by {@link Schema.element}, {@link Schema.type}, and
+ * {@link Definition.child}, always with inherited/effective annotations
+ * (`description`, `deprecated`, `default`) already resolved through
+ * references and `allof` composition.
+ */
+export class Definition {
+  readonly #raw: RawDefinition;
+
+  /** @internal */
+  constructor(raw: RawDefinition) {
+    this.#raw = raw;
+  }
+
+  /** @internal */
+  get raw(): RawDefinition {
+    return this.#raw;
+  }
+
+  /** The definition's simple name (its key within its parent table). */
+  get name(): string {
+    return this.#raw.name;
+  }
+
+  /** The effective `description`, inherited from a named type reference if unset locally. */
+  get description(): string | undefined {
+    return this.#raw.description;
+  }
+
+  /** The effective `deprecated` flag, propagated through references and `allof`. */
+  get deprecated(): boolean {
+    return this.#raw.deprecated;
+  }
+
+  /** Whether this definition declares an effective, non-materializing `default`. */
+  hasDefault(): boolean {
+    return this.#raw.hasDefault;
+  }
+
+  /** The effective `default` value, or `undefined` if none is declared. */
+  default(): TomlValue | undefined {
+    return this.#raw.defaultValue;
+  }
+
+  /** Whether the parent may omit this value. */
+  get optional(): boolean {
+    return this.#raw.optional;
+  }
+
+  /** Looks up a fixed child definition by name (for `table`/`collection` kinds). */
+  child(name: string): Definition | undefined {
+    const child = this.#raw.children[name];
+    return child ? new Definition(child) : undefined;
+  }
+
+  /** Lists the names of all fixed child definitions. */
+  childNames(): string[] {
+    return Object.keys(this.#raw.children);
+  }
+}

--- a/reference-implementations/typescript/src/discovery.ts
+++ b/reference-implementations/typescript/src/discovery.ts
@@ -1,0 +1,163 @@
+import { readFile } from "node:fs/promises";
+import * as path from "node:path";
+import { pathToFileURL, fileURLToPath } from "node:url";
+import { TomlDate } from "smol-toml";
+import { DocumentError, SchemaError } from "./errors.js";
+import { loadSchema, Schema } from "./schema.js";
+import { parseSemVer } from "./semver.js";
+import { parseToml } from "./document.js";
+import { isTomlTable, type TomlTable } from "./values.js";
+import { ValidationResult } from "./validator.js";
+
+/** The result of resolving a schema from a document's `[toml-schema]` metadata. */
+export interface DiscoveryResult {
+  readonly schema: Schema;
+  readonly document: TomlTable;
+}
+
+function isSchemaReferenceScalar(value: unknown): boolean {
+  return (
+    typeof value === "string" ||
+    typeof value === "bigint" ||
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    value instanceof TomlDate
+  );
+}
+
+const INVALID_URI_REFERENCE_CHARACTERS = new Set(['\\', '"', "<", ">", "^", "`", "{", "|", "}"]);
+
+function hasInvalidURIReferenceCharacter(reference: string): boolean {
+  for (const character of reference) {
+    const code = character.codePointAt(0) ?? 0;
+    if (code <= 0x20 || code === 0x7f) return true;
+    if (INVALID_URI_REFERENCE_CHARACTERS.has(character)) return true;
+  }
+  return false;
+}
+
+function localPathFromFileURL(url: URL): string {
+  if (url.search !== "" || url.hash !== "" || url.username !== "" || url.password !== "") {
+    throw new SchemaError("file URI contains unsupported components");
+  }
+  if (url.hostname !== "" && url.hostname.toLowerCase() !== "localhost") {
+    throw new SchemaError("file URI has a non-local host");
+  }
+  const escapedPath = url.pathname.toLowerCase();
+  if (escapedPath.includes("%2f") || escapedPath.includes("%5c")) {
+    throw new SchemaError("file URI contains an encoded path separator");
+  }
+  if (url.pathname === "" || url.pathname.includes("\0")) {
+    throw new SchemaError("file URI does not contain a safe path");
+  }
+  let localPath: string;
+  try {
+    localPath = fileURLToPath(url);
+  } catch (cause) {
+    throw new SchemaError(
+      `invalid file schema location: ${cause instanceof Error ? cause.message : String(cause)}`,
+    );
+  }
+  if (!path.isAbsolute(localPath)) {
+    throw new SchemaError("file URI path is not absolute");
+  }
+  return localPath;
+}
+
+/**
+ * Resolves a `[toml-schema].location` value (an absolute path or a relative
+ * `file:` URI reference against the document's own location) to a local
+ * filesystem path.
+ */
+export function resolveSchemaLocation(documentPath: string, location: string): string {
+  if (path.isAbsolute(location)) {
+    return path.normalize(location);
+  }
+  if (hasInvalidURIReferenceCharacter(location)) {
+    throw new SchemaError(`invalid [toml-schema].location URI: ${location}`);
+  }
+  const absoluteDocumentPath = path.resolve(documentPath);
+  const base = pathToFileURL(absoluteDocumentPath);
+  let resolved: URL;
+  try {
+    resolved = new URL(location, base);
+  } catch (cause) {
+    throw new SchemaError(
+      `invalid [toml-schema].location URI: ${location}: ${cause instanceof Error ? cause.message : String(cause)}`,
+    );
+  }
+  if (resolved.protocol.toLowerCase() !== "file:") {
+    throw new SchemaError(`unsupported schema location URI scheme: ${resolved.protocol.replace(/:$/, "")}`);
+  }
+  const localPath = localPathFromFileURL(resolved);
+  return path.normalize(localPath);
+}
+
+/** Compares a document's expected schema version against the resolved schema's actual version. */
+export function compareDocumentSchemaVersion(expected: unknown, actual: string): string | undefined {
+  if (typeof expected !== "string") {
+    throw new SchemaError("document [toml-schema].version must be a SemVer string");
+  }
+  const expectedParts = parseSemVer(expected);
+  if (!expectedParts) {
+    throw new SchemaError("document [toml-schema].version must use SemVer MAJOR.MINOR.PATCH syntax");
+  }
+  const actualParts = parseSemVer(actual);
+  if (!actualParts || expectedParts.major !== actualParts.major) {
+    throw new SchemaError(
+      `document expects TOML Schema major version ${expected}, but resolved schema uses ${actual}`,
+    );
+  }
+  if (expected !== actual) {
+    return `Warning: document expects TOML Schema version ${expected}, but resolved schema uses ${actual}`;
+  }
+  return undefined;
+}
+
+/**
+ * Discovers and loads the schema referenced by a document's `[toml-schema]`
+ * table (`location`, and optionally `version`), and returns both the loaded
+ * schema and the parsed document. A version mismatch that shares the same
+ * major version is recorded as a schema warning rather than rejected.
+ */
+export async function schemaFromDocument(documentPath: string): Promise<DiscoveryResult> {
+  let source: string;
+  try {
+    source = await readFile(documentPath, "utf-8");
+  } catch (cause) {
+    throw new DocumentError(
+      `unable to read document ${documentPath}: ${cause instanceof Error ? cause.message : String(cause)}`,
+    );
+  }
+  const document = parseToml(source);
+  const metadata = document["toml-schema"];
+  if (!isTomlTable(metadata)) {
+    throw new SchemaError("document does not contain [toml-schema].location");
+  }
+  for (const [key, value] of Object.entries(metadata)) {
+    if (!isSchemaReferenceScalar(value)) {
+      throw new SchemaError(`document [toml-schema].${key} must be a scalar value`);
+    }
+  }
+  const location = metadata["location"];
+  if (typeof location !== "string" || location.trim() === "") {
+    throw new SchemaError("document does not contain [toml-schema].location");
+  }
+  const schemaPath = resolveSchemaLocation(documentPath, location);
+  const schema = await loadSchema(schemaPath);
+  if ("version" in metadata) {
+    const warning = compareDocumentSchemaVersion(metadata["version"], schema.version);
+    if (warning !== undefined) schema.addWarning(warning);
+  }
+  return { schema, document };
+}
+
+/**
+ * Convenience one-shot helper: discovers the schema referenced by a
+ * document's `[toml-schema]` metadata and immediately validates the document
+ * against it.
+ */
+export async function validateDocument(documentPath: string): Promise<ValidationResult> {
+  const { schema, document } = await schemaFromDocument(documentPath);
+  return schema.validate(document);
+}

--- a/reference-implementations/typescript/src/document.ts
+++ b/reference-implementations/typescript/src/document.ts
@@ -1,0 +1,18 @@
+import { readFile } from "node:fs/promises";
+import { parse } from "smol-toml";
+import type { TomlTable } from "./values.js";
+
+/** Parses TOML source text, preserving integer/float distinction via BigInt integers. */
+export function parseToml(source: string): TomlTable {
+  return parse(source, { integersAsBigInt: true }) as TomlTable;
+}
+
+/**
+ * Loads and parses a TOML document from disk, returning its root table.
+ * Integers are represented as `bigint` and floats as `number` (see
+ * {@link parseToml}); pass the result directly to {@link Schema.validate}.
+ */
+export async function loadDocument(path: string): Promise<TomlTable> {
+  const source = await readFile(path, "utf-8");
+  return parseToml(source);
+}

--- a/reference-implementations/typescript/src/errors.ts
+++ b/reference-implementations/typescript/src/errors.ts
@@ -1,0 +1,15 @@
+/** Thrown for structural/semantic problems detected while loading a schema. */
+export class SchemaError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SchemaError";
+  }
+}
+
+/** Thrown when a document or schema file cannot be located or parsed. */
+export class DocumentError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DocumentError";
+  }
+}

--- a/reference-implementations/typescript/src/extract.ts
+++ b/reference-implementations/typescript/src/extract.ts
@@ -1,0 +1,70 @@
+import { writeFile, readFile } from "node:fs/promises";
+import { TomlDate } from "smol-toml";
+import { CURRENT_TOML_SCHEMA_VERSION, type SchemaType } from "./builtins.js";
+import { parseToml } from "./document.js";
+import { encodeTomlKey } from "./paths.js";
+import { isTomlArray, isTomlTable, type TomlTable, type TomlValue } from "./values.js";
+
+/** Infers the built-in TOML Schema type name that best describes a parsed TOML value. */
+function schemaTypeOf(value: TomlValue): SchemaType {
+  if (typeof value === "string") return "string";
+  if (typeof value === "bigint") return "integer";
+  if (typeof value === "number") return "float";
+  if (typeof value === "boolean") return "boolean";
+  if (value instanceof TomlDate) {
+    if (value.isDateTime()) return value.isLocal() ? "local-date-time" : "offset-date-time";
+    if (value.isDate()) return "local-date";
+    if (value.isTime()) return "local-time";
+    return "any";
+  }
+  if (isTomlArray(value)) return "array";
+  if (isTomlTable(value)) return "table";
+  return "any";
+}
+
+/** Infers a homogeneous `itemtype` for an array, falling back to `"any"` when mixed or empty. */
+function inferItemType(items: readonly TomlValue[]): SchemaType {
+  if (items.length === 0) return "any";
+  const first = schemaTypeOf(items[0] as TomlValue);
+  for (const item of items.slice(1)) {
+    if (schemaTypeOf(item) !== first) return "any";
+  }
+  return first;
+}
+
+function appendDefinition(lines: string[], path: readonly string[], value: TomlValue): void {
+  lines.push("");
+  lines.push(`[${path.map(encodeTomlKey).join(".")}]`);
+  const typeName = schemaTypeOf(value);
+  lines.push(`type = ${JSON.stringify(typeName)}`);
+  if (typeName === "array" && isTomlArray(value)) {
+    lines.push(`itemtype = ${JSON.stringify(inferItemType(value))}`);
+  }
+  if (isTomlTable(value)) {
+    for (const childKey of Object.keys(value).sort()) {
+      appendDefinition(lines, [...path, childKey], value[childKey] as TomlValue);
+    }
+  }
+}
+
+/**
+ * Generates draft TOML Schema source text describing the structural shape of
+ * a parsed TOML document. Every element is typed by inferring its TOML kind;
+ * arrays additionally receive an inferred `itemtype` when homogeneous. The
+ * root `[toml-schema]` table (if present in the document) is not itself
+ * described, per the reserved-metadata convention.
+ */
+export function generateSchema(document: TomlTable): string {
+  const lines: string[] = ["[toml-schema]", `version = ${JSON.stringify(CURRENT_TOML_SCHEMA_VERSION)}`, "", "[elements]"];
+  for (const key of Object.keys(document).sort()) {
+    if (key === "toml-schema") continue;
+    appendDefinition(lines, ["elements", key], document[key] as TomlValue);
+  }
+  return lines.join("\n") + "\n";
+}
+
+/** Reads a TOML document, infers a draft schema for it, and writes the schema to `schemaPath`. */
+export async function extractSchemaFile(documentPath: string, schemaPath: string): Promise<void> {
+  const document = parseToml(await readFile(documentPath, "utf-8"));
+  await writeFile(schemaPath, generateSchema(document), "utf-8");
+}

--- a/reference-implementations/typescript/src/index.ts
+++ b/reference-implementations/typescript/src/index.ts
@@ -1,0 +1,40 @@
+/**
+ * @tomlschema/toml-schema — a Node.js/TypeScript reference implementation of
+ * the [TOML Schema](https://github.com/brunoborges/toml-schema) 1.0 specification.
+ *
+ * @packageDocumentation
+ */
+
+export { BUILTIN_TYPES, DEFINITION_KEYS, CURRENT_TOML_SCHEMA_VERSION } from "./builtins.js";
+export type { SchemaType, DefinitionKey } from "./builtins.js";
+
+export type {
+  TomlScalar,
+  TomlTable,
+  TomlValue,
+} from "./values.js";
+
+export { Definition } from "./definition.js";
+export type { Condition } from "./definition.js";
+
+export { SchemaError, DocumentError } from "./errors.js";
+
+export { parseToml, loadDocument } from "./document.js";
+
+export { Schema, loadSchema, loadSchemaFromSource } from "./schema.js";
+
+export {
+  schemaFromDocument,
+  validateDocument,
+  resolveSchemaLocation,
+  compareDocumentSchemaVersion,
+} from "./discovery.js";
+export type { DiscoveryResult } from "./discovery.js";
+
+export { generateSchema, extractSchemaFile } from "./extract.js";
+
+export { ValidationResult } from "./validator.js";
+export type { Severity, ValidationError, Diagnostic } from "./validator.js";
+
+export { parseSemVer, validateSchemaVersion } from "./semver.js";
+export type { SemVerParts } from "./semver.js";

--- a/reference-implementations/typescript/src/paths.ts
+++ b/reference-implementations/typescript/src/paths.ts
@@ -1,0 +1,61 @@
+const BARE_KEY_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+/** Encodes a single key for a `$.a.b` validation-diagnostic path, quoting when necessary. */
+export function encodePathKey(key: string): string {
+  if (key !== "" && BARE_KEY_PATTERN.test(key)) return key;
+  return JSON.stringify(key);
+}
+
+/** Appends `key` to a diagnostic path, e.g. `appendPath("$.a", "b")` -> `"$.a.b"`. */
+export function appendPath(path: string, key: string): string {
+  return `${path}.${encodePathKey(key)}`;
+}
+
+/** Whether a TOML key can be written unquoted (used by the schema extractor). */
+export function isBareKey(key: string): boolean {
+  return key !== "" && BARE_KEY_PATTERN.test(key);
+}
+
+/** Quotes and escapes a TOML key using basic-string syntax. */
+export function quoteTomlKey(key: string): string {
+  let escaped = "";
+  for (const ch of key) {
+    switch (ch) {
+      case "\\":
+        escaped += "\\\\";
+        break;
+      case '"':
+        escaped += '\\"';
+        break;
+      case "\b":
+        escaped += "\\b";
+        break;
+      case "\t":
+        escaped += "\\t";
+        break;
+      case "\n":
+        escaped += "\\n";
+        break;
+      case "\f":
+        escaped += "\\f";
+        break;
+      case "\r":
+        escaped += "\\r";
+        break;
+      default: {
+        const code = ch.codePointAt(0) ?? 0;
+        if (code < 0x20) {
+          escaped += `\\u${code.toString(16).toUpperCase().padStart(4, "0")}`;
+        } else {
+          escaped += ch;
+        }
+      }
+    }
+  }
+  return `"${escaped}"`;
+}
+
+/** Renders a TOML key, quoting only when required. */
+export function encodeTomlKey(key: string): string {
+  return isBareKey(key) ? key : quoteTomlKey(key);
+}

--- a/reference-implementations/typescript/src/schema.ts
+++ b/reference-implementations/typescript/src/schema.ts
@@ -1,0 +1,179 @@
+import { readFile } from "node:fs/promises";
+import { AnnotationResolver, validateAllowedValueTypes, validateArrayRanges, validateDefaults, validateReferences, validateSelectorCycles, validateSemantics, type SchemaData } from "./semantics.js";
+import { parseDefinitions } from "./schemaParser.js";
+import { Definition, type RawDefinition } from "./definition.js";
+import { SchemaSource } from "./tomlSource.js";
+import { parseToml } from "./document.js";
+import { SchemaError, DocumentError } from "./errors.js";
+import { validateSchemaVersion } from "./semver.js";
+import { DocumentValidator, ValidationResult, type ValidationError } from "./validator.js";
+import { isTomlTable, type TomlTable, type TomlValue } from "./values.js";
+import { appendPath } from "./paths.js";
+
+const TOP_LEVEL_KEYS = new Set(["toml-schema", "types", "elements"]);
+const TOML_SCHEMA_KEYS = new Set(["version", "meta"]);
+
+/**
+ * A loaded, fully schema-load-time-validated TOML Schema document. Construct
+ * instances with {@link loadSchema} or {@link schemaFromDocument}; validate
+ * TOML documents against one with {@link Schema.validate} or
+ * {@link Schema.validateFile}.
+ */
+export class Schema {
+  readonly #data: SchemaData;
+  readonly #version: string;
+  readonly #warnings: string[];
+
+  /** @internal */
+  constructor(data: SchemaData, version: string, warnings: string[] = []) {
+    this.#data = data;
+    this.#version = version;
+    this.#warnings = warnings;
+  }
+
+  /** @internal */
+  get data(): SchemaData {
+    return this.#data;
+  }
+
+  /** The `[toml-schema].version` this schema declares. */
+  get version(): string {
+    return this.#version;
+  }
+
+  /** Non-fatal warnings produced while discovering this schema (e.g. a version mismatch). */
+  get warnings(): readonly string[] {
+    return this.#warnings;
+  }
+
+  /** @internal */
+  addWarning(warning: string): void {
+    this.#warnings.push(warning);
+  }
+
+  /** Looks up a top-level element definition, with inherited annotations resolved. */
+  element(name: string): Definition | undefined {
+    const definition = this.#data.elements[name];
+    if (!definition) return undefined;
+    return new Definition(this.withEffectiveAnnotations(definition));
+  }
+
+  /** Looks up a named reusable type definition, with inherited annotations resolved. */
+  type(name: string): Definition | undefined {
+    const normalized = name.startsWith("types.") ? name.slice("types.".length) : name;
+    const definition = this.#data.types[normalized];
+    if (!definition) return undefined;
+    return new Definition(this.withEffectiveAnnotations(definition));
+  }
+
+  private withEffectiveAnnotations(definition: RawDefinition): RawDefinition {
+    const resolver = new AnnotationResolver(this.#data, (candidate) =>
+      new DocumentValidator(this.#data).resolve(candidate, new Set()),
+    );
+    return resolver.resolve(definition);
+  }
+
+  /** Validates an already-parsed TOML document table against this schema's `[elements]`. */
+  validate(document: TomlTable): ValidationResult {
+    const validator = new DocumentValidator(this.#data);
+    validator.validateTable("$", document, this.#data.elements);
+    for (const key of Object.keys(document)) {
+      if (!Object.hasOwn(this.#data.elements, key) && key !== "toml-schema") {
+        validator.add(appendPath("$", key), "unexpected key");
+      }
+    }
+    return validator.toResult();
+  }
+
+  /** Reads, parses, and validates a TOML document file against this schema. */
+  async validateFile(path: string): Promise<ValidationResult> {
+    let document: TomlTable;
+    try {
+      document = parseToml(await readFile(path, "utf-8"));
+    } catch (cause) {
+      const message = cause instanceof Error ? cause.message : String(cause);
+      const diagnostic: ValidationError = {
+        severity: "error",
+        code: "document-parse-error",
+        path: "$",
+        message,
+      };
+      return new ValidationResult([diagnostic], []);
+    }
+    return this.validate(document);
+  }
+}
+
+/** Loads and fully schema-load-time-validates a TOML Schema (`.tosd`) document from disk. */
+export async function loadSchema(path: string): Promise<Schema> {
+  let source: string;
+  try {
+    source = await readFile(path, "utf-8");
+  } catch (cause) {
+    throw new DocumentError(
+      `unable to read schema ${path}: ${cause instanceof Error ? cause.message : String(cause)}`,
+    );
+  }
+  return loadSchemaFromSource(path, source);
+}
+
+/** Parses and fully schema-load-time-validates TOML Schema source text already read from `path`. */
+export function loadSchemaFromSource(path: string, source: string): Schema {
+  let parsed: TomlTable;
+  try {
+    parsed = parseToml(source);
+  } catch (cause) {
+    throw new SchemaError(
+      `unable to parse schema ${path}: ${cause instanceof Error ? cause.message : String(cause)}`,
+    );
+  }
+  const schemaSource = new SchemaSource(source);
+
+  const metadataValue = parsed["toml-schema"];
+  if (!isTomlTable(metadataValue)) {
+    throw new SchemaError("schema must contain a [toml-schema] table");
+  }
+  const elementsValue = parsed["elements"];
+  if (!isTomlTable(elementsValue)) {
+    throw new SchemaError("schema must contain an [elements] table");
+  }
+  for (const key of Object.keys(parsed)) {
+    if (!TOP_LEVEL_KEYS.has(key)) {
+      throw new SchemaError(`unsupported top-level schema key: ${key}`);
+    }
+  }
+  const version = metadataValue["version"];
+  if (version === undefined) {
+    throw new SchemaError("[toml-schema] must contain version");
+  }
+  validateSchemaVersion(version);
+  for (const key of Object.keys(metadataValue)) {
+    if (!TOML_SCHEMA_KEYS.has(key)) {
+      throw new SchemaError(`unsupported [toml-schema] key: ${key}`);
+    }
+  }
+
+  const typesValue = parsed["types"];
+  const types = parseDefinitions(
+    "types",
+    isTomlTable(typesValue) ? typesValue : undefined,
+    false,
+    schemaSource,
+  );
+  const elements = parseDefinitions("elements", elementsValue, true, schemaSource);
+
+  const data: SchemaData = { types, elements };
+  validateReferences(data, types);
+  validateReferences(data, elements);
+  validateSelectorCycles(data);
+  validateAllowedValueTypes(data);
+  validateSemantics(data);
+  validateArrayRanges(data);
+  validateDefaults(data, (definition, value: TomlValue) => {
+    const candidate = new DocumentValidator(data, true);
+    candidate.validateValue(definition.name, value, definition);
+    return candidate.errors[0]?.message;
+  });
+
+  return new Schema(data, version, []);
+}

--- a/reference-implementations/typescript/src/schemaParser.ts
+++ b/reference-implementations/typescript/src/schemaParser.ts
@@ -1,0 +1,675 @@
+import {
+  CONDITIONAL_KEYS,
+  DEFINITION_KEYS,
+  NAMED_REFERENCE_KEYS,
+  UNION_KEYS,
+  isRangeComparable,
+  normalizeReference,
+  parseSchemaType,
+  type SchemaType,
+} from "./builtins.js";
+import { emptyRecord, type Condition, type RawDefinition } from "./definition.js";
+import { SchemaError } from "./errors.js";
+import { SchemaSource } from "./tomlSource.js";
+import {
+  compareValues,
+  boundaryMatchesType,
+  isNaNValue,
+  isNumeric,
+  isTomlArray,
+  isTomlTable,
+  scalarLength,
+  type TomlTable,
+  type TomlValue,
+} from "./values.js";
+import { TomlDate } from "smol-toml";
+
+/** Reads a definition-table property, treating a raw table value as "not present". */
+function propertyValue(table: TomlTable, key: string): TomlValue | undefined {
+  const value = table[key];
+  if (value !== undefined && isTomlTable(value)) return undefined;
+  return value;
+}
+
+function getStringProp(table: TomlTable, key: string, context: string): string {
+  const value = propertyValue(table, key);
+  if (value === undefined) return "";
+  if (typeof value !== "string") {
+    throw new SchemaError(`expected ${key} to be a string (${context})`);
+  }
+  return value;
+}
+
+function getBoolProp(table: TomlTable, key: string, context: string): boolean {
+  const value = propertyValue(table, key);
+  if (value === undefined) return false;
+  if (typeof value !== "boolean") {
+    throw new SchemaError(`expected ${key} to be a boolean (${context})`);
+  }
+  return value;
+}
+
+function getOptionalBoolProp(
+  table: TomlTable,
+  key: string,
+  context: string,
+): boolean | undefined {
+  const value = propertyValue(table, key);
+  if (value === undefined) return undefined;
+  if (typeof value !== "boolean") {
+    throw new SchemaError(`expected ${key} to be a boolean (${context})`);
+  }
+  return value;
+}
+
+const MAX_INT32 = 2147483647;
+
+function getIntegerProp(table: TomlTable, key: string, context: string): number | undefined {
+  const value = propertyValue(table, key);
+  if (value === undefined) return undefined;
+  if (typeof value !== "bigint") {
+    throw new SchemaError(`expected ${key} to be an integer (${context})`);
+  }
+  if (value < 0n || value > BigInt(MAX_INT32)) {
+    throw new SchemaError(`${key} must be between 0 and ${MAX_INT32} (${context})`);
+  }
+  return Number(value);
+}
+
+function getPatternProp(
+  table: TomlTable,
+  key: string,
+  context: string,
+): { regex: RegExp; source: string } | undefined {
+  const value = propertyValue(table, key);
+  if (value === undefined) return undefined;
+  if (typeof value !== "string") {
+    throw new SchemaError(`expected ${key} to be a string (${context})`);
+  }
+  try {
+    return { regex: new RegExp(value, "u"), source: value };
+  } catch (cause) {
+    throw new SchemaError(
+      `${context} has invalid ${key}: ${cause instanceof Error ? cause.message : String(cause)}`,
+    );
+  }
+}
+
+function getArrayProp(table: TomlTable, key: string, context: string): TomlValue[] | undefined {
+  const value = propertyValue(table, key);
+  if (value === undefined) return undefined;
+  if (!isTomlArray(value)) {
+    throw new SchemaError(`expected ${key} to be an array (${context})`);
+  }
+  return value;
+}
+
+function getStringArrayProp(table: TomlTable, key: string, context: string): string[] {
+  const values = getArrayProp(table, key, context);
+  if (values === undefined) return [];
+  return values.map((value) => {
+    if (typeof value !== "string") {
+      throw new SchemaError(`expected ${key} to contain only strings (${context})`);
+    }
+    return value;
+  });
+}
+
+function normalizeReferences(references: readonly string[]): string[] {
+  return references.map(normalizeReference);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Top-level and reference-shape validation helpers                           */
+/* -------------------------------------------------------------------------- */
+
+function rejectBareCollectionReference(name: string, property: string, reference: string): void {
+  if (reference !== "" && normalizeReference(reference) === "collection") {
+    throw new SchemaError(`${name} cannot use collection as a bare ${property} reference`);
+  }
+}
+
+function rejectBareCollectionReferences(
+  name: string,
+  property: string,
+  references: readonly string[],
+): void {
+  for (const reference of references) {
+    rejectBareCollectionReference(name, property, normalizeReference(reference));
+  }
+}
+
+function validateAlternativeReferences(
+  name: string,
+  property: string,
+  references: readonly string[],
+): void {
+  for (const reference of references) {
+    const normalized = normalizeReference(reference);
+    rejectBareCollectionReference(name, property, normalized);
+    if (normalized === "any") {
+      throw new SchemaError(`${name} cannot use any directly in ${property}`);
+    }
+  }
+}
+
+function isRangeBoundary(value: TomlValue): boolean {
+  return isNumeric(value) || value instanceof TomlDate;
+}
+
+function validateRangeBoundary(name: string, key: string, value: TomlValue | undefined): void {
+  if (value === undefined || isRangeBoundary(value)) return;
+  throw new SchemaError(`${name} ${key} must be an integer, float, or temporal value`);
+}
+
+function validateBoundaryMatchesType(
+  name: string,
+  key: string,
+  value: TomlValue | undefined,
+  typeName: SchemaType,
+): void {
+  if (value === undefined || boundaryMatchesType(value, typeName)) return;
+  throw new SchemaError(`${name} ${key} must be comparable with ${typeName}`);
+}
+
+function validateRangeConstraints(
+  name: string,
+  typeName: SchemaType | undefined,
+  min: TomlValue | undefined,
+  max: TomlValue | undefined,
+): void {
+  if (min === undefined && max === undefined) return;
+  validateRangeBoundary(name, "min", min);
+  validateRangeBoundary(name, "max", max);
+  if (isNaNValue(min)) throw new SchemaError(`${name} cannot use NaN as min`);
+  if (isNaNValue(max)) throw new SchemaError(`${name} cannot use NaN as max`);
+  if (typeName === "any") {
+    throw new SchemaError(`${name} cannot define min or max when type is any`);
+  }
+  if (typeName === "array") return;
+  if (typeName !== undefined && !isRangeComparable(typeName)) {
+    throw new SchemaError(
+      `${name} can only define min or max for integer, float, date/time, or compatible array types`,
+    );
+  }
+  if (typeName !== undefined) {
+    validateBoundaryMatchesType(name, "min", min, typeName);
+    validateBoundaryMatchesType(name, "max", max, typeName);
+  }
+}
+
+function validateAllowedValuesConstraints(
+  name: string,
+  typeName: SchemaType | undefined,
+  allowedValues: readonly TomlValue[],
+  pattern: RegExp | undefined,
+  min: TomlValue | undefined,
+  max: TomlValue | undefined,
+  minLength: number | undefined,
+  maxLength: number | undefined,
+): void {
+  if (allowedValues.length === 0 || typeName === "array") return;
+  allowedValues.forEach((allowed, index) => {
+    const entry = `${name} allowedvalues[${index}]`;
+    if (pattern !== undefined) {
+      if (typeof allowed !== "string" || !pattern.test(allowed)) {
+        throw new SchemaError(`${entry} does not satisfy pattern`);
+      }
+    }
+    if ((min !== undefined || max !== undefined) && isNaNValue(allowed)) {
+      throw new SchemaError(`${entry} does not satisfy min or max`);
+    }
+    if (min !== undefined) {
+      let comparison: number;
+      try {
+        comparison = compareValues(allowed, min);
+      } catch (cause) {
+        throw new SchemaError(
+          `${entry} cannot be compared with min: ${cause instanceof Error ? cause.message : String(cause)}`,
+        );
+      }
+      if (comparison < 0) throw new SchemaError(`${entry} is less than min`);
+    }
+    if (max !== undefined) {
+      let comparison: number;
+      try {
+        comparison = compareValues(allowed, max);
+      } catch (cause) {
+        throw new SchemaError(
+          `${entry} cannot be compared with max: ${cause instanceof Error ? cause.message : String(cause)}`,
+        );
+      }
+      if (comparison > 0) throw new SchemaError(`${entry} is greater than max`);
+    }
+    if (minLength !== undefined || maxLength !== undefined) {
+      if (typeof allowed !== "string") {
+        throw new SchemaError(`${entry} does not satisfy string length constraints`);
+      }
+      const length = scalarLength(allowed);
+      if (minLength !== undefined && length < minLength) {
+        throw new SchemaError(`${entry} is shorter than minlength`);
+      }
+      if (maxLength !== undefined && length > maxLength) {
+        throw new SchemaError(`${entry} is longer than maxlength`);
+      }
+    }
+  });
+}
+
+/* -------------------------------------------------------------------------- */
+/* Conditional (`if`/`then`/`else`) and sibling-rule property parsing         */
+/* -------------------------------------------------------------------------- */
+
+interface ParsedConditional {
+  condition?: Condition;
+  thenReference: string;
+  elseReference: string;
+}
+
+function getConditional(
+  name: string,
+  path: readonly string[],
+  table: TomlTable,
+  source: SchemaSource,
+): ParsedConditional {
+  const hasIf = source.isProperty(table, path, "if");
+  const hasThen = source.isProperty(table, path, "then");
+  const hasElse = source.isProperty(table, path, "else");
+  if (!hasIf && !hasThen && !hasElse) {
+    return { thenReference: "", elseReference: "" };
+  }
+  if (!hasIf || !hasThen || !hasElse) {
+    throw new SchemaError(`${name} must define if, then, and else together`);
+  }
+  const rawCondition = table["if"];
+  if (!isTomlTable(rawCondition)) {
+    throw new SchemaError(`${name} if must be an inline table`);
+  }
+  for (const key of Object.keys(rawCondition)) {
+    if (key !== "key" && key !== "equals" && key !== "in") {
+      throw new SchemaError(`${name} if contains unsupported property: ${key}`);
+    }
+  }
+  const key = rawCondition["key"];
+  if (typeof key !== "string") {
+    throw new SchemaError(`${name} if.key must be a string`);
+  }
+  const hasEquals = "equals" in rawCondition;
+  const hasIn = "in" in rawCondition;
+  if (hasEquals === hasIn) {
+    throw new SchemaError(`${name} if must define exactly one of equals and in`);
+  }
+  let inValues: TomlValue[] = [];
+  if (hasIn) {
+    const rawIn = rawCondition["in"];
+    if (!isTomlArray(rawIn) || rawIn.length === 0) {
+      throw new SchemaError(`${name} if.in must be a non-empty array`);
+    }
+    inValues = rawIn;
+  }
+  const thenReference = table["then"];
+  if (typeof thenReference !== "string" || thenReference.trim() === "") {
+    throw new SchemaError(`${name} then must be a non-blank named type reference`);
+  }
+  const elseReference = table["else"];
+  if (typeof elseReference !== "string" || elseReference.trim() === "") {
+    throw new SchemaError(`${name} else must be a non-blank named type reference`);
+  }
+  for (const [property, reference] of [
+    ["then", thenReference],
+    ["else", elseReference],
+  ] as const) {
+    if (parseSchemaType(normalizeReference(reference)) !== undefined) {
+      throw new SchemaError(`${name} ${property} must be a named reusable type reference`);
+    }
+  }
+  const condition: Condition = hasEquals
+    ? { key, hasEquals: true, equals: rawCondition["equals"], in: [] }
+    : { key, hasEquals: false, in: inValues };
+  return { condition, thenReference, elseReference };
+}
+
+function getDependentRequired(
+  name: string,
+  path: readonly string[],
+  table: TomlTable,
+  source: SchemaSource,
+): Record<string, readonly string[]> | undefined {
+  if (!source.isProperty(table, path, "dependentrequired")) return undefined;
+  const dependencies = table["dependentrequired"];
+  if (!isTomlTable(dependencies)) {
+    throw new SchemaError(`${name} dependentrequired must be a table`);
+  }
+  const entries = Object.entries(dependencies);
+  if (entries.length === 0) {
+    throw new SchemaError(`${name} dependentrequired must not be empty`);
+  }
+  const result: Record<string, string[]> = {};
+  for (const [trigger, raw] of entries) {
+    if (!isTomlArray(raw) || raw.length === 0) {
+      throw new SchemaError(
+        `${name} dependentrequired.${trigger} must be a non-empty string array`,
+      );
+    }
+    const seen = new Set<string>();
+    const values: string[] = [];
+    for (const value of raw) {
+      if (typeof value !== "string") {
+        throw new SchemaError(`${name} dependentrequired.${trigger} must contain only strings`);
+      }
+      if (seen.has(value)) {
+        throw new SchemaError(
+          `${name} dependentrequired.${trigger} contains duplicate ${JSON.stringify(value)}`,
+        );
+      }
+      seen.add(value);
+      values.push(value);
+    }
+    result[trigger] = values;
+  }
+  return result;
+}
+
+function getKeyGroups(
+  name: string,
+  path: readonly string[],
+  table: TomlTable,
+  key: string,
+  source: SchemaSource,
+): string[][] | undefined {
+  if (!source.isProperty(table, path, key)) return undefined;
+  const groups = table[key];
+  if (!isTomlArray(groups) || groups.length === 0) {
+    throw new SchemaError(`${name} ${key} must be a non-empty array`);
+  }
+  return groups.map((rawGroup, index) => {
+    if (!isTomlArray(rawGroup) || rawGroup.length < 2) {
+      throw new SchemaError(`${name} ${key}[${index}] must contain at least two strings`);
+    }
+    const seen = new Set<string>();
+    const converted: string[] = [];
+    for (const rawName of rawGroup) {
+      if (typeof rawName !== "string") {
+        throw new SchemaError(`${name} ${key}[${index}] must contain only strings`);
+      }
+      if (seen.has(rawName)) {
+        throw new SchemaError(
+          `${name} ${key}[${index}] contains duplicate ${JSON.stringify(rawName)}`,
+        );
+      }
+      seen.add(rawName);
+      converted.push(rawName);
+    }
+    return converted;
+  });
+}
+
+/* -------------------------------------------------------------------------- */
+/* Definition parsing                                                         */
+/* -------------------------------------------------------------------------- */
+
+export function parseDefinitions(
+  prefix: string,
+  table: TomlTable | undefined,
+  required: boolean,
+  source: SchemaSource,
+): Record<string, RawDefinition> {
+  if (table === undefined) {
+    if (required) {
+      throw new SchemaError(`missing required [${prefix}] table`);
+    }
+    return emptyRecord();
+  }
+  const definitions = emptyRecord<RawDefinition>();
+  for (const [key, value] of Object.entries(table)) {
+    if (prefix === "types") {
+      if (parseSchemaType(key) !== undefined) {
+        throw new SchemaError(`[types.${key}] uses a reserved built-in type name`);
+      }
+      if (key.startsWith("types.")) {
+        throw new SchemaError(`[types.${key}] uses the reserved type-reference prefix`);
+      }
+    }
+    if (!isTomlTable(value)) {
+      throw new SchemaError(`[${prefix}] entry must be a table: ${key}`);
+    }
+    definitions[key] = parseDefinition(`${prefix}.${key}`, [prefix, key], value, source);
+  }
+  return definitions;
+}
+
+export function parseDefinition(
+  name: string,
+  path: readonly string[],
+  table: TomlTable,
+  source: SchemaSource,
+): RawDefinition {
+  const typeSelector = getStringProp(table, "type", name);
+  if (propertyValue(table, "type") !== undefined && typeSelector === "") {
+    throw new SchemaError(`${name} type must not be blank`);
+  }
+  let typeName: SchemaType | undefined;
+  let reference = "";
+  if (typeSelector !== "") {
+    const builtIn = parseSchemaType(typeSelector);
+    if (builtIn !== undefined) {
+      typeName = builtIn;
+    } else {
+      reference = normalizeReference(typeSelector);
+    }
+  }
+  if (reference !== "") {
+    for (const key of Object.keys(table)) {
+      if (!NAMED_REFERENCE_KEYS.has(key)) {
+        throw new SchemaError(`${name} named type reference cannot define ${key}`);
+      }
+    }
+  }
+  const description = getStringProp(table, "description", name);
+  const itemReference = getStringProp(table, "itemtype", name);
+  if (propertyValue(table, "itemtype") !== undefined && itemReference === "") {
+    throw new SchemaError(`${name} itemtype must not be blank`);
+  }
+  const items = getStringArrayProp(table, "items", name);
+  if (propertyValue(table, "items") !== undefined && items.length === 0) {
+    throw new SchemaError(`${name} items must contain at least one type reference`);
+  }
+  const optional = getBoolProp(table, "optional", name);
+  const patternResult = getPatternProp(table, "pattern", name);
+  const keyPatternResult = getPatternProp(table, "keypattern", name);
+  const minLength = getIntegerProp(table, "minlength", name);
+  const maxLength = getIntegerProp(table, "maxlength", name);
+  const allowedValues = getArrayProp(table, "allowedvalues", name) ?? [];
+  const hasAllowedValues = propertyValue(table, "allowedvalues") !== undefined;
+  if (hasAllowedValues && allowedValues.length === 0) {
+    throw new SchemaError(`${name} allowedvalues must contain at least one entry`);
+  }
+  const hasOneOf = propertyValue(table, "oneof") !== undefined;
+  const hasAnyOf = propertyValue(table, "anyof") !== undefined;
+  const oneOf = getStringArrayProp(table, "oneof", name);
+  const anyOf = getStringArrayProp(table, "anyof", name);
+  const allOf = getStringArrayProp(table, "allof", name);
+  const { condition, thenReference, elseReference } = getConditional(name, path, table, source);
+
+  for (const [property, references] of [
+    ["items", items],
+    ["oneof", oneOf],
+    ["anyof", anyOf],
+    ["allof", allOf],
+  ] as const) {
+    for (const reference of references) {
+      if (reference === "") {
+        throw new SchemaError(`${name} ${property} references must not be blank`);
+      }
+    }
+  }
+  if (hasOneOf && oneOf.length === 0) {
+    throw new SchemaError(`${name} oneof must contain at least one type reference`);
+  }
+  if (hasAnyOf && anyOf.length === 0) {
+    throw new SchemaError(`${name} anyof must contain at least one type reference`);
+  }
+  if (propertyValue(table, "allof") !== undefined && allOf.length === 0) {
+    throw new SchemaError(`${name} allof must contain at least one type reference`);
+  }
+  rejectBareCollectionReference(name, "itemtype", itemReference);
+  rejectBareCollectionReferences(name, "items", items);
+  validateAlternativeReferences(name, "oneof", oneOf);
+  validateAlternativeReferences(name, "anyof", anyOf);
+  validateAlternativeReferences(name, "allof", allOf);
+  if (typeSelector !== "" && typeName !== "collection" && normalizeReference(typeSelector) === "collection") {
+    throw new SchemaError(`${name} cannot use collection as a bare type reference`);
+  }
+
+  let typeSelectors = 0;
+  if (typeSelector !== "") typeSelectors++;
+  if (hasOneOf) typeSelectors++;
+  if (hasAnyOf) typeSelectors++;
+  if (condition !== undefined) typeSelectors++;
+  if (typeSelectors > 1) {
+    throw new SchemaError(`${name} cannot define more than one of type, oneof, anyof, and if`);
+  }
+
+  const children = emptyRecord<RawDefinition>();
+  for (const [key, value] of Object.entries(table)) {
+    if ((DEFINITION_KEYS as readonly string[]).includes(key) && source.isProperty(table, path, key)) {
+      continue;
+    }
+    if (isTomlTable(value)) {
+      if (Object.hasOwn(children, key)) {
+        throw new SchemaError(`${name} defines child ${key} more than once`);
+      }
+      children[key] = parseDefinition(`${name}.${key}`, [...path, key], value, source);
+    } else if (!(DEFINITION_KEYS as readonly string[]).includes(key)) {
+      throw new SchemaError(`${name} contains unsupported property: ${key}`);
+    }
+  }
+
+  if (hasOneOf || hasAnyOf) {
+    for (const key of Object.keys(table)) {
+      if (!UNION_KEYS.has(key)) {
+        throw new SchemaError(`${name} union cannot define ${key}`);
+      }
+    }
+  }
+  if (condition !== undefined) {
+    for (const key of Object.keys(table)) {
+      if (!CONDITIONAL_KEYS.has(key)) {
+        throw new SchemaError(`${name} conditional selector cannot define ${key}`);
+      }
+    }
+    if (Object.keys(children).length > 0) {
+      throw new SchemaError(`${name} conditional selector cannot define child definitions`);
+    }
+  }
+  if (typeName === undefined && reference === "" && !hasOneOf && !hasAnyOf && condition === undefined) {
+    if (Object.keys(children).length === 0) {
+      throw new SchemaError(`${name} must define type, oneof, anyof, or child definitions`);
+    }
+    typeName = "table";
+  }
+  if (Object.keys(children).length > 0 && typeName !== "table" && typeName !== "collection") {
+    throw new SchemaError(`${name} can only define children when type is table or collection`);
+  }
+  if (typeName !== "array" && typeName !== "collection" && itemReference !== "") {
+    throw new SchemaError(`${name} can only define itemtype when type is array or collection`);
+  }
+  if (typeName !== "array" && items.length > 0) {
+    throw new SchemaError(`${name} can only define items when type is array`);
+  }
+  if (items.length > 0) {
+    if (itemReference !== "") {
+      throw new SchemaError(`${name} cannot define both items and itemtype`);
+    }
+    if (minLength !== undefined || maxLength !== undefined) {
+      throw new SchemaError(`${name} cannot define minlength or maxlength together with items`);
+    }
+    if (hasAllowedValues) {
+      throw new SchemaError(`${name} cannot define allowedvalues together with items`);
+    }
+    if (propertyValue(table, "min") !== undefined || propertyValue(table, "max") !== undefined) {
+      throw new SchemaError(`${name} cannot define min or max together with items`);
+    }
+  }
+  const min = propertyValue(table, "min");
+  const max = propertyValue(table, "max");
+  if (minLength !== undefined && maxLength !== undefined && minLength > maxLength) {
+    throw new SchemaError(`${name} minlength must not be greater than maxlength`);
+  }
+  if (keyPatternResult !== undefined && typeName !== "collection") {
+    throw new SchemaError(`${name} can only define keypattern when type is collection`);
+  }
+  if (patternResult !== undefined && typeName !== "string") {
+    throw new SchemaError(`${name} can only define pattern when type is string`);
+  }
+  if (hasAllowedValues && (typeName === "table" || typeName === "collection")) {
+    throw new SchemaError(`${name} can only define allowedvalues for scalar, unconstrained, or array types`);
+  }
+  if (
+    (minLength !== undefined || maxLength !== undefined) &&
+    typeName !== "string" &&
+    typeName !== "array" &&
+    typeName !== "collection"
+  ) {
+    throw new SchemaError(
+      `${name} can only define minlength or maxlength when type is string, array, or collection`,
+    );
+  }
+  if (typeName === "collection" && itemReference === "" && allOf.length === 0) {
+    throw new SchemaError(`${name} must define itemtype when type is collection`);
+  }
+  validateRangeConstraints(name, typeName, min, max);
+  validateAllowedValuesConstraints(
+    name,
+    typeName,
+    allowedValues,
+    patternResult?.regex,
+    min,
+    max,
+    minLength,
+    maxLength,
+  );
+  const dependentRequired = getDependentRequired(name, path, table, source);
+  const mutuallyExclusive = getKeyGroups(name, path, table, "mutuallyexclusive", source);
+  const exactlyOne = getKeyGroups(name, path, table, "exactlyone", source);
+  const uniqueItems = getOptionalBoolProp(table, "uniqueitems", name);
+  const deprecated = getOptionalBoolProp(table, "deprecated", name);
+  const hasDefault = source.isProperty(table, path, "default");
+  const defaultValue = hasDefault ? table["default"] : undefined;
+
+  const raw: RawDefinition = {
+    name,
+    ...(typeName !== undefined ? { typeName } : {}),
+    ...(reference !== "" ? { reference } : {}),
+    ...(description !== "" ? { description } : {}),
+    ...(itemReference !== "" ? { itemReference: normalizeReference(itemReference) } : {}),
+    ...(items.length > 0 ? { items: normalizeReferences(items) } : {}),
+    optional,
+    ...(allowedValues.length > 0 ? { allowedValues } : {}),
+    ...(patternResult !== undefined
+      ? { pattern: patternResult.regex, patternSource: patternResult.source }
+      : {}),
+    ...(keyPatternResult !== undefined
+      ? { keyPattern: keyPatternResult.regex, keyPatternSource: keyPatternResult.source }
+      : {}),
+    ...(min !== undefined ? { min } : {}),
+    ...(max !== undefined ? { max } : {}),
+    ...(minLength !== undefined ? { minLength } : {}),
+    ...(maxLength !== undefined ? { maxLength } : {}),
+    ...(oneOf.length > 0 ? { oneOf: normalizeReferences(oneOf) } : {}),
+    ...(anyOf.length > 0 ? { anyOf: normalizeReferences(anyOf) } : {}),
+    ...(condition !== undefined ? { condition } : {}),
+    ...(thenReference !== "" ? { thenReference: normalizeReference(thenReference) } : {}),
+    ...(elseReference !== "" ? { elseReference: normalizeReference(elseReference) } : {}),
+    ...(allOf.length > 0 ? { allOf: normalizeReferences(allOf) } : {}),
+    ...(dependentRequired !== undefined ? { dependentRequired } : {}),
+    ...(mutuallyExclusive !== undefined ? { mutuallyExclusive } : {}),
+    ...(exactlyOne !== undefined ? { exactlyOne } : {}),
+    ...(uniqueItems !== undefined ? { uniqueItems } : {}),
+    ...(hasDefault ? { defaultValue } : {}),
+    hasDefault,
+    deprecated: deprecated ?? false,
+    children,
+  };
+  return raw;
+}

--- a/reference-implementations/typescript/src/semantics.ts
+++ b/reference-implementations/typescript/src/semantics.ts
@@ -1,0 +1,630 @@
+import { isRangeComparable, normalizeReference, parseSchemaType, type SchemaType } from "./builtins.js";
+import { cloneDefinition, emptyRecord, type RawDefinition } from "./definition.js";
+import { SchemaError } from "./errors.js";
+import {
+  boundaryMatchesType,
+  isType,
+  valuesEqual,
+  type TomlValue,
+} from "./values.js";
+
+/** The parsed `types` and `elements` tables of a loaded schema. */
+export interface SchemaData {
+  readonly types: Readonly<Record<string, RawDefinition>>;
+  readonly elements: Readonly<Record<string, RawDefinition>>;
+}
+
+function isBuiltIn(reference: string): boolean {
+  return parseSchemaType(reference) !== undefined;
+}
+
+/** Resolves a bare type-selector string (built-in name or `[types.*]` reference) to a definition. */
+export function definitionForReference(data: SchemaData, reference: string): RawDefinition {
+  const normalized = normalizeReference(reference);
+  const builtIn = parseSchemaType(normalized);
+  if (builtIn !== undefined) {
+    return {
+      name: normalized,
+      typeName: builtIn,
+      optional: false,
+      hasDefault: false,
+      deprecated: false,
+      children: emptyRecord(),
+    };
+  }
+  const definition = data.types[normalized];
+  if (!definition) {
+    throw new SchemaError(`unknown type reference: ${reference}`);
+  }
+  return definition;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Effective kind / fixed children / collection item constraint resolution   */
+/* -------------------------------------------------------------------------- */
+
+interface EffectiveKindResult {
+  kind: SchemaType | undefined;
+  resolved: boolean;
+}
+
+export function effectiveKind(
+  data: SchemaData,
+  definition: RawDefinition,
+  visiting: Set<string>,
+): EffectiveKindResult {
+  let result: EffectiveKindResult;
+  if (definition.reference) {
+    const reference = definition.reference;
+    const target = data.types[reference];
+    if (!target) throw new SchemaError(`unknown type reference: ${reference}`);
+    if (visiting.has(reference)) throw new SchemaError(`cyclic type reference: ${reference}`);
+    visiting.add(reference);
+    try {
+      result = effectiveKind(data, target, visiting);
+    } finally {
+      visiting.delete(reference);
+    }
+  } else if ((definition.oneOf?.length ?? 0) > 0 || (definition.anyOf?.length ?? 0) > 0) {
+    const alternatives = definition.oneOf?.length ? definition.oneOf : (definition.anyOf ?? []);
+    let kind: SchemaType | undefined;
+    let resolved = false;
+    for (const reference of alternatives) {
+      const alternative = definitionForReference(data, reference);
+      const alternativeResult = effectiveKind(data, alternative, visiting);
+      if (!alternativeResult.resolved || (resolved && alternativeResult.kind !== kind)) {
+        resolved = false;
+        kind = undefined;
+        break;
+      }
+      kind = alternativeResult.kind;
+      resolved = true;
+    }
+    result = { kind, resolved };
+  } else if (definition.condition) {
+    let kind: SchemaType | undefined;
+    let resolved = false;
+    for (const reference of [definition.thenReference, definition.elseReference]) {
+      const branch = definitionForReference(data, reference ?? "");
+      const branchResult = effectiveKind(data, branch, visiting);
+      if (!branchResult.resolved || (resolved && branchResult.kind !== kind)) {
+        throw new SchemaError("conditional branches have incompatible effective kinds");
+      }
+      kind = branchResult.kind;
+      resolved = true;
+    }
+    result = { kind, resolved };
+  } else {
+    result = { kind: definition.typeName, resolved: definition.typeName !== undefined };
+  }
+  const allOf = definition.allOf ?? [];
+  if (allOf.length === 0) return result;
+  if (!result.resolved || result.kind === "any") {
+    throw new SchemaError("allof requires a determinate effective kind");
+  }
+  for (const reference of allOf) {
+    const component = definitionForReference(data, reference);
+    const componentResult = effectiveKind(data, component, visiting);
+    if (!componentResult.resolved || componentResult.kind === "any" || componentResult.kind !== result.kind) {
+      throw new SchemaError(`allof component ${reference} has incompatible effective kind`);
+    }
+  }
+  return { kind: result.kind, resolved: true };
+}
+
+export function effectiveFixedChildren(
+  data: SchemaData,
+  definition: RawDefinition,
+  visiting: Set<string>,
+): Set<string> {
+  const fixed = new Set<string>(Object.keys(definition.children));
+  const references: string[] = [
+    ...(definition.allOf ?? []),
+    ...(definition.reference ? [definition.reference] : []),
+    ...(definition.oneOf ?? []),
+    ...(definition.anyOf ?? []),
+    ...(definition.condition ? [definition.thenReference ?? "", definition.elseReference ?? ""] : []),
+  ];
+  for (const reference of references) {
+    if (isBuiltIn(reference)) continue;
+    if (visiting.has(reference)) throw new SchemaError(`cyclic composition reference: ${reference}`);
+    const target = data.types[reference];
+    if (!target) throw new SchemaError(`unknown type reference: ${reference}`);
+    visiting.add(reference);
+    let targetFixed: Set<string>;
+    try {
+      targetFixed = effectiveFixedChildren(data, target, visiting);
+    } finally {
+      visiting.delete(reference);
+    }
+    for (const name of targetFixed) fixed.add(name);
+  }
+  return fixed;
+}
+
+/**
+ * Reports whether a dynamic-entry constraint is supplied by this definition,
+ * by the definition it references, by a union alternative, a conditional
+ * branch, or an allof component.
+ */
+export function hasCollectionItemConstraint(
+  data: SchemaData,
+  definition: RawDefinition,
+  visiting: Set<string>,
+): boolean {
+  if (definition.itemReference) return true;
+  const references: string[] = [
+    ...(definition.reference ? [definition.reference] : []),
+    ...(definition.oneOf ?? []),
+    ...(definition.anyOf ?? []),
+    ...(definition.condition ? [definition.thenReference ?? "", definition.elseReference ?? ""] : []),
+    ...(definition.allOf ?? []),
+  ];
+  for (const reference of references) {
+    if (isBuiltIn(reference)) continue;
+    if (visiting.has(reference)) throw new SchemaError(`cyclic composition reference: ${reference}`);
+    const target = data.types[reference];
+    if (!target) throw new SchemaError(`unknown type reference: ${reference}`);
+    visiting.add(reference);
+    let found: boolean;
+    try {
+      found = hasCollectionItemConstraint(data, target, visiting);
+    } finally {
+      visiting.delete(reference);
+    }
+    if (found) return true;
+  }
+  return false;
+}
+
+export function resolveItemKind(
+  data: SchemaData,
+  reference: string | undefined,
+  seen: Set<string>,
+): EffectiveKindResult {
+  const normalized = normalizeReference(reference ?? "");
+  if (normalized === "") return { kind: undefined, resolved: false };
+  const builtIn = parseSchemaType(normalized);
+  if (builtIn !== undefined) return { kind: builtIn, resolved: true };
+  if (seen.has(normalized)) throw new SchemaError(`cyclic type reference: ${normalized}`);
+  const definition = data.types[normalized];
+  if (!definition) throw new SchemaError(`unknown type reference: ${reference}`);
+  seen.add(normalized);
+  try {
+    if (definition.reference) return resolveItemKind(data, definition.reference, seen);
+    if (definition.condition) {
+      let kind: SchemaType | undefined;
+      for (const ref of [definition.thenReference, definition.elseReference]) {
+        const branch = resolveItemKind(data, ref, seen);
+        if (!branch.resolved || (kind !== undefined && branch.kind !== kind)) return { kind: undefined, resolved: false };
+        kind = branch.kind;
+      }
+      return kind !== undefined ? { kind, resolved: true } : { kind: undefined, resolved: false };
+    }
+    const alternatives = definition.oneOf?.length ? definition.oneOf : (definition.anyOf ?? []);
+    if (alternatives.length === 0) {
+      return definition.typeName !== undefined
+        ? { kind: definition.typeName, resolved: true }
+        : { kind: undefined, resolved: false };
+    }
+    let resolvedType: SchemaType | undefined;
+    for (const alternative of alternatives) {
+      const alternativeResult = resolveItemKind(data, alternative, seen);
+      if (!alternativeResult.resolved || (resolvedType !== undefined && alternativeResult.kind !== resolvedType)) {
+        return { kind: undefined, resolved: false };
+      }
+      resolvedType = alternativeResult.kind;
+    }
+    return resolvedType !== undefined ? { kind: resolvedType, resolved: true } : { kind: undefined, resolved: false };
+  } finally {
+    seen.delete(normalized);
+  }
+}
+
+export function collectReferenceTypes(
+  data: SchemaData,
+  reference: string,
+  seen: Set<string>,
+  types: Set<SchemaType>,
+): void {
+  const normalized = normalizeReference(reference);
+  const builtIn = parseSchemaType(normalized);
+  if (builtIn !== undefined) {
+    types.add(builtIn);
+    return;
+  }
+  if (seen.has(normalized)) throw new SchemaError(`cyclic type reference: ${normalized}`);
+  const definition = data.types[normalized];
+  if (!definition) throw new SchemaError(`unknown type reference: ${reference}`);
+  seen.add(normalized);
+  try {
+    if (definition.reference) {
+      collectReferenceTypes(data, definition.reference, seen, types);
+      return;
+    }
+    if (definition.condition) {
+      for (const ref of [definition.thenReference, definition.elseReference]) {
+        collectReferenceTypes(data, ref ?? "", seen, types);
+      }
+      return;
+    }
+    const alternatives = definition.oneOf?.length ? definition.oneOf : (definition.anyOf ?? []);
+    if (alternatives.length === 0) {
+      if (definition.typeName !== undefined) types.add(definition.typeName);
+      return;
+    }
+    for (const alternative of alternatives) {
+      collectReferenceTypes(data, alternative, seen, types);
+    }
+  } finally {
+    seen.delete(normalized);
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Schema-load-time semantic validation                                      */
+/* -------------------------------------------------------------------------- */
+
+export function validateSemantics(data: SchemaData): void {
+  for (const definitions of [data.types, data.elements]) {
+    for (const definition of Object.values(definitions)) {
+      validateDefinitionSemantics(data, definition);
+    }
+  }
+}
+
+function validateDefinitionSemantics(data: SchemaData, definition: RawDefinition): void {
+  let kind: SchemaType | undefined;
+  let resolved: boolean;
+  try {
+    ({ kind, resolved } = effectiveKind(data, definition, new Set()));
+  } catch (cause) {
+    throw new SchemaError(`${definition.name}: ${errorMessage(cause)}`);
+  }
+  const hasSiblingRules =
+    Object.keys(definition.dependentRequired ?? {}).length > 0 ||
+    (definition.mutuallyExclusive?.length ?? 0) > 0 ||
+    (definition.exactlyOne?.length ?? 0) > 0;
+  if (hasSiblingRules) {
+    if (!resolved || (kind !== "table" && kind !== "collection")) {
+      throw new SchemaError(`${definition.name} sibling rules require an effective table or collection`);
+    }
+    let fixed: Set<string>;
+    try {
+      fixed = effectiveFixedChildren(data, definition, new Set());
+    } catch (cause) {
+      throw new SchemaError(`${definition.name}: ${errorMessage(cause)}`);
+    }
+    const checkName = (property: string, operand: string): void => {
+      if (!fixed.has(operand)) {
+        throw new SchemaError(`${definition.name} ${property} contains unknown fixed child "${operand}"`);
+      }
+    };
+    for (const [trigger, dependencies] of Object.entries(definition.dependentRequired ?? {})) {
+      checkName("dependentrequired", trigger);
+      for (const dependency of dependencies) checkName("dependentrequired", dependency);
+    }
+    for (const [property, groups] of [
+      ["mutuallyexclusive", definition.mutuallyExclusive ?? []],
+      ["exactlyone", definition.exactlyOne ?? []],
+    ] as const) {
+      for (const group of groups) {
+        for (const operand of group) checkName(property, operand);
+      }
+    }
+  }
+  if (definition.uniqueItems !== undefined && (!resolved || kind !== "array")) {
+    throw new SchemaError(`${definition.name} uniqueitems requires an effective array`);
+  }
+  if (resolved && kind === "collection") {
+    let hasItemConstraint: boolean;
+    try {
+      hasItemConstraint = hasCollectionItemConstraint(data, definition, new Set());
+    } catch (cause) {
+      throw new SchemaError(`${definition.name}: ${errorMessage(cause)}`);
+    }
+    if (!hasItemConstraint) {
+      throw new SchemaError(`${definition.name} effective collection must define at least one itemtype`);
+    }
+  }
+  if (definition.condition && (!resolved || (kind !== "table" && kind !== "collection"))) {
+    throw new SchemaError(
+      `${definition.name} conditional selector requires compatible table or collection branches`,
+    );
+  }
+  for (const child of Object.values(definition.children)) {
+    validateDefinitionSemantics(data, child);
+  }
+}
+
+function errorMessage(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause);
+}
+
+export function validateReferences(data: SchemaData, definitions: Readonly<Record<string, RawDefinition>>): void {
+  for (const definition of Object.values(definitions)) {
+    const references: (string | undefined)[] = [
+      definition.reference,
+      definition.itemReference,
+      ...(definition.items ?? []),
+      ...(definition.oneOf ?? []),
+      ...(definition.anyOf ?? []),
+      ...(definition.condition ? [definition.thenReference, definition.elseReference] : []),
+      ...(definition.allOf ?? []),
+    ];
+    for (const reference of references) {
+      if (!reference) continue;
+      if (isBuiltIn(reference)) continue;
+      if (!Object.hasOwn(data.types, reference)) {
+        throw new SchemaError(`${definition.name} contains unknown type reference: ${reference}`);
+      }
+    }
+    validateReferences(data, definition.children);
+  }
+}
+
+export function validateSelectorCycles(data: SchemaData): void {
+  const visited = new Set<string>();
+  for (const typeName of Object.keys(data.types)) {
+    validateSelectorCycle(data, typeName, new Set(), visited);
+  }
+}
+
+function validateSelectorCycle(
+  data: SchemaData,
+  typeName: string,
+  visiting: Set<string>,
+  visited: Set<string>,
+): void {
+  if (isBuiltIn(typeName) || visited.has(typeName)) return;
+  if (visiting.has(typeName)) {
+    throw new SchemaError(`cyclic type selector reference involving types.${typeName}`);
+  }
+  const definition = data.types[typeName];
+  if (!definition) return;
+  visiting.add(typeName);
+  const references: (string | undefined)[] = [
+    definition.reference,
+    ...(definition.oneOf ?? []),
+    ...(definition.anyOf ?? []),
+    ...(definition.condition ? [definition.thenReference, definition.elseReference] : []),
+    ...(definition.allOf ?? []),
+  ];
+  for (const reference of references) {
+    if (reference) validateSelectorCycle(data, reference, visiting, visited);
+  }
+  visiting.delete(typeName);
+  visited.add(typeName);
+}
+
+export function validateArrayRanges(data: SchemaData): void {
+  const validateDefinition = (definition: RawDefinition): void => {
+    if (definition.typeName === "array" && (definition.min !== undefined || definition.max !== undefined)) {
+      let itemResult: EffectiveKindResult;
+      try {
+        itemResult = resolveItemKind(data, definition.itemReference, new Set());
+      } catch (cause) {
+        throw new SchemaError(`${definition.name} has invalid itemtype: ${errorMessage(cause)}`);
+      }
+      if (!itemResult.resolved || !isRangeComparable(itemResult.kind)) {
+        throw new SchemaError(
+          `${definition.name} can only define min or max when itemtype resolves to one comparable built-in type`,
+        );
+      }
+      const itemType = itemResult.kind as SchemaType;
+      if (definition.min !== undefined && !boundaryMatchesType(definition.min, itemType)) {
+        throw new SchemaError(`${definition.name} min must be comparable with ${itemType}`);
+      }
+      if (definition.max !== undefined && !boundaryMatchesType(definition.max, itemType)) {
+        throw new SchemaError(`${definition.name} max must be comparable with ${itemType}`);
+      }
+    }
+    for (const child of Object.values(definition.children)) validateDefinition(child);
+  };
+  for (const definitions of [data.types, data.elements]) {
+    for (const definition of Object.values(definitions)) validateDefinition(definition);
+  }
+}
+
+export function validateAllowedValueTypes(data: SchemaData): void {
+  const validateDefinition = (definition: RawDefinition): void => {
+    const allowedValues = definition.allowedValues ?? [];
+    if (allowedValues.length > 0) {
+      const permittedTypes = new Set<SchemaType>();
+      if (definition.typeName === "array") {
+        if (definition.itemReference) {
+          collectReferenceTypes(data, definition.itemReference, new Set(), permittedTypes);
+        }
+      } else if (definition.typeName !== undefined) {
+        permittedTypes.add(definition.typeName);
+      }
+      allowedValues.forEach((value, index) => {
+        const matches =
+          permittedTypes.size === 0 || [...permittedTypes].some((typeName) => isType(value, typeName));
+        if (!matches) {
+          throw new SchemaError(
+            `${definition.name} allowedvalues[${index}] does not match the permitted TOML type`,
+          );
+        }
+      });
+    }
+    for (const child of Object.values(definition.children)) validateDefinition(child);
+  };
+  for (const definitions of [data.types, data.elements]) {
+    for (const definition of Object.values(definitions)) validateDefinition(definition);
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Effective annotation resolution (description / deprecated / default)       */
+/* -------------------------------------------------------------------------- */
+
+export function effectiveDescription(
+  data: SchemaData,
+  definition: RawDefinition,
+  visiting: Set<string>,
+): string | undefined {
+  if (definition.description) return definition.description;
+  const reference = definition.reference;
+  if (!reference || isBuiltIn(reference) || visiting.has(reference)) return undefined;
+  const target = data.types[reference];
+  if (!target) return undefined;
+  visiting.add(reference);
+  try {
+    return effectiveDescription(data, target, visiting);
+  } finally {
+    visiting.delete(reference);
+  }
+}
+
+export function effectiveDeprecated(
+  data: SchemaData,
+  definition: RawDefinition,
+  visiting: Set<string>,
+): boolean {
+  if (definition.deprecated) return true;
+  const references = [...(definition.allOf ?? []), ...(definition.reference ? [definition.reference] : [])];
+  for (const reference of references) {
+    if (isBuiltIn(reference) || visiting.has(reference)) continue;
+    const target = data.types[reference];
+    if (!target) continue;
+    visiting.add(reference);
+    let deprecated: boolean;
+    try {
+      deprecated = effectiveDeprecated(data, target, visiting);
+    } finally {
+      visiting.delete(reference);
+    }
+    if (deprecated) return true;
+  }
+  return false;
+}
+
+export function effectiveDefault(
+  data: SchemaData,
+  definition: RawDefinition,
+  visiting: Set<string>,
+): { value: TomlValue | undefined; found: boolean } {
+  if (definition.hasDefault) return { value: definition.defaultValue, found: true };
+  let value: TomlValue | undefined;
+  let found = false;
+  const references = definition.reference
+    ? [definition.reference, ...(definition.allOf ?? [])]
+    : [...(definition.allOf ?? [])];
+  for (const reference of references) {
+    if (isBuiltIn(reference)) continue;
+    if (visiting.has(reference)) throw new SchemaError(`cyclic default reference: ${reference}`);
+    const target = data.types[reference];
+    if (!target) continue;
+    visiting.add(reference);
+    let candidate: { value: TomlValue | undefined; found: boolean };
+    try {
+      candidate = effectiveDefault(data, target, visiting);
+    } finally {
+      visiting.delete(reference);
+    }
+    if (!candidate.found) continue;
+    if (found && !valuesEqual(value, candidate.value)) {
+      throw new SchemaError(`${definition.name} has conflicting inherited defaults`);
+    }
+    value = candidate.value;
+    found = true;
+  }
+  return { value, found };
+}
+
+/**
+ * `validateDefaultValue` is injected by the document validator to break the
+ * mutual dependency between schema-load-time default validation and the
+ * document-validation engine (which itself needs `effectiveKind` et al.).
+ */
+export type DefaultValueValidator = (definition: RawDefinition, value: TomlValue) => string | undefined;
+
+export function validateDefaults(data: SchemaData, validateValue: DefaultValueValidator): void {
+  const validateDefinition = (definition: RawDefinition): void => {
+    const { value, found } = effectiveDefault(data, definition, new Set());
+    if (found) {
+      const error = validateValue(definition, value as TomlValue);
+      if (error !== undefined) {
+        throw new SchemaError(`${definition.name} default is invalid: ${error}`);
+      }
+    }
+    for (const child of Object.values(definition.children)) validateDefinition(child);
+  };
+  for (const definitions of [data.types, data.elements]) {
+    for (const definition of Object.values(definitions)) validateDefinition(definition);
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Effective-annotation resolution for the public Definition accessors        */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Resolves the full effective annotation tree (description/deprecated/default,
+ * and reference/allof/union/conditional flattening for direct child lookups)
+ * for a definition, guarding against re-entering a definition already being
+ * expanded (legal self-referential recursion through children).
+ */
+export class AnnotationResolver {
+  readonly #data: SchemaData;
+  readonly #resolveReferenceValue: (definition: RawDefinition) => RawDefinition;
+  readonly #visiting = new Set<string>();
+  readonly #resolved = new Map<string, RawDefinition>();
+
+  constructor(data: SchemaData, resolveReferenceValue: (definition: RawDefinition) => RawDefinition) {
+    this.#data = data;
+    this.#resolveReferenceValue = resolveReferenceValue;
+  }
+
+  resolve(definition: RawDefinition): RawDefinition {
+    return this.resolveInternal(definition).definition;
+  }
+
+  private resolveInternal(definition: RawDefinition): { definition: RawDefinition; complete: boolean } {
+    const key = `${definition.name}\u0000${definition.reference ?? ""}`;
+    const cached = this.#resolved.get(key);
+    if (cached) return { definition: cached, complete: true };
+    let effective = this.annotate(definition);
+    if (this.#visiting.has(key)) return { definition: effective, complete: false };
+    this.#visiting.add(key);
+    let complete = true;
+    const children = emptyRecord<RawDefinition>();
+    for (const [name, child] of Object.entries(effective.children)) {
+      const resolvedChild = this.resolveInternal(child);
+      complete = complete && resolvedChild.complete;
+      children[name] = resolvedChild.definition;
+    }
+    effective = { ...effective, children };
+    this.#visiting.delete(key);
+    if (complete) this.#resolved.set(key, effective);
+    return { definition: effective, complete };
+  }
+
+  private annotate(definition: RawDefinition): RawDefinition {
+    let resolved = definition;
+    try {
+      resolved = this.#resolveReferenceValue(definition);
+    } catch {
+      // Fall through with the original definition, mirroring Go's `if err == nil`.
+    }
+    let result = resolved;
+    try {
+      const { value, found } = effectiveDefault(this.#data, definition, new Set());
+      if (found) result = cloneDefinition(result, { defaultValue: value, hasDefault: true });
+    } catch {
+      // Ignore; validated separately at schema-load time.
+    }
+    result = cloneDefinition(result, {
+      deprecated: effectiveDeprecated(this.#data, definition, new Set()),
+    });
+    if (!result.description) {
+      result = cloneDefinition(result, {
+        description: effectiveDescription(this.#data, definition, new Set()),
+      });
+    }
+    return result;
+  }
+}
+
+export { isBuiltIn };

--- a/reference-implementations/typescript/src/semver.ts
+++ b/reference-implementations/typescript/src/semver.ts
@@ -1,0 +1,35 @@
+import { SchemaError } from "./errors.js";
+
+// SemVer 2.0.0 MAJOR.MINOR.PATCH[-PRERELEASE][+BUILD], per semver.org's reference regex.
+const SEMVER_PATTERN =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
+
+export interface SemVerParts {
+  readonly major: string;
+  readonly minor: string;
+  readonly patch: string;
+}
+
+/** Parses a SemVer string, returning its major/minor/patch components. */
+export function parseSemVer(value: string): SemVerParts | undefined {
+  const match = SEMVER_PATTERN.exec(value);
+  if (!match) return undefined;
+  return { major: match[1] as string, minor: match[2] as string, patch: match[3] as string };
+}
+
+/** Validates that `value` is a well-formed `1.0.x` TOML Schema language version string. */
+export function validateSchemaVersion(value: unknown): asserts value is string {
+  if (typeof value !== "string") {
+    throw new SchemaError("[toml-schema].version must be a SemVer string");
+  }
+  const parts = parseSemVer(value);
+  if (!parts) {
+    throw new SchemaError("[toml-schema].version must use SemVer MAJOR.MINOR.PATCH syntax");
+  }
+  if (parts.major !== "1") {
+    throw new SchemaError(`unsupported TOML Schema major version: ${value}`);
+  }
+  if (parts.minor !== "0") {
+    throw new SchemaError(`unsupported TOML Schema minor version: ${value}`);
+  }
+}

--- a/reference-implementations/typescript/src/tomlSource.ts
+++ b/reference-implementations/typescript/src/tomlSource.ts
@@ -1,0 +1,329 @@
+import type { TomlTable, TomlValue } from "./values.js";
+import { isTomlTable } from "./values.js";
+
+/**
+ * Recovers which table-valued schema keys were written using inline-table
+ * syntax (`key = { ... }`) versus a table header (`[a.b.key]`).
+ *
+ * TOML Schema disambiguates an annotation property from a child definition by
+ * syntax rather than by member name: `default = { ... }`, `dependentrequired
+ * = { ... }`, and `if = { ... }` are always annotations, while a table header
+ * such as `[elements.options.default]` is always a child definition named
+ * `default`. A parsed TOML value alone cannot recover this distinction (see
+ * SPEC.md, "Validation and Data Model"), so this scanner walks the raw schema
+ * source text to record every key path that was assigned via inline-table
+ * syntax.
+ *
+ * This is a narrow, source-shape-only scanner: it assumes `content` is
+ * already known to be valid TOML (the caller parses it with a real TOML
+ * parser first) and only needs to recover table-header/inline-table syntax
+ * choices, not TOML values themselves.
+ */
+export class SchemaSource {
+  private readonly inlineTablePaths: ReadonlySet<string>;
+
+  constructor(content: string) {
+    let inlineTablePaths: ReadonlySet<string>;
+    try {
+      inlineTablePaths = scanInlineTablePaths(content);
+    } catch {
+      // Fail open: an implementation MUST NOT guess from inline-table member
+      // names, but a scan failure on already-parsed-valid TOML should not
+      // itself abort schema loading. Structural checks elsewhere still catch
+      // genuine schema errors.
+      inlineTablePaths = new Set();
+    }
+    this.inlineTablePaths = inlineTablePaths;
+  }
+
+  /**
+   * Reports whether `key` on the definition table at `path` carries an
+   * annotation value (a property) rather than a nested child definition. A
+   * non-table value is always a property; a table value is a property only
+   * when the source wrote it as an inline table.
+   */
+  isProperty(table: TomlTable, path: readonly string[], key: string): boolean {
+    if (!(key in table)) return false;
+    const value = table[key];
+    if (!isTomlTable(value as TomlValue)) return true;
+    return this.inlineTablePaths.has(pathKey([...path, key]));
+  }
+}
+
+function pathKey(path: readonly string[]): string {
+  return path.join("\u0000");
+}
+
+function scanInlineTablePaths(text: string): Set<string> {
+  const inlineTablePaths = new Set<string>();
+  const length = text.length;
+  let i = 0;
+  let prefix: string[] = [];
+  while (i < length) {
+    i = skipInsignificant(text, i);
+    if (i >= length) break;
+    if (text[i] === "[") {
+      const isArrayTable = text[i + 1] === "[";
+      let j = isArrayTable ? i + 2 : i + 1;
+      const key = parseKeyPath(text, j);
+      j = skipInlineWs(text, key.next);
+      if (isArrayTable) {
+        if (text[j] !== "]" || text[j + 1] !== "]") {
+          throw new Error("malformed array table header");
+        }
+        j += 2;
+      } else {
+        if (text[j] !== "]") {
+          throw new Error("malformed table header");
+        }
+        j += 1;
+      }
+      prefix = key.segments;
+      i = j;
+      continue;
+    }
+    const key = parseKeyPath(text, i);
+    let j = skipInlineWs(text, key.next);
+    if (text[j] !== "=") {
+      throw new Error("expected '=' in key/value pair");
+    }
+    j = skipInlineWs(text, j + 1);
+    const fullPath = [...prefix, ...key.segments];
+    i = consumeValue(text, j, fullPath, inlineTablePaths);
+  }
+  return inlineTablePaths;
+}
+
+function consumeValue(
+  text: string,
+  i: number,
+  path: readonly string[],
+  inlineTablePaths: Set<string>,
+): number {
+  const ch = text[i];
+  if (ch === "{") {
+    const close = skipGroup(text, i);
+    inlineTablePaths.add(pathKey(path));
+    parseInlineTableBody(text, i + 1, close - 1, path, inlineTablePaths);
+    return close;
+  }
+  if (ch === "[") {
+    return skipGroup(text, i);
+  }
+  if (ch === '"' || ch === "'") {
+    return skipString(text, i);
+  }
+  // Bare scalar values (integers, floats, booleans, and bare dates/times)
+  // never contain '\n', '\r', '#', ',', '}', or ']'. Stopping at all of
+  // these (not just newline/comment) lets this branch double as both the
+  // top-level/table-header scanner and the inline-table-body scanner: a
+  // bare value nested inside an inline table must stop at its enclosing
+  // ',' separator or '}'/']' close, not run on to the end of the line.
+  let j = i;
+  while (j < text.length) {
+    const c = text[j];
+    if (c === "\n" || c === "\r" || c === "#" || c === "," || c === "}" || c === "]") {
+      break;
+    }
+    j++;
+  }
+  return j;
+}
+
+function parseInlineTableBody(
+  text: string,
+  start: number,
+  end: number,
+  basePath: readonly string[],
+  inlineTablePaths: Set<string>,
+): void {
+  let i = start;
+  while (true) {
+    i = skipInlineWsCommasAndNewlines(text, i, end);
+    if (i >= end) break;
+    const key = parseKeyPath(text, i);
+    let j = skipInlineWs(text, key.next);
+    if (text[j] !== "=") {
+      throw new Error("expected '=' in inline table");
+    }
+    j = skipInlineWs(text, j + 1);
+    const fullPath = [...basePath, ...key.segments];
+    i = consumeValue(text, j, fullPath, inlineTablePaths);
+  }
+}
+
+function skipInsignificant(text: string, start: number): number {
+  let i = start;
+  while (i < text.length) {
+    const ch = text[i];
+    if (ch === " " || ch === "\t" || ch === "\n" || ch === "\r") {
+      i++;
+      continue;
+    }
+    if (ch === "#") {
+      while (i < text.length && text[i] !== "\n") i++;
+      continue;
+    }
+    break;
+  }
+  return i;
+}
+
+function skipInlineWs(text: string, start: number): number {
+  let i = start;
+  while (i < text.length && (text[i] === " " || text[i] === "\t")) i++;
+  return i;
+}
+
+function skipInlineWsCommasAndNewlines(text: string, start: number, end: number): number {
+  let i = start;
+  while (i < end) {
+    const ch = text[i];
+    if (ch === " " || ch === "\t" || ch === "\n" || ch === "\r" || ch === ",") {
+      i++;
+      continue;
+    }
+    if (ch === "#") {
+      while (i < end && text[i] !== "\n") i++;
+      continue;
+    }
+    break;
+  }
+  return i;
+}
+
+const BARE_KEY_PATTERN = /^[A-Za-z0-9_-]+/;
+
+function parseKeyPath(text: string, start: number): { segments: string[]; next: number } {
+  const segments: string[] = [];
+  let i = skipInlineWs(text, start);
+  for (;;) {
+    if (text[i] === '"' || text[i] === "'") {
+      const quote = text[i];
+      const end = skipString(text, i);
+      const raw = text.slice(i + 1, end - 1);
+      segments.push(quote === '"' ? unescapeBasicString(raw) : raw);
+      i = end;
+    } else {
+      const match = BARE_KEY_PATTERN.exec(text.slice(i));
+      if (!match) {
+        throw new Error(`invalid key at offset ${i}`);
+      }
+      segments.push(match[0]);
+      i += match[0].length;
+    }
+    i = skipInlineWs(text, i);
+    if (text[i] === ".") {
+      i = skipInlineWs(text, i + 1);
+      continue;
+    }
+    break;
+  }
+  return { segments, next: i };
+}
+
+/** Skips a (possibly triple-quoted) string starting at `text[start]`, returning the index after it. */
+function skipString(text: string, start: number): number {
+  const quote = text[start];
+  const triple = text[start + 1] === quote && text[start + 2] === quote;
+  const literal = quote === "'";
+  let i = start + (triple ? 3 : 1);
+  while (i < text.length) {
+    if (!literal && text[i] === "\\") {
+      i += 2;
+      continue;
+    }
+    if (triple) {
+      if (text[i] === quote && text[i + 1] === quote && text[i + 2] === quote) {
+        return i + 3;
+      }
+    } else {
+      if (text[i] === quote) return i + 1;
+      if (!literal && text[i] === "\n") {
+        throw new Error("unterminated single-line string");
+      }
+    }
+    i++;
+  }
+  throw new Error("unterminated string");
+}
+
+/** Skips a balanced `{...}` or `[...]` group, returning the index after the matching close. */
+function skipGroup(text: string, start: number): number {
+  const closers: string[] = [text[start] === "{" ? "}" : "]"];
+  let i = start + 1;
+  while (i < text.length) {
+    const ch = text[i];
+    if (ch === '"' || ch === "'") {
+      i = skipString(text, i);
+      continue;
+    }
+    if (ch === "#") {
+      while (i < text.length && text[i] !== "\n") i++;
+      continue;
+    }
+    if (ch === "{" || ch === "[") {
+      closers.push(ch === "{" ? "}" : "]");
+      i++;
+      continue;
+    }
+    if (ch === "}" || ch === "]") {
+      closers.pop();
+      i++;
+      if (closers.length === 0) return i;
+      continue;
+    }
+    i++;
+  }
+  throw new Error("unterminated group");
+}
+
+function unescapeBasicString(raw: string): string {
+  let result = "";
+  for (let i = 0; i < raw.length; i++) {
+    const ch = raw[i];
+    if (ch !== "\\") {
+      result += ch;
+      continue;
+    }
+    const next = raw[++i];
+    switch (next) {
+      case "b":
+        result += "\b";
+        break;
+      case "t":
+        result += "\t";
+        break;
+      case "n":
+        result += "\n";
+        break;
+      case "f":
+        result += "\f";
+        break;
+      case "r":
+        result += "\r";
+        break;
+      case '"':
+        result += '"';
+        break;
+      case "\\":
+        result += "\\";
+        break;
+      case "u": {
+        const code = raw.slice(i + 1, i + 5);
+        result += String.fromCodePoint(Number.parseInt(code, 16));
+        i += 4;
+        break;
+      }
+      case "U": {
+        const code = raw.slice(i + 1, i + 9);
+        result += String.fromCodePoint(Number.parseInt(code, 16));
+        i += 8;
+        break;
+      }
+      default:
+        result += next ?? "";
+    }
+  }
+  return result;
+}

--- a/reference-implementations/typescript/src/validator.ts
+++ b/reference-implementations/typescript/src/validator.ts
@@ -1,0 +1,810 @@
+import { normalizeReference, parseSchemaType, type SchemaType } from "./builtins.js";
+import {
+  cloneDefinition,
+  emptyRecord,
+  mergeDependentRequired,
+  type Condition,
+  type RawDefinition,
+} from "./definition.js";
+import { SchemaError } from "./errors.js";
+import { appendPath } from "./paths.js";
+import {
+  effectiveFixedChildren,
+  effectiveKind,
+  resolveItemKind,
+  type SchemaData,
+} from "./semantics.js";
+import {
+  compareValues,
+  isTomlTable,
+  isType,
+  scalarLength,
+  typeNameOf,
+  valuesEqual,
+  type TomlTable,
+  type TomlValue,
+} from "./values.js";
+
+export type Severity = "error" | "warning";
+
+/** A single validation error or warning, addressed to a document path such as `$.a.b[2]`. */
+export interface ValidationError {
+  readonly severity: Severity;
+  readonly code: string;
+  readonly path: string;
+  readonly message: string;
+}
+
+export type Diagnostic = ValidationError;
+
+/**
+ * The outcome of validating a document (or a single value) against a schema.
+ * `errors` are the hard failures that make the document invalid; `warnings`
+ * (for example, `deprecated` usage) do not. `diagnostics` is the concatenation
+ * of both, in `errors` then `warnings` order.
+ */
+export class ValidationResult {
+  readonly errors: readonly ValidationError[];
+  readonly warnings: readonly Diagnostic[];
+  readonly diagnostics: readonly Diagnostic[];
+
+  constructor(errors: readonly ValidationError[], warnings: readonly Diagnostic[]) {
+    this.errors = errors;
+    this.warnings = warnings;
+    this.diagnostics = [...errors, ...warnings];
+  }
+
+  /** Whether the document is valid, i.e. has no errors (warnings are permitted). */
+  get valid(): boolean {
+    return this.errors.length === 0;
+  }
+
+  /** Method form of {@link ValidationResult.valid}, for idiomatic call-site use (`result.isValid()`). */
+  isValid(): boolean {
+    return this.valid;
+  }
+}
+
+function errorMessage(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause);
+}
+
+function conditionMatches(table: TomlTable, condition: Condition): boolean {
+  if (!(condition.key in table)) return false;
+  const value = table[condition.key];
+  if (condition.hasEquals) return valuesEqual(condition.equals, value);
+  return condition.in.some((candidate) => valuesEqual(candidate, value));
+}
+
+function presentGroupMembers(table: TomlTable, group: readonly string[]): string[] {
+  return group.filter((name) => name in table);
+}
+
+interface CompositionParts {
+  structural: RawDefinition[];
+  unions: RawDefinition[];
+  conditionals: RawDefinition[];
+}
+
+/**
+ * Validates a parsed TOML document (or a single value) against a loaded
+ * schema's definitions. This is an internal engine; construct it only via
+ * {@link Schema.validate}/{@link Schema.validateFile}.
+ */
+export class DocumentValidator {
+  readonly #data: SchemaData;
+  readonly #suppressWarnings: boolean;
+  readonly errors: ValidationError[] = [];
+  readonly warnings: Diagnostic[] = [];
+
+  constructor(data: SchemaData, suppressWarnings = false) {
+    this.#data = data;
+    this.#suppressWarnings = suppressWarnings;
+  }
+
+  toResult(): ValidationResult {
+    return new ValidationResult(this.errors, this.warnings);
+  }
+
+  validateTable(path: string, table: TomlTable, definitions: Readonly<Record<string, RawDefinition>>): void {
+    for (const [key, definition] of Object.entries(definitions)) {
+      let resolved: RawDefinition;
+      try {
+        resolved = this.resolve(definition, new Set());
+      } catch (cause) {
+        this.add(appendPath(path, key), errorMessage(cause));
+        continue;
+      }
+      const value = table[key];
+      const childPath = appendPath(path, key);
+      if (value === undefined) {
+        if (!resolved.optional) this.add(childPath, "required value is missing");
+        continue;
+      }
+      this.validateValue(childPath, value, resolved);
+    }
+  }
+
+  validateValue(path: string, value: TomlValue, definition: RawDefinition): void {
+    const candidate = new DocumentValidator(this.#data, this.#suppressWarnings);
+    candidate.validateValueInternal(path, value, definition);
+    this.errors.push(...candidate.errors);
+    if (candidate.errors.length === 0) this.appendWarnings(candidate.warnings);
+  }
+
+  private validateValueInternal(path: string, value: TomlValue, definition: RawDefinition): void {
+    let resolved: RawDefinition;
+    try {
+      resolved = this.resolve(definition, new Set());
+    } catch (cause) {
+      this.add(path, errorMessage(cause));
+      return;
+    }
+    if (resolved.condition) {
+      this.validateConditional(path, value, resolved);
+    } else if ((resolved.oneOf?.length ?? 0) > 0 || (resolved.anyOf?.length ?? 0) > 0) {
+      this.validateUnion(path, value, resolved);
+    } else if ((resolved.allOf?.length ?? 0) > 0) {
+      this.validateAllOf(path, value, resolved);
+    } else {
+      this.validatePlainValue(path, value, resolved);
+    }
+    if (this.errors.length === 0 && resolved.deprecated) {
+      this.warn(path, "deprecated", "value is deprecated");
+    }
+  }
+
+  private validateConditional(path: string, value: TomlValue, definition: RawDefinition): void {
+    let reference = definition.elseReference ?? "";
+    if (isTomlTable(value) && conditionMatches(value, definition.condition as Condition)) {
+      reference = definition.thenReference ?? "";
+    }
+    let branch: RawDefinition;
+    try {
+      branch = this.resolveReference(reference, new Set());
+    } catch (cause) {
+      this.add(path, errorMessage(cause));
+      return;
+    }
+    branch = cloneDefinition(branch, { allOf: [...(branch.allOf ?? []), ...(definition.allOf ?? [])] });
+    this.validateValue(path, value, branch);
+  }
+
+  private validatePlainValue(path: string, value: TomlValue, definition: RawDefinition): void {
+    const typeName = definition.typeName ?? "any";
+    this.validateType(path, value, typeName);
+    if (!isType(value, typeName)) return;
+    this.validateCommonConstraints(path, value, definition);
+    switch (typeName) {
+      case "table":
+        this.validateTableValue(path, value as TomlTable, definition);
+        break;
+      case "collection":
+        this.validateCollection(path, value as TomlTable, definition);
+        break;
+      case "array":
+        this.validateArray(path, value as TomlValue[], definition);
+        break;
+      default:
+        break;
+    }
+  }
+
+  private validateUnion(path: string, value: TomlValue, definition: RawDefinition): void {
+    const alternatives = definition.oneOf?.length ? definition.oneOf : (definition.anyOf ?? []);
+    let matches = 0;
+    const successes: DocumentValidator[] = [];
+    for (const reference of alternatives) {
+      let referenced: RawDefinition;
+      try {
+        referenced = this.resolveReference(reference, new Set());
+      } catch (cause) {
+        this.add(path, errorMessage(cause));
+        return;
+      }
+      referenced = cloneDefinition(referenced, {
+        allOf: [...(referenced.allOf ?? []), ...(definition.allOf ?? [])],
+        dependentRequired: mergeDependentRequired(referenced.dependentRequired, definition.dependentRequired),
+        mutuallyExclusive: [...(referenced.mutuallyExclusive ?? []), ...(definition.mutuallyExclusive ?? [])],
+        exactlyOne: [...(referenced.exactlyOne ?? []), ...(definition.exactlyOne ?? [])],
+        ...(definition.uniqueItems !== undefined ? { uniqueItems: definition.uniqueItems } : {}),
+      });
+      const candidate = new DocumentValidator(this.#data, this.#suppressWarnings);
+      candidate.validateValue(path, value, referenced);
+      if (candidate.errors.length === 0) {
+        matches++;
+        successes.push(candidate);
+      }
+    }
+    if ((definition.oneOf?.length ?? 0) > 0) {
+      if (matches !== 1) {
+        this.add(path, `expected exactly one matching type from oneof but found ${matches}`);
+      } else {
+        this.appendWarnings(successes[0]?.warnings ?? []);
+      }
+    }
+    if ((definition.anyOf?.length ?? 0) > 0) {
+      if (matches === 0) {
+        this.add(path, "expected at least one matching type from anyof");
+      } else {
+        for (const candidate of successes) this.appendWarnings(candidate.warnings);
+      }
+    }
+  }
+
+  private validateAllOf(path: string, value: TomlValue, definition: RawDefinition): void {
+    let kind: SchemaType | undefined;
+    let resolved: boolean;
+    try {
+      ({ kind, resolved } = effectiveKind(this.#data, definition, new Set()));
+    } catch (cause) {
+      this.add(path, errorMessage(cause));
+      return;
+    }
+    if (!resolved) {
+      this.add(path, "allof has no determinate effective kind");
+      return;
+    }
+    if (kind === "table" || kind === "collection") {
+      this.validateComposedStructure(path, value, kind, definition, undefined);
+      return;
+    }
+    const local = cloneDefinition(definition, { allOf: [] });
+    this.validatePlainValue(path, value, local);
+    for (const reference of definition.allOf ?? []) {
+      let component: RawDefinition;
+      try {
+        component = this.resolveReference(reference, new Set());
+      } catch (cause) {
+        this.add(path, errorMessage(cause));
+        continue;
+      }
+      this.validateValue(path, value, component);
+    }
+  }
+
+  private compositionParts(definition: RawDefinition, visiting: Set<string>): CompositionParts {
+    const resolved = this.resolve(definition, new Set());
+    const references = resolved.allOf ?? [];
+    const withoutAllOf = cloneDefinition(resolved, { allOf: [] });
+    const parts: CompositionParts = { structural: [], unions: [], conditionals: [] };
+    if (withoutAllOf.condition) parts.conditionals.push(withoutAllOf);
+    else if ((withoutAllOf.oneOf?.length ?? 0) > 0 || (withoutAllOf.anyOf?.length ?? 0) > 0) {
+      parts.unions.push(withoutAllOf);
+    } else parts.structural.push(withoutAllOf);
+    for (const reference of references) {
+      if (visiting.has(reference)) {
+        throw new SchemaError(`cyclic composition reference: ${reference}`);
+      }
+      visiting.add(reference);
+      let nested: CompositionParts;
+      try {
+        const component = this.resolveReference(reference, new Set());
+        nested = this.compositionParts(component, visiting);
+      } finally {
+        visiting.delete(reference);
+      }
+      parts.structural.push(...nested.structural);
+      parts.unions.push(...nested.unions);
+      parts.conditionals.push(...nested.conditionals);
+    }
+    return parts;
+  }
+
+  private validateComposedStructure(
+    path: string,
+    value: TomlValue,
+    kind: SchemaType,
+    definition: RawDefinition,
+    inheritedKeys: ReadonlySet<string> | undefined,
+  ): void {
+    let parts: CompositionParts;
+    try {
+      parts = this.compositionParts(definition, new Set());
+    } catch (cause) {
+      this.add(path, errorMessage(cause));
+      return;
+    }
+    this.validateComposedParts(path, value, kind, parts, inheritedKeys);
+  }
+
+  private validateComposedParts(
+    path: string,
+    value: TomlValue,
+    kind: SchemaType,
+    parts: CompositionParts,
+    inheritedKeys: ReadonlySet<string> | undefined,
+  ): void {
+    if (!isTomlTable(value)) {
+      this.validateType(path, value, kind);
+      return;
+    }
+    const table = value;
+    const children = new Map<string, RawDefinition[]>();
+    let hasFixedStructure = (inheritedKeys?.size ?? 0) > 0;
+    for (const component of parts.structural) {
+      if (component.typeName !== kind) {
+        this.add(path, `expected ${kind} component but found ${component.typeName}`);
+        continue;
+      }
+      if (Object.keys(component.children).length > 0) hasFixedStructure = true;
+      for (const [name, child] of Object.entries(component.children)) {
+        children.set(name, [...(children.get(name) ?? []), child]);
+      }
+    }
+    const knownKeys = new Set<string>(inheritedKeys ?? []);
+    for (const name of children.keys()) knownKeys.add(name);
+
+    const unions: RawDefinition[] = [];
+    const unionKeySets: Set<string>[] = [];
+    for (const union of parts.unions) {
+      let alternativeKeys: Set<string>;
+      try {
+        alternativeKeys = effectiveFixedChildren(this.#data, union, new Set());
+      } catch (cause) {
+        this.add(path, errorMessage(cause));
+        continue;
+      }
+      if (alternativeKeys.size > 0) hasFixedStructure = true;
+      for (const name of alternativeKeys) knownKeys.add(name);
+      unions.push(union);
+      unionKeySets.push(alternativeKeys);
+    }
+
+    const conditionals: RawDefinition[] = [];
+    const conditionalKeySets: Set<string>[] = [];
+    for (const conditional of parts.conditionals) {
+      let branchKeys: Set<string>;
+      try {
+        branchKeys = effectiveFixedChildren(this.#data, conditional, new Set());
+      } catch (cause) {
+        this.add(path, errorMessage(cause));
+        continue;
+      }
+      if (branchKeys.size > 0) hasFixedStructure = true;
+      for (const name of branchKeys) knownKeys.add(name);
+      conditionals.push(conditional);
+      conditionalKeySets.push(branchKeys);
+    }
+
+    const selectorKeys = [...unionKeySets, ...conditionalKeySets];
+
+    for (const [name, definitions] of children) {
+      const childPath = appendPath(path, name);
+      const childValue = table[name];
+      const present = childValue !== undefined;
+      for (const child of definitions) {
+        let resolved: RawDefinition;
+        try {
+          resolved = this.resolve(child, new Set());
+        } catch (cause) {
+          this.add(childPath, errorMessage(cause));
+          continue;
+        }
+        if (!present) {
+          if (!resolved.optional) this.add(childPath, "required value is missing");
+          continue;
+        }
+        this.validateValue(childPath, childValue, child);
+      }
+    }
+
+    unions.forEach((union, index) => {
+      // A branch is closed against the keys contributed by the rest of the
+      // composition, but not against the keys exclusive to its sibling
+      // alternatives.
+      const branchKeys = new Set<string>(inheritedKeys ?? []);
+      for (const name of children.keys()) branchKeys.add(name);
+      selectorKeys.forEach((keys, otherIndex) => {
+        if (otherIndex === index) return;
+        for (const name of keys) branchKeys.add(name);
+      });
+      this.validateComposedUnion(path, value, kind, union, branchKeys);
+    });
+
+    conditionals.forEach((conditional, index) => {
+      const branchKeys = new Set<string>(inheritedKeys ?? []);
+      for (const name of children.keys()) branchKeys.add(name);
+      const selectorIndex = unions.length + index;
+      selectorKeys.forEach((keys, otherIndex) => {
+        if (otherIndex === selectorIndex) return;
+        for (const name of keys) branchKeys.add(name);
+      });
+      this.validateComposedConditional(path, value, kind, conditional, branchKeys);
+    });
+
+    for (const component of parts.structural) this.validateSiblingRules(path, table, component);
+    for (const union of unions) this.validateSiblingRules(path, table, union);
+
+    if (kind === "table") {
+      if (hasFixedStructure) {
+        for (const key of Object.keys(table)) {
+          if (!knownKeys.has(key)) this.add(appendPath(path, key), "unexpected key");
+        }
+      }
+    } else {
+      for (const component of parts.structural) {
+        let dynamicEntries = 0;
+        for (const [key, entry] of Object.entries(table)) {
+          if (knownKeys.has(key)) continue;
+          dynamicEntries++;
+          const childPath = appendPath(path, key);
+          if (component.keyPattern && !component.keyPattern.test(key)) {
+            this.add(childPath, `key does not match keypattern ${component.keyPatternSource}`);
+          }
+          // A composed collection may take its dynamic-entry constraint
+          // entirely from another contributor.
+          if (!component.itemReference) continue;
+          try {
+            const item = this.resolveReference(component.itemReference, new Set());
+            this.validateValue(childPath, entry, item);
+          } catch (cause) {
+            this.add(childPath, errorMessage(cause));
+          }
+        }
+        this.validateLength(path, dynamicEntries, component);
+      }
+    }
+
+    for (const component of parts.structural) {
+      if (component.deprecated) this.warn(path, "deprecated", "value is deprecated");
+    }
+    for (const union of unions) {
+      if (union.deprecated) this.warn(path, "deprecated", "value is deprecated");
+    }
+    for (const conditional of conditionals) {
+      if (conditional.deprecated) this.warn(path, "deprecated", "value is deprecated");
+    }
+  }
+
+  /**
+   * Selects an alternative of a union contributor against the composed
+   * value. Alternatives are validated in isolated validators so a failed
+   * branch never leaks its own diagnostics; only the aggregate union outcome
+   * is reported.
+   */
+  private validateComposedUnion(
+    path: string,
+    value: TomlValue,
+    kind: SchemaType,
+    definition: RawDefinition,
+    knownKeys: ReadonlySet<string>,
+  ): void {
+    const alternatives = definition.oneOf?.length ? definition.oneOf : (definition.anyOf ?? []);
+    let matches = 0;
+    const successes: DocumentValidator[] = [];
+    for (const reference of alternatives) {
+      let alternative: RawDefinition;
+      try {
+        alternative = this.resolveReference(reference, new Set());
+      } catch (cause) {
+        this.add(path, errorMessage(cause));
+        return;
+      }
+      const candidate = new DocumentValidator(this.#data, this.#suppressWarnings);
+      try {
+        const { kind: alternativeKind, resolved } = effectiveKind(this.#data, alternative, new Set());
+        if (!resolved || alternativeKind !== kind) {
+          candidate.add(path, `expected ${kind} alternative but found ${alternativeKind}`);
+        } else {
+          candidate.validateComposedStructure(path, value, kind, alternative, knownKeys);
+        }
+      } catch (cause) {
+        candidate.add(path, errorMessage(cause));
+      }
+      if (candidate.errors.length === 0) {
+        matches++;
+        successes.push(candidate);
+      }
+    }
+    if ((definition.oneOf?.length ?? 0) > 0) {
+      if (matches !== 1) {
+        this.add(path, `expected exactly one matching type from oneof but found ${matches}`);
+        return;
+      }
+      this.appendWarnings(successes[0]?.warnings ?? []);
+      return;
+    }
+    if (matches === 0) {
+      this.add(path, "expected at least one matching type from anyof");
+      return;
+    }
+    for (const candidate of successes) this.appendWarnings(candidate.warnings);
+  }
+
+  private validateComposedConditional(
+    path: string,
+    value: TomlValue,
+    kind: SchemaType,
+    definition: RawDefinition,
+    knownKeys: ReadonlySet<string>,
+  ): void {
+    let reference = definition.elseReference ?? "";
+    if (isTomlTable(value) && conditionMatches(value, definition.condition as Condition)) {
+      reference = definition.thenReference ?? "";
+    }
+    let branch: RawDefinition;
+    try {
+      branch = this.resolveReference(reference, new Set());
+    } catch (cause) {
+      this.add(path, errorMessage(cause));
+      return;
+    }
+    try {
+      const { kind: branchKind, resolved } = effectiveKind(this.#data, branch, new Set());
+      if (!resolved || branchKind !== kind) {
+        this.add(path, `expected ${kind} conditional branch but found ${branchKind}`);
+        return;
+      }
+      this.validateComposedStructure(path, value, kind, branch, knownKeys);
+    } catch (cause) {
+      this.add(path, errorMessage(cause));
+    }
+  }
+
+  private validateTableValue(path: string, table: TomlTable, definition: RawDefinition): void {
+    if (Object.keys(definition.children).length === 0) return;
+    this.validateTable(path, table, definition.children);
+    for (const key of Object.keys(table)) {
+      if (!Object.hasOwn(definition.children, key)) this.add(appendPath(path, key), "unexpected key");
+    }
+    this.validateSiblingRules(path, table, definition);
+  }
+
+  private validateCollection(path: string, table: TomlTable, definition: RawDefinition): void {
+    let dynamicEntries = 0;
+    for (const [key, value] of Object.entries(table)) {
+      const childPath = appendPath(path, key);
+      const fixedChild = Object.hasOwn(definition.children, key)
+        ? definition.children[key]
+        : undefined;
+      if (fixedChild !== undefined) {
+        this.validateValue(childPath, value, fixedChild);
+        continue;
+      }
+      dynamicEntries++;
+      if (definition.keyPattern && !definition.keyPattern.test(key)) {
+        this.add(childPath, `key does not match keypattern ${definition.keyPatternSource}`);
+      }
+      if (!definition.itemReference) {
+        this.add(childPath, "collection entry has no itemtype reference");
+        continue;
+      }
+      try {
+        const referenced = this.resolveReference(definition.itemReference, new Set());
+        this.validateValue(childPath, value, referenced);
+      } catch (cause) {
+        this.add(childPath, errorMessage(cause));
+      }
+    }
+    this.validateLength(path, dynamicEntries, definition);
+    for (const [key, child] of Object.entries(definition.children)) {
+      let resolved: RawDefinition;
+      try {
+        resolved = this.resolve(child, new Set());
+      } catch (cause) {
+        this.add(appendPath(path, key), errorMessage(cause));
+        continue;
+      }
+      if (!(key in table) && !resolved.optional) {
+        this.add(appendPath(path, key), "required value is missing");
+      }
+    }
+    this.validateSiblingRules(path, table, definition);
+  }
+
+  private validateArray(path: string, array: readonly TomlValue[], definition: RawDefinition): void {
+    this.validateLength(path, array.length, definition);
+    if (definition.uniqueItems) {
+      for (let index = 0; index < array.length; index++) {
+        for (let previous = 0; previous < index; previous++) {
+          if (valuesEqual(array[previous], array[index])) {
+            this.add(`${path}[${index}]`, `duplicate item equals item at index ${previous}`);
+            break;
+          }
+        }
+      }
+    }
+    if ((definition.items?.length ?? 0) > 0) {
+      this.validateTupleArray(path, array, definition);
+      return;
+    }
+    if (!definition.itemReference) {
+      if ((definition.allowedValues?.length ?? 0) === 0) return;
+      array.forEach((item, index) => this.validateAllowedValues(`${path}[${index}]`, item, definition));
+      return;
+    }
+    let itemDefinition: RawDefinition;
+    try {
+      itemDefinition = this.resolveReference(definition.itemReference, new Set());
+    } catch (cause) {
+      this.add(path, errorMessage(cause));
+      return;
+    }
+    let rangeType: SchemaType | undefined;
+    let hasRangeType = false;
+    try {
+      ({ kind: rangeType, resolved: hasRangeType } = resolveItemKind(this.#data, definition.itemReference, new Set()));
+    } catch {
+      hasRangeType = false;
+    }
+    array.forEach((item, index) => {
+      const itemPath = `${path}[${index}]`;
+      this.validateValue(itemPath, item, itemDefinition);
+      if ((definition.allowedValues?.length ?? 0) > 0) {
+        this.validateAllowedValues(itemPath, item, definition);
+      }
+      if (hasRangeType && rangeType !== undefined && isType(item, rangeType)) {
+        this.validateRange(itemPath, item, definition);
+      }
+    });
+  }
+
+  private validateSiblingRules(path: string, table: TomlTable, definition: RawDefinition): void {
+    // dependentrequired is evaluated on direct presence only. A mapping whose
+    // trigger is absent never fires, so it cannot be reached through another
+    // mapping that merely requires the trigger.
+    for (const [trigger, dependencies] of Object.entries(definition.dependentRequired ?? {})) {
+      if (!(trigger in table)) continue;
+      for (const dependency of dependencies) {
+        if (!(dependency in table)) {
+          this.add(appendPath(path, dependency), `required by dependentrequired triggered by sibling "${trigger}"`);
+        }
+      }
+    }
+    for (const group of definition.mutuallyExclusive ?? []) {
+      const present = presentGroupMembers(table, group);
+      if (present.length > 1) {
+        this.add(path, `mutuallyexclusive group has multiple present members: ${present.join(", ")}`);
+      }
+    }
+    for (const group of definition.exactlyOne ?? []) {
+      const present = presentGroupMembers(table, group);
+      if (present.length !== 1) {
+        this.add(path, `exactlyone group requires exactly one present member from: ${group.join(", ")}`);
+      }
+    }
+  }
+
+  private validateTupleArray(path: string, array: readonly TomlValue[], definition: RawDefinition): void {
+    const items = definition.items ?? [];
+    if (array.length !== items.length) {
+      this.add(path, `expected array length ${items.length} but found ${array.length}`);
+    }
+    const upperBound = Math.min(array.length, items.length);
+    for (let index = 0; index < upperBound; index++) {
+      const itemPath = `${path}[${index}]`;
+      let itemDefinition: RawDefinition;
+      try {
+        itemDefinition = this.resolveReference(items[index] as string, new Set());
+      } catch (cause) {
+        this.add(itemPath, errorMessage(cause));
+        continue;
+      }
+      this.validateValue(itemPath, array[index] as TomlValue, itemDefinition);
+    }
+  }
+
+  private validateType(path: string, value: TomlValue, typeName: SchemaType): void {
+    if (!isType(value, typeName)) {
+      this.add(path, `expected ${typeName} but found ${typeNameOf(value)}`);
+    }
+  }
+
+  private validateCommonConstraints(path: string, value: TomlValue, definition: RawDefinition): void {
+    if (Array.isArray(value)) {
+      this.validateLength(path, value.length, definition);
+      return;
+    }
+    this.validateAllowedValues(path, value, definition);
+    if ((definition.allowedValues?.length ?? 0) > 0) return;
+    this.validateRange(path, value, definition);
+    if (typeof value === "string") {
+      this.validateLength(path, scalarLength(value), definition);
+      if (definition.pattern && !definition.pattern.test(value)) {
+        this.add(path, `does not match pattern ${definition.patternSource}`);
+      }
+    }
+  }
+
+  private validateAllowedValues(path: string, value: TomlValue, definition: RawDefinition): void {
+    const allowedValues = definition.allowedValues ?? [];
+    if (allowedValues.length === 0) return;
+    if (allowedValues.some((allowed) => valuesEqual(allowed, value))) return;
+    this.add(path, "value is not in allowedvalues");
+  }
+
+  private validateRange(path: string, value: TomlValue, definition: RawDefinition): void {
+    if (definition.min !== undefined) {
+      try {
+        if (compareValues(value, definition.min) < 0) this.add(path, "value is less than min");
+      } catch (cause) {
+        this.add(path, errorMessage(cause));
+      }
+    }
+    if (definition.max !== undefined) {
+      try {
+        if (compareValues(value, definition.max) > 0) this.add(path, "value is greater than max");
+      } catch (cause) {
+        this.add(path, errorMessage(cause));
+      }
+    }
+  }
+
+  private validateLength(path: string, length: number, definition: RawDefinition): void {
+    if (definition.minLength !== undefined && length < definition.minLength) {
+      this.add(path, "length is less than minlength");
+    }
+    if (definition.maxLength !== undefined && length > definition.maxLength) {
+      this.add(path, "length is greater than maxlength");
+    }
+  }
+
+  resolve(definition: RawDefinition, seenReferences: Set<string>): RawDefinition {
+    if (!definition.reference) return definition;
+    const referenced = this.resolveReference(definition.reference, seenReferences);
+    return cloneDefinition(referenced, {
+      name: definition.name,
+      ...(definition.description ? { description: definition.description } : {}),
+      optional: definition.optional || referenced.optional,
+      allOf: [...(referenced.allOf ?? []), ...(definition.allOf ?? [])],
+      dependentRequired: mergeDependentRequired(referenced.dependentRequired, definition.dependentRequired),
+      mutuallyExclusive: [...(referenced.mutuallyExclusive ?? []), ...(definition.mutuallyExclusive ?? [])],
+      exactlyOne: [...(referenced.exactlyOne ?? []), ...(definition.exactlyOne ?? [])],
+      ...(definition.uniqueItems !== undefined ? { uniqueItems: definition.uniqueItems } : {}),
+      ...(definition.hasDefault
+        ? { defaultValue: definition.defaultValue, hasDefault: true }
+        : {}),
+      deprecated: definition.deprecated || referenced.deprecated,
+    });
+  }
+
+  resolveReference(reference: string, seenReferences: Set<string>): RawDefinition {
+    const normalized = normalizeReference(reference);
+    const builtIn = parseSchemaType(normalized);
+    if (builtIn !== undefined) {
+      return {
+        name: normalized,
+        typeName: builtIn,
+        optional: false,
+        hasDefault: false,
+        deprecated: false,
+        children: emptyRecord(),
+      };
+    }
+    if (seenReferences.has(normalized)) {
+      throw new SchemaError(`cyclic type reference: ${normalized}`);
+    }
+    const definition = this.#data.types[normalized];
+    if (!definition) {
+      throw new SchemaError(`unknown type reference: ${reference}`);
+    }
+    seenReferences.add(normalized);
+    try {
+      return this.resolve(definition, seenReferences);
+    } finally {
+      seenReferences.delete(normalized);
+    }
+  }
+
+  add(path: string, message: string): void {
+    this.errors.push({ severity: "error", code: "validation-error", path, message });
+  }
+
+  private warn(path: string, code: string, message: string): void {
+    if (this.#suppressWarnings) return;
+    this.appendWarnings([{ severity: "warning", code, path, message }]);
+  }
+
+  private appendWarnings(warnings: readonly Diagnostic[]): void {
+    for (const warning of warnings) {
+      const duplicate = this.warnings.some(
+        (existing) =>
+          existing.code === warning.code &&
+          existing.path === warning.path &&
+          existing.message === warning.message,
+      );
+      if (!duplicate) this.warnings.push(warning);
+    }
+  }
+}

--- a/reference-implementations/typescript/src/values.ts
+++ b/reference-implementations/typescript/src/values.ts
@@ -1,0 +1,276 @@
+import { TomlDate } from "smol-toml";
+import type { SchemaType } from "./builtins.js";
+
+/**
+ * The parsed TOML value model used throughout this library. Integers are
+ * `bigint` (via smol-toml's `integersAsBigInt` option) so they remain
+ * distinct from floats (`number`), matching the reference Go implementation's
+ * `int64`/`float64` split. Temporal values are `TomlDate` instances,
+ * distinguished by its `isDateTime()`/`isDate()`/`isTime()`/`isLocal()`
+ * predicates.
+ */
+export type TomlScalar = string | bigint | number | boolean | TomlDate;
+export type TomlTable = { [key: string]: TomlValue };
+export type TomlValue = TomlScalar | TomlValue[] | TomlTable;
+
+export function isTomlTable(value: unknown): value is TomlTable {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    !(value instanceof TomlDate)
+  );
+}
+
+export function isTomlArray(value: unknown): value is TomlValue[] {
+  return Array.isArray(value);
+}
+
+export function isNumeric(value: unknown): value is bigint | number {
+  return typeof value === "bigint" || typeof value === "number";
+}
+
+export function isNaNValue(value: unknown): boolean {
+  return typeof value === "number" && Number.isNaN(value);
+}
+
+/** Reports whether `value` matches the parsed-TOML kind selected by `typeName`. */
+export function isType(value: TomlValue | undefined, typeName: SchemaType): boolean {
+  switch (typeName) {
+    case "any":
+      return value !== undefined;
+    case "string":
+      return typeof value === "string";
+    case "integer":
+      return typeof value === "bigint";
+    case "float":
+      return typeof value === "number";
+    case "boolean":
+      return typeof value === "boolean";
+    case "offset-date-time":
+      return value instanceof TomlDate && value.isDateTime() && !value.isLocal();
+    case "local-date-time":
+      return value instanceof TomlDate && value.isDateTime() && value.isLocal();
+    case "local-date":
+      return value instanceof TomlDate && value.isDate();
+    case "local-time":
+      return value instanceof TomlDate && value.isTime();
+    case "array":
+      return isTomlArray(value);
+    case "table":
+    case "collection":
+      return isTomlTable(value);
+    default:
+      return false;
+  }
+}
+
+export function typeNameOf(value: TomlValue | undefined): string {
+  if (value === undefined) return "undefined";
+  if (typeof value === "string") return "string";
+  if (typeof value === "bigint") return "integer";
+  if (typeof value === "number") return "float";
+  if (typeof value === "boolean") return "boolean";
+  if (value instanceof TomlDate) {
+    if (value.isDateTime()) return value.isLocal() ? "local-date-time" : "offset-date-time";
+    if (value.isDate()) return "local-date";
+    if (value.isTime()) return "local-time";
+    return "date-time";
+  }
+  if (Array.isArray(value)) return "array";
+  return "table";
+}
+
+/* -------------------------------------------------------------------------- */
+/* Exact bigint/float numeric comparison                                      */
+/* -------------------------------------------------------------------------- */
+
+/** Decomposes a finite JS double into an exact `num / den` rational (den a power of two). */
+function floatToRational(value: number): { num: bigint; den: bigint } {
+  if (value === 0) return { num: 0n, den: 1n };
+  const buffer = new ArrayBuffer(8);
+  new Float64Array(buffer)[0] = value;
+  const bits = new BigUint64Array(buffer)[0]!;
+  const sign = (bits >> 63n) & 1n;
+  const rawExponent = Number((bits >> 52n) & 0x7ffn);
+  const rawMantissa = bits & 0xfffffffffffffn;
+  let mantissa: bigint;
+  let exponent: number;
+  if (rawExponent === 0) {
+    // Subnormal: value = mantissa * 2^-1074.
+    mantissa = rawMantissa;
+    exponent = -1074;
+  } else {
+    // Normal: value = (2^52 + mantissa) * 2^(exponent-1075).
+    mantissa = rawMantissa | (1n << 52n);
+    exponent = rawExponent - 1075;
+  }
+  if (sign === 1n) mantissa = -mantissa;
+  if (exponent >= 0) {
+    return { num: mantissa << BigInt(exponent), den: 1n };
+  }
+  return { num: mantissa, den: 1n << BigInt(-exponent) };
+}
+
+function toRational(value: bigint | number): { num: bigint; den: bigint } {
+  return typeof value === "bigint" ? { num: value, den: 1n } : floatToRational(value);
+}
+
+function signOf(value: bigint): -1 | 0 | 1 {
+  return value < 0n ? -1 : value > 0n ? 1 : 0;
+}
+
+/** Exact comparison between a bigint integer and/or a finite JS float, without rounding. */
+function compareExact(left: bigint | number, right: bigint | number): -1 | 0 | 1 {
+  const a = toRational(left);
+  const b = toRational(right);
+  return signOf(a.num * b.den - b.num * a.den);
+}
+
+function compareFloatApprox(left: number, right: number): -1 | 0 | 1 {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+function asApproxFloat(value: bigint | number): number {
+  return typeof value === "bigint" ? Number(value) : value;
+}
+
+/**
+ * Compares two TOML numeric values (integer `bigint` or float `number`) by
+ * mathematical value. Integer/integer and integer/float comparisons remain
+ * exact across the full range; NaN is unordered and throws.
+ */
+export function compareNumbers(left: bigint | number, right: bigint | number): -1 | 0 | 1 {
+  if (isNaNValue(left) || isNaNValue(right)) {
+    throw new Error("NaN is unordered");
+  }
+  if (typeof left === "bigint" && typeof right === "bigint") {
+    return left < right ? -1 : left > right ? 1 : 0;
+  }
+  const leftInfinite = typeof left === "number" && !Number.isFinite(left);
+  const rightInfinite = typeof right === "number" && !Number.isFinite(right);
+  if (leftInfinite || rightInfinite) {
+    return compareFloatApprox(asApproxFloat(left), asApproxFloat(right));
+  }
+  return compareExact(left, right);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Temporal ordering and equality                                             */
+/* -------------------------------------------------------------------------- */
+
+function requireFiniteTime(date: TomlDate): number {
+  const time = date.getTime();
+  if (Number.isNaN(time)) {
+    throw new Error("invalid temporal value");
+  }
+  return time;
+}
+
+/** Instant/lexicographic ordering, per "Minimum Value / Maximum Value" in SPEC.md. */
+function compareTemporal(left: TomlDate, right: TomlDate): -1 | 0 | 1 {
+  const a = requireFiniteTime(left);
+  const b = requireFiniteTime(right);
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/** Splits an offset date-time's canonical ISO text into local fields + a signed offset (minutes). */
+function offsetDateTimeParts(date: TomlDate): { local: string; offsetMinutes: number } {
+  const iso = date.toISOString();
+  if (iso.endsWith("Z")) {
+    return { local: iso.slice(0, -1), offsetMinutes: 0 };
+  }
+  const sign = iso.at(-6) === "-" ? -1 : 1;
+  const hours = Number(iso.slice(-5, -3));
+  const minutes = Number(iso.slice(-2));
+  return { local: iso.slice(0, -6), offsetMinutes: sign * (hours * 60 + minutes) };
+}
+
+/**
+ * Parsed Value Equality for temporal values (SPEC.md "Parsed Value Equality"):
+ * same TOML temporal type and same parsed fields, including the numeric UTC
+ * offset for an offset date-time. Equivalent spellings (`.1`/`.100`,
+ * `Z`/`+00:00`) are equal; different offsets for the same instant are not.
+ */
+function temporalValuesEqual(left: TomlDate, right: TomlDate): boolean {
+  if (left.isDateTime() !== right.isDateTime()) return false;
+  if (left.isDate() !== right.isDate()) return false;
+  if (left.isTime() !== right.isTime()) return false;
+  if (left.isLocal() !== right.isLocal()) return false;
+  if (left.isDateTime() && !left.isLocal()) {
+    const a = offsetDateTimeParts(left);
+    const b = offsetDateTimeParts(right);
+    return a.local === b.local && a.offsetMinutes === b.offsetMinutes;
+  }
+  return left.toISOString() === right.toISOString();
+}
+
+/**
+ * Parsed Value Equality (SPEC.md), used by `allowedvalues` membership,
+ * `uniqueitems`, and comparing defaults contributed by composition.
+ */
+export function valuesEqual(left: TomlValue | undefined, right: TomlValue | undefined): boolean {
+  if (isNumeric(left) && isNumeric(right)) {
+    if (isNaNValue(left) || isNaNValue(right)) {
+      return isNaNValue(left) && isNaNValue(right);
+    }
+    return compareNumbers(left, right) === 0;
+  }
+  if (left instanceof TomlDate) {
+    return right instanceof TomlDate && temporalValuesEqual(left, right);
+  }
+  if (Array.isArray(left)) {
+    if (!Array.isArray(right) || left.length !== right.length) return false;
+    return left.every((item, index) => valuesEqual(item, right[index]));
+  }
+  if (isTomlTable(left)) {
+    if (!isTomlTable(right)) return false;
+    const leftKeys = Object.keys(left);
+    const rightKeys = Object.keys(right);
+    if (leftKeys.length !== rightKeys.length) return false;
+    return leftKeys.every((key) => key in right && valuesEqual(left[key], right[key]));
+  }
+  if (typeof left === "string") return typeof right === "string" && left === right;
+  if (typeof left === "boolean") return typeof right === "boolean" && left === right;
+  return left === undefined && right === undefined;
+}
+
+/**
+ * Compares a document value against a `min`/`max` boundary. Both operands
+ * must be one comparable kind (numeric-with-numeric, or matching temporal
+ * types); throws otherwise.
+ */
+export function compareValues(value: TomlValue, boundary: TomlValue): -1 | 0 | 1 {
+  if (isNumeric(value) && isNumeric(boundary)) {
+    return compareNumbers(value, boundary);
+  }
+  if (value instanceof TomlDate && boundary instanceof TomlDate) {
+    return compareTemporal(value, boundary);
+  }
+  throw new Error(`cannot compare ${typeNameOf(value)} with boundary ${typeNameOf(boundary)}`);
+}
+
+export function boundaryMatchesType(value: TomlValue, typeName: SchemaType): boolean {
+  switch (typeName) {
+    case "integer":
+    case "float":
+      return isNumeric(value);
+    case "offset-date-time":
+      return value instanceof TomlDate && value.isDateTime() && !value.isLocal();
+    case "local-date-time":
+      return value instanceof TomlDate && value.isDateTime() && value.isLocal();
+    case "local-date":
+      return value instanceof TomlDate && value.isDate();
+    case "local-time":
+      return value instanceof TomlDate && value.isTime();
+    default:
+      return false;
+  }
+}
+
+/** Unicode-scalar-value length of a string, per "Length - minlength and maxlength" in SPEC.md. */
+export function scalarLength(value: string): number {
+  return [...value].length;
+}

--- a/reference-implementations/typescript/test/abnf.test.ts
+++ b/reference-implementations/typescript/test/abnf.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+import { BUILTIN_TYPES, DEFINITION_KEYS } from "../src/index.js";
+import { repoPath } from "./helpers.js";
+
+async function readAbnf(): Promise<string> {
+  return readFile(repoPath("toml-schema.abnf"), "utf-8");
+}
+
+function ruleExpression(ruleName: string, abnf: string): string {
+  let expression = "";
+  let inRule = false;
+  for (const line of abnf.split("\n")) {
+    if (line.startsWith(`${ruleName} =`)) {
+      const [, value] = line.split(/=(.*)/s);
+      expression += (value ?? "").trim();
+      inRule = true;
+      continue;
+    }
+    if (inRule) {
+      if (line.startsWith(" ") || line.startsWith("\t")) {
+        expression += ` ${line.trim()}`;
+        continue;
+      }
+      break;
+    }
+  }
+  return expression;
+}
+
+function alternativesFor(ruleName: string, abnf: string): string[] {
+  const expression = ruleExpression(ruleName, abnf);
+  const tokens: string[] = [];
+  for (const rawToken of expression.split("/")) {
+    const token = rawToken.trim();
+    if (token === "" || token === "version") continue;
+    tokens.push(token);
+  }
+  return tokens;
+}
+
+function builtInTypeTokens(abnf: string): string[] {
+  const tokens: string[] = [];
+  const pattern = /;\s*"([^"]+)"/;
+  for (const line of abnf.split("\n")) {
+    const match = pattern.exec(line);
+    if (!match) continue;
+    const token = match[1] as string;
+    if ((DEFINITION_KEYS as readonly string[]).includes(token)) continue;
+    tokens.push(token);
+  }
+  return tokens;
+}
+
+test("DEFINITION_KEYS matches the ABNF schema-key alternatives", async () => {
+  const abnf = await readAbnf();
+  const expected = alternativesFor("schema-key", abnf);
+  assert.deepEqual([...DEFINITION_KEYS].sort(), [...expected].sort());
+});
+
+test("BUILTIN_TYPES matches the ABNF built-in-type token comments", async () => {
+  const abnf = await readAbnf();
+  const expected = builtInTypeTokens(abnf);
+  assert.deepEqual([...BUILTIN_TYPES].sort(), [...expected].sort());
+});

--- a/reference-implementations/typescript/test/checked-in.test.ts
+++ b/reference-implementations/typescript/test/checked-in.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { loadDocument, loadSchema } from "../src/index.js";
+import { examplePath, repoPath } from "./helpers.js";
+
+test("config.toml validates against config.tosd (checked-in example)", async () => {
+  const schema = await loadSchema(repoPath("config.tosd"));
+  const result = await schema.validateFile(repoPath("config.toml"));
+  assert.equal(result.valid, true, JSON.stringify(result.errors));
+  assert.equal(result.isValid(), true);
+});
+
+test("config.tosd validates against the toml-schema.tosd self-schema", async () => {
+  const selfSchema = await loadSchema(repoPath("toml-schema.tosd"));
+  const result = await selfSchema.validateFile(repoPath("config.tosd"));
+  assert.equal(result.valid, true, JSON.stringify(result.errors));
+});
+
+test("toml-schema.tosd validates against itself", async () => {
+  const selfSchema = await loadSchema(repoPath("toml-schema.tosd"));
+  const result = await selfSchema.validateFile(repoPath("toml-schema.tosd"));
+  assert.equal(result.valid, true, JSON.stringify(result.errors));
+});
+
+test("all checked-in example schemas load without error", async () => {
+  const names = [
+    "cargo.tosd",
+    "database-conditional.tosd",
+    "gitlab-runner.tosd",
+    "hugo.tosd",
+    "netlify.tosd",
+    "pyproject.tosd",
+    "wrangler.tosd",
+  ];
+  for (const name of names) {
+    await assert.doesNotReject(
+      async () => loadSchema(examplePath(name)),
+      `expected ${name} to load without error`,
+    );
+  }
+});
+
+test("validates the Rust reference implementation's own Cargo.toml against cargo.tosd", async () => {
+  const schema = await loadSchema(examplePath("cargo.tosd"));
+  const result = await schema.validateFile(repoPath("reference-implementations", "rust", "Cargo.toml"));
+  assert.equal(result.valid, true, JSON.stringify(result.errors));
+});
+
+test("validates the two database-conditional.tosd sample documents via discovery", async () => {
+  const { schemaFromDocument } = await import("../src/index.js");
+  for (const name of ["database-postgresql.toml", "database-sqlite.toml"]) {
+    const { schema, document } = await schemaFromDocument(examplePath(name));
+    const result = schema.validate(document);
+    assert.equal(result.valid, true, `${name}: ${JSON.stringify(result.errors)}`);
+  }
+});
+
+test("loadDocument returns a plain parsed table usable with Schema.validate", async () => {
+  const schema = await loadSchema(repoPath("config.tosd"));
+  const document = await loadDocument(repoPath("config.toml"));
+  const result = schema.validate(document);
+  assert.equal(result.valid, true, JSON.stringify(result.errors));
+});

--- a/reference-implementations/typescript/test/composition.test.ts
+++ b/reference-implementations/typescript/test/composition.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { loadSchemaFromSource } from "../src/index.js";
+
+test("oneof validates against exactly one alternative type", () => {
+  const schema = loadSchemaFromSource(
+    "oneof.tosd",
+    `
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+oneof = ["string", "integer"]
+`,
+  );
+  assert.equal(schema.validate({ value: "text" }).valid, true);
+  assert.equal(schema.validate({ value: 1n }).valid, true);
+  assert.equal(schema.validate({ value: true }).valid, false);
+});
+
+test("anyof validates against at-least-one matching alternative", () => {
+  const schema = loadSchemaFromSource(
+    "anyof.tosd",
+    `
+[toml-schema]
+version = "1.0.0"
+
+[types.small]
+type = "integer"
+max = 10
+
+[types.big]
+type = "integer"
+min = 5
+
+[elements.value]
+anyof = ["types.small", "types.big"]
+`,
+  );
+  assert.equal(schema.validate({ value: 7n }).valid, true); // matches both
+  assert.equal(schema.validate({ value: 1n }).valid, true); // matches small only
+  assert.equal(schema.validate({ value: 100n }).valid, true); // matches big only
+  assert.equal(schema.validate({ value: "nope" }).valid, false);
+});
+
+test("allof composes table structure additively (closure over all contributing shapes)", () => {
+  const schema = loadSchemaFromSource(
+    "allof.tosd",
+    `
+[toml-schema]
+version = "1.0.0"
+
+[types.base]
+type = "table"
+[types.base.id]
+type = "integer"
+
+[types.extra]
+type = "table"
+[types.extra.label]
+type = "string"
+
+[elements.item]
+type = "table"
+allof = ["types.base", "types.extra"]
+`,
+  );
+  const valid = schema.validate({ item: { id: 1n, label: "x" } });
+  assert.equal(valid.valid, true, JSON.stringify(valid.errors));
+
+  const missingLabel = schema.validate({ item: { id: 1n } });
+  assert.equal(missingLabel.valid, false);
+
+  const unexpectedKey = schema.validate({ item: { id: 1n, label: "x", other: true } });
+  assert.equal(unexpectedKey.valid, false);
+});
+
+test("allof composes collection dynamic-entry constraints from every component", () => {
+  const schema = loadSchemaFromSource(
+    "allof-collection.tosd",
+    `
+[toml-schema]
+version = "1.0.0"
+
+[types.evenLength]
+type = "collection"
+itemtype = "string"
+keypattern = "^[a-z]+$"
+
+[elements.values]
+type = "collection"
+itemtype = "string"
+minlength = 1
+allof = ["types.evenLength"]
+`,
+  );
+  assert.equal(schema.validate({ values: { ok: "x" } }).valid, true);
+  assert.equal(schema.validate({ values: { BAD: "x" } }).valid, false);
+  assert.equal(schema.validate({ values: {} }).valid, false);
+});
+
+test("allof accepts oneof/anyof components with an unambiguous effective kind", () => {
+  const schema = loadSchemaFromSource(
+    "allof-union.tosd",
+    `
+[toml-schema]
+version = "1.0.0"
+
+[types.a]
+type = "integer"
+min = 0
+
+[types.b]
+type = "integer"
+max = 100
+
+[types.union]
+oneof = ["types.a"]
+
+[elements.value]
+type = "integer"
+allof = ["types.union", "types.b"]
+`,
+  );
+  assert.equal(schema.validate({ value: 5n }).valid, true);
+  assert.equal(schema.validate({ value: -1n }).valid, false);
+  assert.equal(schema.validate({ value: 500n }).valid, false);
+});
+
+test("allof rejects components whose effective kind conflicts", async () => {
+  await assert.rejects(async () => {
+    loadSchemaFromSource(
+      "allof-conflict.tosd",
+      `
+[toml-schema]
+version = "1.0.0"
+
+[types.a]
+type = "integer"
+
+[types.b]
+type = "string"
+
+[elements.value]
+type = "integer"
+allof = ["types.a", "types.b"]
+`,
+    );
+  }, /incompatible/);
+});

--- a/reference-implementations/typescript/test/conditional.test.ts
+++ b/reference-implementations/typescript/test/conditional.test.ts
@@ -1,0 +1,198 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { loadSchemaFromSource } from "../src/index.js";
+
+const conditionalSchema = `
+[toml-schema]
+version = "1.0.0"
+
+[types.postgresql]
+type = "table"
+[types.postgresql.engine]
+type = "string"
+[types.postgresql.host]
+type = "string"
+[types.postgresql.port]
+type = "integer"
+
+[types.sqlite]
+type = "table"
+[types.sqlite.engine]
+type = "string"
+[types.sqlite.path]
+type = "string"
+
+[elements.database]
+if = { key = "engine", equals = "postgresql" }
+then = "types.postgresql"
+else = "types.sqlite"
+`;
+
+test("if/then/else selects and validates the matching branch", () => {
+  const schema = loadSchemaFromSource("conditional.tosd", conditionalSchema);
+
+  const postgres = schema.validate({
+    database: { engine: "postgresql", host: "db.internal", port: 5432n },
+  });
+  assert.equal(postgres.valid, true, JSON.stringify(postgres.errors));
+
+  const sqlite = schema.validate({ database: { engine: "sqlite", path: "./data.db" } });
+  assert.equal(sqlite.valid, true, JSON.stringify(sqlite.errors));
+
+  const wrongBranch = schema.validate({ database: { engine: "sqlite", host: "db.internal" } });
+  assert.equal(wrongBranch.valid, false);
+});
+
+test("if selector uses TOML parsed-value equality, not identity", () => {
+  const schema = loadSchemaFromSource(
+    "conditional-equality.tosd",
+    `
+[toml-schema]
+version = "1.0.0"
+
+[types.enabled]
+type = "table"
+[types.enabled.flag]
+type = "boolean"
+[types.enabled.count]
+type = "integer"
+
+[types.disabled]
+type = "table"
+[types.disabled.flag]
+type = "boolean"
+
+[elements.item]
+if = { key = "count", equals = 3 }
+then = "types.enabled"
+else = "types.disabled"
+`,
+  );
+  assert.equal(schema.validate({ item: { flag: true, count: 3n } }).valid, true);
+  assert.equal(
+    schema.validate({ item: { flag: true } }).valid,
+    true,
+    "an absent discriminator key falls through to the else branch, which is satisfied here",
+  );
+  assert.equal(
+    schema.validate({ item: { count: 3n } }).valid,
+    false,
+    "count=3 selects the enabled branch, which additionally requires flag",
+  );
+});
+
+test("if selector supports an `in` alternative-set form", () => {
+  const schema = loadSchemaFromSource(
+    "conditional-in.tosd",
+    `
+[toml-schema]
+version = "1.0.0"
+
+[types.known]
+type = "table"
+[types.known.engine]
+type = "string"
+[types.known.host]
+type = "string"
+
+[types.other]
+type = "table"
+[types.other.engine]
+type = "string"
+
+[elements.database]
+if = { key = "engine", in = ["postgresql", "mysql"] }
+then = "types.known"
+else = "types.other"
+`,
+  );
+  assert.equal(schema.validate({ database: { engine: "mysql", host: "x" } }).valid, true);
+  assert.equal(schema.validate({ database: { engine: "sqlite" } }).valid, true);
+  assert.equal(schema.validate({ database: { engine: "postgresql" } }).valid, false);
+});
+
+test("a conditional discriminator key remains a legal direct child even when not a known branch key", () => {
+  const schema = loadSchemaFromSource("conditional-discriminator.tosd", conditionalSchema);
+  const result = schema.validate({
+    database: { engine: "postgresql", host: "db.internal", port: 5432n },
+  });
+  assert.equal(result.valid, true, JSON.stringify(result.errors));
+});
+
+test("rejects a conditional selector that names more than one key", async () => {
+  await assert.rejects(async () => {
+    loadSchemaFromSource(
+      "bad-conditional.tosd",
+      `
+[toml-schema]
+version = "1.0.0"
+
+[types.a]
+type = "string"
+[types.b]
+type = "string"
+
+[elements.value]
+if = { key = "engine", equals = "x", extra = 1 }
+then = "types.a"
+else = "types.b"
+`,
+    );
+  });
+});
+
+test("rejects incompatible conditional branch effective kinds", async () => {
+  await assert.rejects(async () => {
+    loadSchemaFromSource(
+      "conditional-incompatible.tosd",
+      `
+[toml-schema]
+version = "1.0.0"
+
+[types.tableBranch]
+type = "table"
+[types.tableBranch.engine]
+type = "string"
+
+[types.collectionBranch]
+type = "collection"
+itemtype = "string"
+[types.collectionBranch.engine]
+type = "string"
+
+[elements.value]
+if = { key = "engine", equals = "x" }
+then = "types.tableBranch"
+else = "types.collectionBranch"
+`,
+    );
+  }, /incompatible/);
+});
+
+test("rejects a conditional selector cycle routed back through a plain type reference", async () => {
+  await assert.rejects(async () => {
+    loadSchemaFromSource(
+      "conditional-cycle.tosd",
+      `
+[toml-schema]
+version = "1.0.0"
+
+[types.fallback]
+type = "table"
+[types.fallback.engine]
+type = "string"
+
+[types.first]
+if = { key = "engine", equals = "x" }
+then = "types.second"
+else = "types.fallback"
+
+[types.second]
+type = "types.first"
+
+[elements.value]
+type = "types.fallback"
+`,
+    );
+  }, /cyclic/);
+});

--- a/reference-implementations/typescript/test/diagnostics.test.ts
+++ b/reference-implementations/typescript/test/diagnostics.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { loadSchemaFromSource } from "../src/index.js";
+
+test("ValidationResult exposes structured errors, warnings, diagnostics, and a valid getter/method", () => {
+  const schema = loadSchemaFromSource(
+    "diagnostics.tosd",
+    `
+[toml-schema]
+version = "1.0.0"
+
+[elements.name]
+type = "string"
+
+[elements.age]
+type = "integer"
+min = 0
+`,
+  );
+
+  const result = schema.validate({ name: 42n, age: -1n } as never);
+  assert.equal(result.valid, false);
+  assert.equal(result.isValid(), false);
+  assert.ok(result.errors.length >= 2);
+  for (const error of result.errors) {
+    assert.equal(error.severity, "error");
+    assert.equal(typeof error.path, "string");
+    assert.equal(typeof error.message, "string");
+    assert.equal(typeof error.code, "string");
+  }
+  assert.deepEqual(result.diagnostics.filter((d) => d.severity === "error"), result.errors);
+  assert.deepEqual(
+    result.diagnostics.filter((d) => d.severity === "warning"),
+    result.warnings,
+  );
+});
+
+test("valid documents report an empty errors/warnings/diagnostics set", () => {
+  const schema = loadSchemaFromSource(
+    "diagnostics-valid.tosd",
+    `
+[toml-schema]
+version = "1.0.0"
+
+[elements.name]
+type = "string"
+`,
+  );
+  const result = schema.validate({ name: "ok" });
+  assert.equal(result.valid, true);
+  assert.equal(result.isValid(), true);
+  assert.deepEqual(result.errors, []);
+  assert.deepEqual(result.warnings, []);
+  assert.deepEqual(result.diagnostics, []);
+});
+
+test("unexpected top-level keys are reported against the closed root", () => {
+  const schema = loadSchemaFromSource(
+    "closed-root.tosd",
+    `
+[toml-schema]
+version = "1.0.0"
+
+[elements.name]
+type = "string"
+`,
+  );
+  const result = schema.validate({ name: "ok", extra: "nope" });
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((e) => e.path === "$.extra"));
+});

--- a/reference-implementations/typescript/test/discovery.test.ts
+++ b/reference-implementations/typescript/test/discovery.test.ts
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { schemaFromDocument, validateDocument } from "../src/index.js";
+import { tempDir, writeFixture } from "./helpers.js";
+
+test("schemaFromDocument discovers a schema via a relative [toml-schema].location", async () => {
+  const dir = await tempDir();
+  await writeFixture(
+    dir,
+    "schema.tosd",
+    `
+[toml-schema]
+version = "1.0.0"
+
+[elements.name]
+type = "string"
+`,
+  );
+  const documentPath = await writeFixture(
+    dir,
+    "document.toml",
+    `
+name = "hello"
+
+[toml-schema]
+location = "schema.tosd"
+version = "1.0.0"
+`,
+  );
+
+  const { schema, document } = await schemaFromDocument(documentPath);
+  assert.equal(schema.version, "1.0.0");
+  assert.deepEqual(schema.warnings, []);
+  const result = schema.validate(document);
+  assert.equal(result.valid, true, JSON.stringify(result.errors));
+});
+
+test("schemaFromDocument resolves a file: URI location", async () => {
+  const dir = await tempDir();
+  const schemaPath = await writeFixture(
+    dir,
+    "schema.tosd",
+    `
+[toml-schema]
+version = "1.0.0"
+
+[elements.name]
+type = "string"
+`,
+  );
+  const documentPath = await writeFixture(
+    dir,
+    "document.toml",
+    `
+name = "hello"
+
+[toml-schema]
+location = "${new URL(`file://${schemaPath}`).href}"
+version = "1.0.0"
+`,
+  );
+
+  const { schema } = await schemaFromDocument(documentPath);
+  assert.equal(schema.version, "1.0.0");
+});
+
+test("schemaFromDocument warns (but does not fail) on a minor-version mismatch sharing the major version", async () => {
+  const dir = await tempDir();
+  await writeFixture(
+    dir,
+    "schema.tosd",
+    `
+[toml-schema]
+version = "1.0.0"
+
+[elements.name]
+type = "string"
+`,
+  );
+  const documentPath = await writeFixture(
+    dir,
+    "document.toml",
+    `
+name = "hello"
+
+[toml-schema]
+location = "schema.tosd"
+version = "1.0.5"
+`,
+  );
+
+  const { schema } = await schemaFromDocument(documentPath);
+  assert.equal(schema.warnings.length, 1);
+  assert.match(schema.warnings[0] ?? "", /1\.0\.5/);
+  assert.match(schema.warnings[0] ?? "", /1\.0\.0/);
+});
+
+test("schemaFromDocument rejects a major-version mismatch", async () => {
+  const dir = await tempDir();
+  await writeFixture(
+    dir,
+    "schema.tosd",
+    `
+[toml-schema]
+version = "1.0.0"
+
+[elements.name]
+type = "string"
+`,
+  );
+  const documentPath = await writeFixture(
+    dir,
+    "document.toml",
+    `
+name = "hello"
+
+[toml-schema]
+location = "schema.tosd"
+version = "2.0.0"
+`,
+  );
+
+  await assert.rejects(() => schemaFromDocument(documentPath), /major version/);
+});
+
+test("schemaFromDocument rejects a document without [toml-schema].location", async () => {
+  const dir = await tempDir();
+  const documentPath = await writeFixture(dir, "document.toml", `name = "hello"\n`);
+  await assert.rejects(() => schemaFromDocument(documentPath), /location/);
+});
+
+test("schemaFromDocument rejects non-scalar [toml-schema] metadata values", async () => {
+  const dir = await tempDir();
+  const documentPath = await writeFixture(
+    dir,
+    "document.toml",
+    `
+[toml-schema]
+location = "schema.tosd"
+extra = { nested = true }
+`,
+  );
+  await assert.rejects(() => schemaFromDocument(documentPath), /scalar value/);
+});
+
+test("validateDocument is a one-shot discover + validate convenience helper", async () => {
+  const dir = await tempDir();
+  await writeFixture(
+    dir,
+    "schema.tosd",
+    `
+[toml-schema]
+version = "1.0.0"
+
+[elements.name]
+type = "string"
+`,
+  );
+  const documentPath = await writeFixture(
+    dir,
+    "document.toml",
+    `
+name = "hello"
+
+[toml-schema]
+location = "schema.tosd"
+version = "1.0.0"
+`,
+  );
+
+  const result = await validateDocument(documentPath);
+  assert.equal(result.valid, true, JSON.stringify(result.errors));
+});

--- a/reference-implementations/typescript/test/extract.test.ts
+++ b/reference-implementations/typescript/test/extract.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+import { extractSchemaFile, generateSchema, loadDocument, loadSchemaFromSource } from "../src/index.js";
+import { tempDir, writeFixture } from "./helpers.js";
+
+test("generateSchema infers types, homogeneous array itemtype, and sorted keys", async () => {
+  const document = {
+    zebra: "z",
+    alpha: 1n,
+    ratio: 1.5,
+    flag: true,
+    numbers: [1n, 2n, 3n],
+    mixed: [1n, "two"],
+    nested: { inner: "value" },
+  };
+  const draft = generateSchema(document);
+  assert.match(draft, /\[toml-schema\]/);
+  assert.match(draft, /version = "1\.0\.0"/);
+  assert.match(draft, /\[elements\]/);
+  assert.match(draft, /\[elements\.alpha\]\ntype = "integer"/);
+  assert.match(draft, /\[elements\.ratio\]\ntype = "float"/);
+  assert.match(draft, /\[elements\.flag\]\ntype = "boolean"/);
+  assert.match(draft, /\[elements\.zebra\]\ntype = "string"/);
+  assert.match(draft, /\[elements\.numbers\]\ntype = "array"\nitemtype = "integer"/);
+  assert.match(draft, /\[elements\.mixed\]\ntype = "array"\nitemtype = "any"/);
+  assert.match(draft, /\[elements\.nested\]\ntype = "table"/);
+  assert.match(draft, /\[elements\.nested\.inner\]\ntype = "string"/);
+
+  // alpha (a) must sort before numbers (n) before zebra (z)
+  const alphaIndex = draft.indexOf("[elements.alpha]");
+  const numbersIndex = draft.indexOf("[elements.numbers]");
+  const zebraIndex = draft.indexOf("[elements.zebra]");
+  assert.ok(alphaIndex < numbersIndex);
+  assert.ok(numbersIndex < zebraIndex);
+});
+
+test("generateSchema skips the root [toml-schema] table", () => {
+  const draft = generateSchema({ "toml-schema": { location: "x.tosd" }, name: "hi" });
+  assert.doesNotMatch(draft, /elements\."toml-schema"/);
+  assert.match(draft, /\[elements\.name\]/);
+});
+
+test("generateSchema quotes keys that are not valid bare TOML keys", () => {
+  const draft = generateSchema({ "has space": "x", 'has"quote': "y", "": "z" });
+  assert.match(draft, /\[elements\."has space"\]/);
+  assert.match(draft, /\[elements\."has\\"quote"\]/);
+  assert.match(draft, /\[elements\.""\]/);
+});
+
+test("the generated draft schema itself loads and successfully validates the source document", async () => {
+  const document = { title: "Example", count: 3n, tags: ["a", "b"] };
+  const draft = generateSchema(document);
+  const schema = loadSchemaFromSource("draft.tosd", draft);
+  const result = schema.validate(document);
+  assert.equal(result.valid, true, JSON.stringify(result.errors));
+});
+
+test("generated schemas preserve every TOML temporal kind", async () => {
+  const document = await loadDocument(
+    await writeFixture(
+      await tempDir(),
+      "temporals.toml",
+      `
+offset = 1979-05-27T07:32:00-08:00
+local_datetime = 1979-05-27T07:32:00
+local_date = 1979-05-27
+local_time = 07:32:00
+`,
+    ),
+  );
+  const draft = generateSchema(document);
+  assert.match(draft, /\[elements\.offset\]\ntype = "offset-date-time"/);
+  assert.match(draft, /\[elements\.local_datetime\]\ntype = "local-date-time"/);
+  assert.match(draft, /\[elements\.local_date\]\ntype = "local-date"/);
+  assert.match(draft, /\[elements\.local_time\]\ntype = "local-time"/);
+  assert.equal(loadSchemaFromSource("temporals.tosd", draft).validate(document).valid, true);
+});
+
+test("extractSchemaFile reads a document from disk and writes a draft schema file", async () => {
+  const dir = await tempDir();
+  const documentPath = await writeFixture(
+    dir,
+    "doc.toml",
+    `
+title = "hi"
+[owner]
+name = "Ada"
+`,
+  );
+  const schemaPath = `${dir}/generated.tosd`;
+  await extractSchemaFile(documentPath, schemaPath);
+  const written = await readFile(schemaPath, "utf-8");
+  assert.match(written, /\[elements\.title\]/);
+  assert.match(written, /\[elements\.owner\]/);
+  assert.match(written, /\[elements\.owner\.name\]/);
+
+  const schema = loadSchemaFromSource(schemaPath, written);
+  const document = await loadDocument(documentPath);
+  const result = schema.validate(document);
+  assert.equal(result.valid, true, JSON.stringify(result.errors));
+});

--- a/reference-implementations/typescript/test/helpers.ts
+++ b/reference-implementations/typescript/test/helpers.ts
@@ -1,0 +1,34 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+/** Absolute path to the repository root (four levels up from `test/`). */
+export const REPO_ROOT = path.resolve(here, "..", "..", "..");
+
+/** Scratch directory inside the package (never under `/tmp`) for generated test fixtures. */
+const SCRATCH_ROOT = path.join(here, ".scratch");
+
+/** Resolves a path relative to the repository root. */
+export function repoPath(...segments: string[]): string {
+  return path.join(REPO_ROOT, ...segments);
+}
+
+/** Resolves a path relative to `examples/` at the repository root. */
+export function examplePath(...segments: string[]): string {
+  return repoPath("examples", ...segments);
+}
+
+/** Creates a fresh scratch directory for a test, nested under `test/.scratch/`. */
+export async function tempDir(prefix = "case-"): Promise<string> {
+  await mkdir(SCRATCH_ROOT, { recursive: true });
+  return mkdtemp(path.join(SCRATCH_ROOT, prefix));
+}
+
+/** Writes `content` to `name` inside `dir` and returns the full path. */
+export async function writeFixture(dir: string, name: string, content: string): Promise<string> {
+  const target = path.join(dir, name);
+  await writeFile(target, content, "utf-8");
+  return target;
+}

--- a/reference-implementations/typescript/test/keys.test.ts
+++ b/reference-implementations/typescript/test/keys.test.ts
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { loadSchemaFromSource } from "../src/index.js";
+
+test("supports quoted, dotted, empty, and schema-keyword-named element keys", () => {
+  const schema = loadSchemaFromSource(
+    "quoted-keys.tosd",
+    `
+[toml-schema]
+version = "1.0.0"
+
+[elements.""]
+type = "string"
+
+[elements.children]
+type = "string"
+
+[elements.site."google.com"]
+type = "boolean"
+
+[elements.plugin.type]
+type = "string"
+`,
+  );
+  const result = schema.validate({
+    "": "blank",
+    children: "literal",
+    site: { "google.com": true },
+    plugin: { type: "npm" },
+  });
+  assert.equal(result.valid, true, JSON.stringify(result.errors));
+});
+
+test("disambiguates an inline-table `default` annotation from a `[..default]` child table", () => {
+  const schema = loadSchemaFromSource(
+    "default-disambiguation.tosd",
+    `
+[toml-schema]
+version = "1.0.0"
+
+[elements]
+inline = { type = "table", optional = true, default = { keep = true } }
+
+[elements.range]
+type = "table"
+optional = true
+default = { min = 1, max = 10 }
+
+[elements.range.min]
+type = "integer"
+[elements.range.max]
+type = "integer"
+
+[elements.options]
+type = "table"
+
+[elements.options.default]
+
+[elements.options.default.min]
+type = "integer"
+
+[elements.entry]
+type = "table"
+
+[elements.entry.dependentrequired]
+type = "string"
+optional = true
+`,
+  );
+
+  const inline = schema.element("inline");
+  assert.ok(inline);
+  assert.equal(inline?.hasDefault(), true);
+  assert.deepEqual(inline?.default(), { keep: true });
+  assert.equal(inline?.child("default"), undefined, "a nested inline default must not become a child");
+
+  const range = schema.element("range");
+  assert.equal(range?.hasDefault(), true);
+  assert.deepEqual(range?.default(), { min: 1n, max: 10n });
+  assert.equal(range?.child("default"), undefined);
+  assert.ok(range?.child("min"));
+
+  const options = schema.element("options");
+  assert.equal(options?.hasDefault(), false, "a [..default] table header must not become an annotation");
+  const defaultChild = options?.child("default");
+  assert.ok(defaultChild, "expected a child definition literally named default");
+  assert.ok(defaultChild?.child("min"));
+
+  const entry = schema.element("entry");
+  assert.ok(entry?.child("dependentrequired"), "expected a child definition literally named dependentrequired");
+
+  const valid = schema.validate({
+    options: { default: { min: 1n } },
+    entry: { dependentrequired: "x" },
+  });
+  assert.equal(valid.valid, true, JSON.stringify(valid.errors));
+
+  const missing = schema.validate({ options: {}, entry: {} });
+  assert.equal(missing.valid, false);
+  assert.equal(missing.errors.length, 1);
+  assert.equal(missing.errors[0]?.path, "$.options.default");
+});
+
+test("a default whose members happen to be schema-keyword-named strings is still treated as an annotation", () => {
+  const schema = loadSchemaFromSource(
+    "keyword-shaped-default.tosd",
+    `
+[toml-schema]
+version = "1.0.0"
+
+[elements.plugin]
+type = "table"
+optional = true
+default = { type = "linter", oneof = "unused", anyof = "unused" }
+`,
+  );
+  const plugin = schema.element("plugin");
+  assert.equal(plugin?.hasDefault(), true);
+  assert.deepEqual(plugin?.default(), { type: "linter", oneof: "unused", anyof: "unused" });
+});
+
+test("Object prototype names remain ordinary closed-schema keys", () => {
+  const schema = loadSchemaFromSource(
+    "prototype-keys.tosd",
+    `
+[toml-schema]
+version = "1.0.0"
+
+[elements.name]
+type = "string"
+
+[elements.server]
+type = "table"
+[elements.server.host]
+type = "string"
+
+[elements.environment]
+type = "collection"
+itemtype = "string"
+keypattern = "^[a-z]+$"
+`,
+  );
+
+  const result = schema.validate({
+    name: "example",
+    toString: 1n,
+    server: { host: "localhost", constructor: 2n },
+    environment: { valueOf: 3n },
+  });
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((error) => error.path === "$.toString"));
+  assert.ok(result.errors.some((error) => error.path === "$.server.constructor"));
+  assert.ok(result.errors.some((error) => error.path === "$.environment.valueOf"));
+});
+
+test("Object prototype names do not resolve as implicit named types", () => {
+  assert.throws(
+    () =>
+      loadSchemaFromSource(
+        "prototype-reference.tosd",
+        `
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "toString"
+`,
+      ),
+    /unknown type reference/,
+  );
+});

--- a/reference-implementations/typescript/test/structure.test.ts
+++ b/reference-implementations/typescript/test/structure.test.ts
@@ -1,0 +1,316 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { loadSchemaFromSource } from "../src/index.js";
+
+test("arrays validate itemtype homogeneously", () => {
+  const schema = loadSchemaFromSource(
+    "array.tosd",
+    `
+[toml-schema]
+version = "1.0.0"
+
+[elements.tags]
+type = "array"
+itemtype = "string"
+`,
+  );
+  assert.equal(schema.validate({ tags: ["a", "b"] }).valid, true);
+  assert.equal(schema.validate({ tags: ["a", 1n] }).valid, false);
+});
+
+test("tuple arrays validate items positionally by the `items` property", () => {
+  const schema = loadSchemaFromSource(
+    "tuple.tosd",
+    `
+[toml-schema]
+version = "1.0.0"
+
+[elements.point]
+type = "array"
+items = ["integer", "integer", "string"]
+`,
+  );
+  assert.equal(schema.validate({ point: [1n, 2n, "label"] }).valid, true);
+  assert.equal(schema.validate({ point: [1n, "x", "label"] }).valid, false);
+  assert.equal(schema.validate({ point: [1n, 2n] }).valid, false, "wrong arity must fail");
+  assert.equal(schema.validate({ point: [1n, 2n, "label", "extra"] }).valid, false);
+});
+
+test("collections validate dynamic-key tables against itemtype and keypattern", () => {
+  const schema = loadSchemaFromSource(
+    "collection.tosd",
+    `
+[toml-schema]
+version = "1.0.0"
+
+[elements.servers]
+type = "collection"
+itemtype = "string"
+keypattern = "^[a-z][a-z0-9_]*$"
+minlength = 1
+`,
+  );
+  assert.equal(schema.validate({ servers: { alpha: "1.2.3.4" } }).valid, true);
+  assert.equal(schema.validate({ servers: {} }).valid, false, "minlength=1 requires at least one entry");
+  assert.equal(schema.validate({ servers: { Bad: "x" } }).valid, false, "keypattern rejects uppercase");
+  assert.equal(schema.validate({ servers: { ok: 1n } }).valid, false, "itemtype rejects non-strings");
+});
+
+test("collections with fixed children plus a dynamic itemtype validate both simultaneously", () => {
+  const schema = loadSchemaFromSource(
+    "mixed-collection.tosd",
+    `
+[toml-schema]
+version = "1.0.0"
+
+[elements.libraries]
+type = "collection"
+itemtype = "types.library"
+
+[types.library]
+type = "table"
+[types.library.name]
+type = "string"
+[types.library.version]
+type = "string"
+`,
+  );
+  const result = schema.validate({
+    libraries: { lib1: { name: "gcc", version: "10.2" }, lib2: { name: "make", version: "4.0" } },
+  });
+  assert.equal(result.valid, true, JSON.stringify(result.errors));
+});
+
+test("dependentrequired: presence of a trigger key requires its dependency keys", () => {
+  const schema = loadSchemaFromSource(
+    "dependent-required.tosd",
+    `
+[toml-schema]
+version = "1.0.0"
+
+[elements.settings]
+type = "table"
+dependentrequired = { branch = ["git"], git = ["url"] }
+[elements.settings.git]
+type = "string"
+optional = true
+[elements.settings.url]
+type = "string"
+optional = true
+[elements.settings.branch]
+type = "string"
+optional = true
+`,
+  );
+  assert.equal(
+    schema.validate({ settings: { branch: "main", git: "repo", url: "origin" } }).valid,
+    true,
+  );
+  assert.equal(
+    schema.validate({ settings: { branch: "main" } }).valid,
+    false,
+    "branch requires git (direct dependency)",
+  );
+  assert.equal(
+    schema.validate({ settings: { branch: "main", git: "repo" } }).valid,
+    false,
+    "dependentrequired does not chain transitively: git's own dependency (url) is still enforced directly",
+  );
+});
+
+test("mutuallyexclusive: at most one member of a group may be present", () => {
+  const schema = loadSchemaFromSource(
+    "mutually-exclusive.tosd",
+    `
+[toml-schema]
+version = "1.0.0"
+
+[elements.source]
+type = "table"
+mutuallyexclusive = [["git", "path"]]
+[elements.source.git]
+type = "string"
+optional = true
+[elements.source.path]
+type = "string"
+optional = true
+`,
+  );
+  assert.equal(schema.validate({ source: { git: "repo" } }).valid, true);
+  assert.equal(schema.validate({ source: {} }).valid, true);
+  assert.equal(schema.validate({ source: { git: "repo", path: "." } }).valid, false);
+});
+
+test("exactlyone: exactly one member of a group must be present", () => {
+  const schema = loadSchemaFromSource(
+    "exactly-one.tosd",
+    `
+[toml-schema]
+version = "1.0.0"
+
+[elements.body]
+type = "table"
+exactlyone = [["file", "text"]]
+[elements.body.file]
+type = "string"
+optional = true
+[elements.body.text]
+type = "string"
+optional = true
+`,
+  );
+  assert.equal(schema.validate({ body: { file: "README.md" } }).valid, true);
+  assert.equal(schema.validate({ body: {} }).valid, false);
+  assert.equal(schema.validate({ body: { file: "a", text: "b" } }).valid, false);
+});
+
+test("uniqueitems rejects duplicate array entries using TOML parsed-value equality", () => {
+  const schema = loadSchemaFromSource(
+    "unique-items.tosd",
+    `
+[toml-schema]
+version = "1.0.0"
+
+[elements.tags]
+type = "array"
+itemtype = "integer"
+uniqueitems = true
+`,
+  );
+  assert.equal(schema.validate({ tags: [1n, 2n, 3n] }).valid, true);
+  assert.equal(schema.validate({ tags: [1n, 2n, 1n] }).valid, false);
+});
+
+test("uniqueitems compares tables recursively using structural TOML equality", () => {
+  const schema = loadSchemaFromSource(
+    "unique-items-tables.tosd",
+    `
+[toml-schema]
+version = "1.0.0"
+
+[elements.points]
+type = "array"
+itemtype = "table"
+uniqueitems = true
+`,
+  );
+  assert.equal(
+    schema.validate({ points: [{ x: 1n }, { x: 2n }] }).valid,
+    true,
+  );
+  assert.equal(
+    schema.validate({ points: [{ x: 1n }, { x: 1n }] }).valid,
+    false,
+    "structurally identical tables are duplicates",
+  );
+});
+
+test("default values are validated at schema-load time but never materialize into documents", () => {
+  const schema = loadSchemaFromSource(
+    "defaults.tosd",
+    `
+[toml-schema]
+version = "1.0.0"
+
+[types.base]
+type = "integer"
+min = 1
+default = 2
+
+[elements.inherited]
+type = "types.base"
+optional = true
+
+[elements.local]
+type = "types.base"
+default = 3
+optional = true
+`,
+  );
+  const inherited = schema.element("inherited");
+  assert.ok(inherited);
+  assert.equal(inherited?.hasDefault(), true);
+  assert.equal(inherited?.default(), 2n);
+
+  const local = schema.element("local");
+  assert.equal(local?.hasDefault(), true);
+  assert.equal(local?.default(), 3n);
+
+  const document: Record<string, unknown> = {};
+  const result = schema.validate(document as never);
+  assert.equal(result.valid, true, JSON.stringify(result.errors));
+  assert.equal(Object.keys(document).length, 0, "validation must not mutate the document");
+});
+
+test("rejects a schema-declared default that fails its own constraints", async () => {
+  await assert.rejects(async () => {
+    loadSchemaFromSource(
+      "invalid-default.tosd",
+      `
+[toml-schema]
+version = "1.0.0"
+
+[elements.count]
+type = "integer"
+min = 2
+default = 1
+`,
+    );
+  }, /default is invalid/);
+});
+
+test("rejects conflicting inherited defaults composed via allof", async () => {
+  await assert.rejects(async () => {
+    loadSchemaFromSource(
+      "conflicting-default.tosd",
+      `
+[toml-schema]
+version = "1.0.0"
+
+[types.a]
+type = "integer"
+default = 1
+
+[types.b]
+type = "integer"
+default = 2
+
+[elements.value]
+type = "integer"
+allof = ["types.a", "types.b"]
+`,
+    );
+  }, /conflicting inherited defaults/);
+});
+
+test("deprecated produces a structured, branch-local warning without affecting validity", () => {
+  const schema = loadSchemaFromSource(
+    "deprecated.tosd",
+    `
+[toml-schema]
+version = "1.0.0"
+
+[types.legacy]
+type = "string"
+pattern = "^old$"
+deprecated = true
+
+[types.current]
+type = "integer"
+
+[elements.value]
+oneof = ["types.legacy", "types.current"]
+`,
+  );
+  const result = schema.validate({ value: "old" });
+  assert.equal(result.valid, true);
+  assert.equal(result.warnings.length, 1);
+  const warning = result.warnings[0];
+  assert.equal(warning?.severity, "warning");
+  assert.equal(warning?.code, "deprecated");
+  assert.equal(warning?.path, "$.value");
+
+  const nonDeprecatedBranch = schema.validate({ value: 1n });
+  assert.equal(nonDeprecatedBranch.valid, true);
+  assert.equal(nonDeprecatedBranch.warnings.length, 0);
+});

--- a/reference-implementations/typescript/test/values.test.ts
+++ b/reference-implementations/typescript/test/values.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { TomlDate } from "smol-toml";
+import { loadSchemaFromSource } from "../src/index.js";
+
+const valueSemanticsSchema = `
+[toml-schema]
+version = "1.0.0"
+
+[elements.precise]
+type = "integer"
+allowedvalues = [ 9007199254740992 ]
+
+[elements.mixed]
+type = "integer"
+max = 9007199254740992.0
+
+[elements.nanValue]
+type = "float"
+allowedvalues = [ nan ]
+
+[elements.nanRange]
+type = "float"
+min = 0.0
+
+[elements.zero]
+type = "float"
+allowedvalues = [ -0.0 ]
+
+[elements.instant]
+type = "offset-date-time"
+min = 2024-01-01T00:00:00Z
+max = 2024-01-01T00:00:00Z
+
+[elements.instantMember]
+type = "offset-date-time"
+allowedvalues = [ 2024-01-01T00:00:00Z ]
+
+[elements.localMember]
+type = "local-time"
+allowedvalues = [ 12:00:00.1 ]
+
+[elements.localDateTime]
+type = "local-date-time"
+max = 2024-01-01T00:00:00.100
+
+[elements.localDate]
+type = "local-date"
+max = 2024-01-01
+
+[elements.localTime]
+type = "local-time"
+max = 12:00:00.100
+`;
+
+test("preserves exact bigint-vs-float numeric precision beyond 2^53", () => {
+  const schema = loadSchemaFromSource("value-semantics.tosd", valueSemanticsSchema);
+
+  const valid = schema.validate({
+    precise: 9007199254740992n,
+    mixed: 9007199254740992n,
+    nanValue: NaN,
+    nanRange: 0.0,
+    zero: -0.0,
+    instant: new TomlDate("2023-12-31T19:00:00-05:00"),
+    instantMember: new TomlDate("2024-01-01T00:00:00+00:00"),
+    localMember: new TomlDate("12:00:00.100"),
+    localDateTime: new TomlDate("2024-01-01T00:00:00.100"),
+    localDate: new TomlDate("2024-01-01"),
+    localTime: new TomlDate("12:00:00.100"),
+  });
+  assert.equal(valid.valid, true, JSON.stringify(valid.errors));
+});
+
+test("rejects out-of-range/imprecise values across every temporal and numeric kind", () => {
+  const schema = loadSchemaFromSource("value-semantics.tosd", valueSemanticsSchema);
+
+  const invalid = schema.validate({
+    precise: 9007199254740993n,
+    mixed: 9007199254740993n,
+    nanValue: 0.0,
+    nanRange: NaN,
+    zero: 1.0,
+    instant: new TomlDate("2024-01-01T00:00:00.001Z"),
+    instantMember: new TomlDate("2023-12-31T19:00:00-05:00"),
+    localMember: new TomlDate("12:00:00.101"),
+    localDateTime: new TomlDate("2024-01-01T00:00:00.101"),
+    localDate: new TomlDate("2024-01-02"),
+    localTime: new TomlDate("12:00:00.101"),
+  });
+  assert.equal(invalid.valid, false);
+  const paths = new Set(invalid.errors.map((e) => e.path));
+  for (const expected of [
+    "$.precise",
+    "$.mixed",
+    "$.nanValue",
+    "$.nanRange",
+    "$.zero",
+    "$.instant",
+    "$.instantMember",
+    "$.localMember",
+    "$.localDateTime",
+    "$.localDate",
+    "$.localTime",
+  ]) {
+    assert.ok(paths.has(expected), `expected an error at ${expected}, got ${JSON.stringify([...paths])}`);
+  }
+});
+
+test("rejects a schema whose allowedvalues/max comparison would require lossy float rounding", async () => {
+  await assert.rejects(async () => {
+    loadSchemaFromSource(
+      "value-semantics-malformed.tosd",
+      `
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "integer"
+allowedvalues = [ 9007199254740993 ]
+max = 9007199254740992.0
+`,
+    );
+  });
+});

--- a/reference-implementations/typescript/tsconfig.build.json
+++ b/reference-implementations/typescript/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/reference-implementations/typescript/tsconfig.json
+++ b/reference-implementations/typescript/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "verbatimModuleSyntax": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/reference-implementations/typescript/tsconfig.test.json
+++ b/reference-implementations/typescript/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/scripts/render-docs.mjs
+++ b/scripts/render-docs.mjs
@@ -14,7 +14,9 @@ const repositoryDirectories = new Set([
   "reference-implementations/java",
   "reference-implementations/go",
   "reference-implementations/dotnet",
+  "reference-implementations/python",
   "reference-implementations/rust",
+  "reference-implementations/typescript",
 ]);
 const pages = [
   {
@@ -29,7 +31,7 @@ const pages = [
     source: "REFERENCE_IMPLEMENTATIONS.md",
     output: join("implementations", "index.html"),
     description:
-      "Build and use the Java, Go, .NET, and Rust TOML Schema reference libraries and the canonical Rust command-line interface.",
+      "Build and use the Java, Go, .NET, Python, Rust, and Node.js/TypeScript TOML Schema reference libraries and the canonical Rust command-line interface.",
     canonical: "https://toml-schema.org/implementations/",
     activeNav: "implementations",
   },


### PR DESCRIPTION
TOML Schema needs a Node.js library for JavaScript and TypeScript consumers that matches the existing cross-language conformance contract. This adds an ESM reference implementation written with TypeScript 6 and integrates it alongside the existing Java, Go, .NET, Python, and Rust implementations.

## What changed

- Adds `@tomlschema/toml-schema` with schema loading, document validation, schema discovery, and starter-schema extraction.
- Implements the TOML Schema 1.0 semantic vocabulary, including unions, composition, conditionals, collections, sibling rules, defaults, deprecation warnings, and structured diagnostics.
- Uses `smol-toml` with bigint and temporal-value preservation so TOML integer, float, and date/time kinds remain distinguishable.
- Adds 59 tests covering checked-in examples, self-schema validation, ABNF vocabulary conformance, discovery, extraction, diagnostics, and semantic edge cases.
- Adds TypeScript to CI, the aggregate build, repository documentation, and the unified website implementation listings.

## Validation

- `npm --prefix reference-implementations/typescript run typecheck`
- `npm --prefix reference-implementations/typescript test`
- `npm --prefix reference-implementations/typescript run build`
- Website documentation render and static design checks