### PR TITLE
Move community tooling to the Editor page

### DIFF
--- a/docs/editor/index.html
+++ b/docs/editor/index.html
@@ -138,6 +138,14 @@
           <a class="button-secondary" href="https://github.com/brunoborges/toml-schema/tree/main/.github/extensions/tosd-editor">Inspect the extension source</a>
         </div>
       </section>
+
+      <section class="section" aria-labelledby="community-tooling-title">
+        <h2 id="community-tooling-title">Community tooling</h2>
+        <p class="section-intro">
+          The third-party <a href="https://github.com/jcbyte/toml-schema-lsp">TOML Schema LSP and VS Code extension</a>
+          provides real-time validation using local <code>.tosd</code> schemas.
+        </p>
+      </section>
     </main>
 
     <footer>

--- a/docs/index.html
+++ b/docs/index.html
@@ -122,14 +122,6 @@ uniqueitems = true</code></pre>
         </a>
       </section>
 
-      <section class="section" aria-labelledby="community-tooling-title">
-        <h2 id="community-tooling-title">Community tooling</h2>
-        <p class="section-intro">
-          The third-party <a href="https://github.com/jcbyte/toml-schema-lsp">TOML Schema LSP and VS Code extension</a>
-          provides real-time validation using local <code>.tosd</code> schemas.
-        </p>
-      </section>
-
       <section class="section" id="tour">
         <h2>A Quick Tour of TOML Schema</h2>
         <p class="section-intro">


### PR DESCRIPTION
The TOML Schema LSP and VS Code extension is more relevant alongside the visual editor than on the project homepage.

This moves the existing Community tooling section to the Editor page without changing its wording or link.