### PR TITLE
Rename canonical Rust CLI to tosd

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,9 +6,9 @@
 - Single Java test method: `mvn -f reference-implementations/java/pom.xml -Dtest=TomlSchemaTest#validatesCheckedInExample test`
 - Full Go test suite: `go -C reference-implementations/go test ./...`
 - Full Rust test suite: `cargo test --manifest-path reference-implementations/rust/Cargo.toml`
-- Build the canonical Rust CLI: `cargo build --manifest-path reference-implementations/rust/Cargo.toml --release`
-- Validate with an explicit schema: `cargo run --quiet --manifest-path reference-implementations/rust/Cargo.toml -- validate config.tosd config.toml`
-- Validate using `[toml-schema].location`: `cargo run --quiet --manifest-path reference-implementations/rust/Cargo.toml -- validate config.toml`
+- Build the canonical Rust CLI: `cargo build --manifest-path reference-implementations/rust/Cargo.toml --release --bin tosd`
+- Validate with an explicit schema: `cargo run --quiet --manifest-path reference-implementations/rust/Cargo.toml --bin tosd -- validate config.tosd config.toml`
+- Validate using `[toml-schema].location`: `cargo run --quiet --manifest-path reference-implementations/rust/Cargo.toml --bin tosd -- validate config.toml`
 
 No separate lint command is defined.
 
@@ -24,7 +24,7 @@ This repository contains the TOML Schema specification/proposal plus reference i
 - `config.tosd` and `config.toml` are the worked example pair: `config.toml` declares `[toml-schema] location = "config.tosd"`, and `config.tosd` describes the allowed document shape.
 - `reference-implementations/java/src/main/java/org/tomlschema` contains the Java reference implementation under the `org.tomlschema` package with Maven coordinate `org.tomlschema:toml-schema`.
 - `reference-implementations/go` is the `tomlschema.org/go` importable Go package.
-- `reference-implementations/rust` provides both the `toml_schema` Rust library and the canonical `toml-schema` CLI.
+- `reference-implementations/rust` provides both the `toml_schema` Rust library and the canonical `tosd` CLI.
 - `reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java` covers the checked-in examples, self-schema validation, and validation errors.
 - Java, Go, .NET, and Rust ABNF conformance tests read `toml-schema.abnf` and check implementation schema properties and built-in type names against it.
 

--- a/.github/workflows/reference-implementations.yml
+++ b/.github/workflows/reference-implementations.yml
@@ -115,25 +115,25 @@ jobs:
 
       - name: Build canonical CLI
         working-directory: reference-implementations/rust
-        run: cargo build --locked --release
+        run: cargo build --locked --release --bin tosd
 
       - name: Validate checked-in example with explicit schema
-        run: reference-implementations/rust/target/release/toml-schema validate config.tosd config.toml
+        run: reference-implementations/rust/target/release/tosd validate config.tosd config.toml
 
       - name: Validate checked-in example with schema reference
-        run: reference-implementations/rust/target/release/toml-schema validate config.toml
+        run: reference-implementations/rust/target/release/tosd validate config.toml
 
       - name: Validate example schema against self-schema
-        run: reference-implementations/rust/target/release/toml-schema validate toml-schema.tosd config.tosd
+        run: reference-implementations/rust/target/release/tosd validate toml-schema.tosd config.tosd
 
       - name: Validate self-schema against itself
-        run: reference-implementations/rust/target/release/toml-schema validate toml-schema.tosd toml-schema.tosd
+        run: reference-implementations/rust/target/release/tosd validate toml-schema.tosd toml-schema.tosd
 
       - name: Extract schema from checked-in example
-        run: reference-implementations/rust/target/release/toml-schema extract config.toml /tmp/config.generated.tosd
+        run: reference-implementations/rust/target/release/tosd extract config.toml /tmp/config.generated.tosd
 
       - name: Validate checked-in example with extracted schema
-        run: reference-implementations/rust/target/release/toml-schema validate /tmp/config.generated.tosd config.toml
+        run: reference-implementations/rust/target/release/tosd validate /tmp/config.generated.tosd config.toml
 
   typescript:
     name: TypeScript reference implementation

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,4 +1,4 @@
-name: TOML Schema CLI release
+name: tosd CLI release
 
 on:
   push:
