### PR TITLE
Align validation report margins with front page

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -625,10 +625,6 @@ footer {
 }
 
 /* Real-world validation report */
-.report {
-  margin: 0 auto;
-  max-width: 960px;
-}
 .report-hero h1 {
   max-width: 13ch;
 }


### PR DESCRIPTION
The validation report had an additional width constraint that made its horizontal margins differ from the front page. Remove the report-only container cap so both pages use the shared site layout.