@@ -42,7 +42,7 @@ jobs:
         run: cargo test --locked
 
   build:
-    name: Build TOML Schema CLI (${{ matrix.asset }})
+    name: Build tosd CLI (${{ matrix.asset }})
     needs: test
     strategy:
       fail-fast: false
@@ -50,16 +50,16 @@ jobs:
         include:
           - os: ubuntu-latest
             asset: linux-x86_64
-            binary: toml-schema
+            binary: tosd
           - os: macos-15-intel
             asset: macos-x86_64
-            binary: toml-schema
+            binary: tosd
           - os: macos-15
             asset: macos-arm64
-            binary: toml-schema
+            binary: tosd
           - os: windows-latest
             asset: windows-x86_64
-            binary: toml-schema.exe
+            binary: tosd.exe
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -78,8 +78,8 @@ jobs:
           release_version="${RELEASE_TAG##*/}"
           release_version="${release_version#rust-v}"
           release_version="${release_version#v}"
-          asset_name="toml-schema-${release_version}-${{ matrix.asset }}"
-          cargo build --locked --release
+          asset_name="tosd-${release_version}-${{ matrix.asset }}"
+          cargo build --locked --release --bin tosd
 
           "./target/release/${{ matrix.binary }}" validate ../../config.tosd ../../config.toml
           "./target/release/${{ matrix.binary }}" validate ../../config.toml
@@ -93,12 +93,12 @@ jobs:
       - name: Upload archive
         uses: actions/upload-artifact@v4
         with:
-          name: toml-schema-${{ matrix.asset }}
+          name: tosd-${{ matrix.asset }}
           path: reference-implementations/rust/dist/*.tar.gz
           if-no-files-found: error
 
   publish:
-    name: Publish TOML Schema CLI release assets
+    name: Publish tosd CLI release assets
     needs: build
     runs-on: ubuntu-latest
 
@@ -115,7 +115,7 @@ jobs:
           release_version="${release_version#rust-v}"
           release_version="${release_version#v}"
           cd dist
-          shasum -a 256 *.tar.gz > "toml-schema-${release_version}-SHA256SUMS.txt"
+          shasum -a 256 *.tar.gz > "tosd-${release_version}-SHA256SUMS.txt"
 
       - name: Upload release assets
         uses: softprops/action-gh-release@v2

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ type = "table"
 
 Java, Go, .NET, Python, Rust, and Node.js/TypeScript reference libraries live
 under `reference-implementations/`. The Rust implementation provides the
-canonical `toml-schema` CLI. See
+canonical `tosd` CLI. See
 [Reference implementations](REFERENCE_IMPLEMENTATIONS.md) for implementation
 status, CLI usage, schema extraction, and conformance expectations.
 

--- a/REFERENCE_IMPLEMENTATIONS.md
+++ b/REFERENCE_IMPLEMENTATIONS.md
@@ -1,7 +1,7 @@
 # Reference Implementations
 
 Build and use the TOML Schema reference libraries in Java, Go, .NET, Python,
-Rust, and Node.js/TypeScript. Rust also provides the canonical `toml-schema`
+Rust, and Node.js/TypeScript. Rust also provides the canonical `tosd`
 command-line interface for validation, schema discovery through
 `[toml-schema].location`, and starter-schema extraction.
 
@@ -218,7 +218,7 @@ match the grammar.
 
 The Rust reference implementation uses the [`toml`](https://crates.io/crates/toml)
 crate to parse TOML and validates the parsed data model against a `.tosd` schema.
-It provides both a library and the canonical `toml-schema` CLI.
+It provides both a library and the canonical `tosd` CLI.
 
 Run the Rust test suite:
 
@@ -229,7 +229,7 @@ cargo test --manifest-path reference-implementations/rust/Cargo.toml
 Build the CLI binary:
 
 ```shell
-cargo build --manifest-path reference-implementations/rust/Cargo.toml --release
+cargo build --manifest-path reference-implementations/rust/Cargo.toml --release --bin tosd
 ```
 
 For document-driven lookup, the CLI resolves a relative
@@ -241,31 +241,31 @@ files and explicitly rejects unsupported URI schemes.
 Validate with an explicit schema:
 
 ```shell
-cargo run --quiet --manifest-path reference-implementations/rust/Cargo.toml -- validate config.tosd config.toml
+cargo run --quiet --manifest-path reference-implementations/rust/Cargo.toml --bin tosd -- validate config.tosd config.toml
 ```
 
 Validate using `[toml-schema].location` from the TOML document:
 
 ```shell
-cargo run --quiet --manifest-path reference-implementations/rust/Cargo.toml -- validate config.toml
+cargo run --quiet --manifest-path reference-implementations/rust/Cargo.toml --bin tosd -- validate config.toml
 ```
 
 Validate the example schema against the TOML Schema self-schema:
 
 ```shell
-cargo run --quiet --manifest-path reference-implementations/rust/Cargo.toml -- validate toml-schema.tosd config.tosd
+cargo run --quiet --manifest-path reference-implementations/rust/Cargo.toml --bin tosd -- validate toml-schema.tosd config.tosd
 ```
 
 Validate the TOML Schema self-schema against itself:
 
 ```shell
-cargo run --quiet --manifest-path reference-implementations/rust/Cargo.toml -- validate toml-schema.tosd toml-schema.tosd
+cargo run --quiet --manifest-path reference-implementations/rust/Cargo.toml --bin tosd -- validate toml-schema.tosd toml-schema.tosd
 ```
 
 Extract a schema from a sample TOML document:
 
 ```shell
-cargo run --quiet --manifest-path reference-implementations/rust/Cargo.toml -- extract config.toml /tmp/config.generated.tosd
+cargo run --quiet --manifest-path reference-implementations/rust/Cargo.toml --bin tosd -- extract config.toml /tmp/config.generated.tosd
 ```
 
 Use the library API:

--- a/examples/README.md
+++ b/examples/README.md
@@ -72,7 +72,7 @@ You can validate a TOML file against any of these schemas using the canonical
 Rust CLI. From the repository root:
 
 ```bash
-cargo run --quiet --manifest-path reference-implementations/rust/Cargo.toml -- \
+cargo run --quiet --manifest-path reference-implementations/rust/Cargo.toml --bin tosd -- \
     validate examples/pyproject.tosd path/to/your/pyproject.toml
 ```
 

--- a/reference-implementations/build-all.sh
+++ b/reference-implementations/build-all.sh
@@ -26,7 +26,7 @@ run_step "Building Python reference implementation" \
     python3 -m compileall -q "$script_dir/python/src"
 
 run_step "Building Rust reference implementation" \
-    cargo build --locked --release --manifest-path "$script_dir/rust/Cargo.toml"
+    cargo build --locked --release --manifest-path "$script_dir/rust/Cargo.toml" --bin tosd
 
 run_step "Installing TypeScript reference implementation dependencies" \
     npm --prefix "$script_dir/typescript" ci

--- a/reference-implementations/rust/Cargo.toml
+++ b/reference-implementations/rust/Cargo.toml
@@ -13,7 +13,7 @@ name = "toml_schema"
 path = "src/lib.rs"
 
 [[bin]]
-name = "toml-schema"
+name = "tosd"
 path = "src/main.rs"
 
 [dependencies]

--- a/reference-implementations/rust/README.md
+++ b/reference-implementations/rust/README.md
@@ -3,11 +3,11 @@
 Rust reference implementation targeting the current, unreleased
 [TOML Schema 1.0.0](../../SPEC.md). It parses TOML with the
 [`toml`](https://crates.io/crates/toml) crate (`1`, TOML 1.0), provides the
-canonical `toml-schema` CLI, and can be used as a library.
+canonical `tosd` CLI, and can be used as a library.
 
 - Crate: `toml-schema`
 - Library name: `toml_schema`
-- Binary name: `toml-schema`
+- Binary name: `tosd`
 
 All commands below assume you run them from the repository root.
 
@@ -22,7 +22,7 @@ cargo test --manifest-path reference-implementations/rust/Cargo.toml
 Build the CLI binary (release):
 
 ```shell
-cargo build --manifest-path reference-implementations/rust/Cargo.toml --release
+cargo build --manifest-path reference-implementations/rust/Cargo.toml --release --bin tosd
 ```
 
 ## CLI usage
@@ -30,31 +30,31 @@ cargo build --manifest-path reference-implementations/rust/Cargo.toml --release
 Validate with an explicit schema:
 
 ```shell
-cargo run --quiet --manifest-path reference-implementations/rust/Cargo.toml -- validate config.tosd config.toml
+cargo run --quiet --manifest-path reference-implementations/rust/Cargo.toml --bin tosd -- validate config.tosd config.toml
 ```
 
 Validate using `[toml-schema].location` from the TOML document:
 
 ```shell
-cargo run --quiet --manifest-path reference-implementations/rust/Cargo.toml -- validate config.toml
+cargo run --quiet --manifest-path reference-implementations/rust/Cargo.toml --bin tosd -- validate config.toml
 ```
 
 Validate the example schema against the TOML Schema self-schema:
 
 ```shell
-cargo run --quiet --manifest-path reference-implementations/rust/Cargo.toml -- validate toml-schema.tosd config.tosd
+cargo run --quiet --manifest-path reference-implementations/rust/Cargo.toml --bin tosd -- validate toml-schema.tosd config.tosd
 ```
 
 Validate the TOML Schema self-schema against itself:
 
 ```shell
-cargo run --quiet --manifest-path reference-implementations/rust/Cargo.toml -- validate toml-schema.tosd toml-schema.tosd
+cargo run --quiet --manifest-path reference-implementations/rust/Cargo.toml --bin tosd -- validate toml-schema.tosd toml-schema.tosd
 ```
 
 Extract a starter schema from a sample TOML document:
 
 ```shell
-cargo run --quiet --manifest-path reference-implementations/rust/Cargo.toml -- extract config.toml config.generated.tosd
+cargo run --quiet --manifest-path reference-implementations/rust/Cargo.toml --bin tosd -- extract config.toml config.generated.tosd
 ```
 
 ## Library usage

--- a/reference-implementations/rust/src/cli.rs
+++ b/reference-implementations/rust/src/cli.rs
@@ -123,13 +123,7 @@ fn report(
 
 fn usage(stream: &mut dyn Write) {
     let _ = writeln!(stream, "Usage:");
-    let _ = writeln!(
-        stream,
-        "  toml-schema validate <schema.tosd> <document.toml>"
-    );
-    let _ = writeln!(stream, "  toml-schema validate <document.toml>");
-    let _ = writeln!(
-        stream,
-        "  toml-schema extract <document.toml> <schema.tosd>"
-    );
+    let _ = writeln!(stream, "  tosd validate <schema.tosd> <document.toml>");
+    let _ = writeln!(stream, "  tosd validate <document.toml>");
+    let _ = writeln!(stream, "  tosd extract <document.toml> <schema.tosd>");
 }

--- a/reference-implementations/rust/tests/integration.rs
+++ b/reference-implementations/rust/tests/integration.rs
@@ -4,6 +4,7 @@
 use std::fs;
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use toml_schema::cli::run;
 use toml_schema::schema::{schema_from_document, Schema, ValidationResult};
@@ -45,6 +46,19 @@ fn capture(args: &[&str]) -> (u8, String, String) {
         String::from_utf8(out.into_inner()).expect("stdout utf-8"),
         String::from_utf8(err.into_inner()).expect("stderr utf-8"),
     )
+}
+
+#[test]
+fn canonical_binary_is_named_tosd() {
+    let output = Command::new(env!("CARGO_BIN_EXE_tosd"))
+        .arg("--help")
+        .output()
+        .expect("run tosd binary");
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout utf-8");
+    assert!(stdout.contains("tosd validate"));
+    assert!(!stdout.contains("toml-schema validate"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Rename the canonical Rust executable from `toml-schema` to `tosd` before the 1.0 release so the command matches the `.tosd` schema format without carrying a compatibility alias.

- changes the sole Cargo binary target and CLI help text to `tosd`
- updates documentation, repository instructions, CI smoke commands, and aggregate builds
- renames release binaries, archives, workflow artifacts, and checksum files
- adds integration coverage through `CARGO_BIN_EXE_tosd` and confirms the old command spelling is not advertised
- preserves the `toml-schema` Rust package, `toml_schema` library, TOML Schema product name, and schema metadata/file names

## Validation

- `cargo test --locked --manifest-path reference-implementations/rust/Cargo.toml`
- locked release build with `--bin tosd`
- explicit-schema, schema-discovery, self-schema, extraction, and extracted-schema CLI smoke checks
- Cargo metadata verification that `tosd` is the only binary target
- `cargo fmt --check`