### PR TITLE
Publish and distribute the tosd CLI

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -3,18 +3,16 @@ name: tosd CLI release
 on:
   push:
     tags:
-      - "v*"
       - "rust-v*"
-      - "reference-implementations/rust/v*"
   workflow_dispatch:
     inputs:
       tag_name:
-        description: Existing tag to release
+        description: Existing rust-v* tag to release
         required: true
         type: string
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: cli-release-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name || github.ref_name }}
@@ -25,7 +23,7 @@ env:
 
 jobs:
   test:
-    name: Test Rust reference implementation
+    name: Test and validate release metadata
     runs-on: ubuntu-latest
 
     steps:
@@ -37,9 +35,40 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Test
-        working-directory: reference-implementations/rust
-        run: cargo test --locked
+      - name: Verify release tag matches Cargo version
+        shell: bash
+        run: |
+          if [[ "${RELEASE_TAG}" != rust-v* ]]; then
+            echo "Release tag must use rust-v<version>: ${RELEASE_TAG}" >&2
+            exit 1
+          fi
+
+          release_version="${RELEASE_TAG#rust-v}"
+          cargo_version="$(
+            cargo metadata \
+              --format-version 1 \
+              --no-deps \
+              --manifest-path reference-implementations/rust/Cargo.toml |
+              jq -r '.packages[0].version'
+          )"
+          installer_version="$(
+            sed -nE 's/^readonly DEFAULT_VERSION="([^"]+)"$/\1/p' \
+              scripts/install-tosd.sh
+          )"
+          if [[ "${release_version}" != "${cargo_version}" ]]; then
+            echo "Tag version ${release_version} does not match Cargo version ${cargo_version}" >&2
+            exit 1
+          fi
+          if [[ "${installer_version}" != "${cargo_version}" ]]; then
+            echo "Installer version ${installer_version} does not match Cargo version ${cargo_version}" >&2
+            exit 1
+          fi
+
+      - name: Test Rust reference implementation
+        run: cargo test --locked --manifest-path reference-implementations/rust/Cargo.toml
+
+      - name: Test installer
+        run: scripts/test-install-tosd.sh
 
   build:
     name: Build tosd CLI (${{ matrix.asset }})
@@ -51,8 +80,8 @@ jobs:
           - os: ubuntu-latest
             asset: linux-x86_64
             binary: tosd
-          - os: macos-15-intel
-            asset: macos-x86_64
+          - os: ubuntu-24.04-arm
+            asset: linux-arm64
             binary: tosd
           - os: macos-15
             asset: macos-arm64
@@ -71,24 +100,37 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Build archive
+      - name: Build, smoke-test, and package
         shell: bash
         working-directory: reference-implementations/rust
         run: |
-          release_version="${RELEASE_TAG##*/}"
-          release_version="${release_version#rust-v}"
-          release_version="${release_version#v}"
+          release_version="${RELEASE_TAG#rust-v}"
           asset_name="tosd-${release_version}-${{ matrix.asset }}"
+          binary="./target/release/${{ matrix.binary }}"
+          smoke_directory="$(mktemp -d)"
+          extracted_schema="${smoke_directory}/config.generated.tosd"
+
           cargo build --locked --release --bin tosd
 
-          "./target/release/${{ matrix.binary }}" validate ../../config.tosd ../../config.toml
-          "./target/release/${{ matrix.binary }}" validate ../../config.toml
-          "./target/release/${{ matrix.binary }}" validate ../../toml-schema.tosd ../../config.tosd
-          "./target/release/${{ matrix.binary }}" validate ../../toml-schema.tosd ../../toml-schema.tosd
+          [[ "$("${binary}" --version)" == "tosd ${release_version}" ]]
+          "${binary}" --help | grep -F "tosd validate"
+          "${binary}" validate ../../config.tosd ../../config.toml
+          "${binary}" validate ../../config.toml
+          "${binary}" validate ../../toml-schema.tosd ../../config.tosd
+          "${binary}" validate ../../toml-schema.tosd ../../toml-schema.tosd
+          "${binary}" extract ../../config.toml "${extracted_schema}"
+          "${binary}" validate "${extracted_schema}" ../../config.toml
 
           mkdir -p "dist/${asset_name}"
-          cp "target/release/${{ matrix.binary }}" "dist/${asset_name}/"
-          tar -C dist -czf "dist/${asset_name}.tar.gz" "${asset_name}"
+          cp "${binary}" "dist/${asset_name}/${{ matrix.binary }}"
+          if [[ "${{ runner.os }}" != "Windows" ]]; then
+            chmod 0755 "dist/${asset_name}/${{ matrix.binary }}"
+          fi
+          tar -C dist -czf "dist/${asset_name}.tar.gz" \
+            "${asset_name}/${{ matrix.binary }}"
+
+          [[ "$(tar -tzf "dist/${asset_name}.tar.gz")" == \
+            "${asset_name}/${{ matrix.binary }}" ]]
 
       - name: Upload archive
         uses: actions/upload-artifact@v4
@@ -97,25 +139,103 @@ jobs:
           path: reference-implementations/rust/dist/*.tar.gz
           if-no-files-found: error
 
-  publish:
-    name: Publish tosd CLI release assets
+  inspect:
+    name: Inspect tosd CLI release bundle
     needs: build
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name || github.ref }}
+
       - name: Download archives
         uses: actions/download-artifact@v4
         with:
           path: dist
           merge-multiple: true
 
-      - name: Generate checksums
+      - name: Inspect archives and generate checksums
+        shell: bash
         run: |
-          release_version="${RELEASE_TAG##*/}"
-          release_version="${release_version#rust-v}"
-          release_version="${release_version#v}"
-          cd dist
-          shasum -a 256 *.tar.gz > "tosd-${release_version}-SHA256SUMS.txt"
+          release_version="${RELEASE_TAG#rust-v}"
+          expected_assets=(
+            "linux-x86_64"
+            "linux-arm64"
+            "macos-arm64"
+            "windows-x86_64"
+          )
+
+          for platform in "${expected_assets[@]}"; do
+            archive="dist/tosd-${release_version}-${platform}.tar.gz"
+            [[ -f "${archive}" ]]
+
+            binary="tosd"
+            if [[ "${platform}" == "windows-x86_64" ]]; then
+              binary="tosd.exe"
+            fi
+            root="${archive##*/}"
+            root="${root%.tar.gz}"
+            [[ "$(tar -tzf "${archive}")" == "${root}/${binary}" ]]
+          done
+
+          [[ "$(find dist -maxdepth 1 -name '*.tar.gz' -type f | wc -l)" -eq 4 ]]
+          install -m 0755 scripts/install-tosd.sh dist/install-tosd.sh
+          (
+            cd dist
+            sha256sum *.tar.gz install-tosd.sh \
+              > "tosd-${release_version}-SHA256SUMS.txt"
+          )
+
+      - name: Upload inspected release bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: tosd-release-bundle
+          path: dist/*
+          if-no-files-found: error
+
+  publish:
+    name: Publish tosd CLI release assets
+    needs: inspect
+    runs-on: ubuntu-latest
+    environment: cli-release
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download inspected release bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: tosd-release-bundle
+          path: dist
+
+      - name: Refuse to replace existing release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          error_file="$(mktemp)"
+          if existing_assets="$(
+            gh release view "${RELEASE_TAG}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --json assets \
+              --jq '.assets | length' 2>"${error_file}"
+          )"; then
+            :
+          elif grep -Eqi 'release not found|HTTP 404' "${error_file}"; then
+            existing_assets=0
+          else
+            cat "${error_file}" >&2
+            exit 1
+          fi
+          rm -f "${error_file}"
+
+          if ((existing_assets > 0)); then
+            echo "Release ${RELEASE_TAG} already has ${existing_assets} asset(s)." >&2
+            echo "Remove partial assets explicitly before retrying this publish job." >&2
+            exit 1
+          fi
 
       - name: Upload release assets
         uses: softprops/action-gh-release@v2
@@ -126,3 +246,4 @@ jobs:
           generate_release_notes: true
           prerelease: ${{ contains(env.RELEASE_TAG, '-rc.') }}
           make_latest: false
+          overwrite_files: false

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -146,7 +146,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name || github.ref }}
 
@@ -189,7 +189,7 @@ jobs:
           )
 
       - name: Upload inspected release bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: tosd-release-bundle
           path: dist/*
@@ -205,7 +205,7 @@ jobs:
 
     steps:
       - name: Download inspected release bundle
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: tosd-release-bundle
           path: dist

--- a/README.md
+++ b/README.md
@@ -77,6 +77,20 @@ canonical `tosd` CLI. See
 [Reference implementations](REFERENCE_IMPLEMENTATIONS.md) for implementation
 status, CLI usage, schema extraction, and conformance expectations.
 
+Install the `1.0.0-rc.2` CLI on Linux or Apple Silicon macOS from GitHub
+Releases:
+
+```shell
+curl --proto '=https' --tlsv1.2 -sSfL \
+  https://github.com/brunoborges/toml-schema/releases/download/rust-v1.0.0-rc.2/install-tosd.sh |
+  bash -s -- --version 1.0.0-rc.2
+```
+
+The installer verifies the release checksum and writes to `$HOME/.local/bin`
+by default. Direct downloads, Windows installation, supported platforms, and
+installer options are documented in the
+[Rust reference implementation README](reference-implementations/rust/README.md#install-the-cli).
+
 ## Schema reference from TOML
 
 A TOML document can point to a schema with reserved metadata:

--- a/REFERENCE_IMPLEMENTATIONS.md
+++ b/REFERENCE_IMPLEMENTATIONS.md
@@ -232,6 +232,26 @@ Build the CLI binary:
 cargo build --manifest-path reference-implementations/rust/Cargo.toml --release --bin tosd
 ```
 
+Install CLI artifact version `1.0.0-rc.2` on Linux x86_64, Linux arm64, or
+Apple Silicon macOS from GitHub Releases:
+
+```shell
+curl --proto '=https' --tlsv1.2 -sSfL \
+  https://github.com/brunoborges/toml-schema/releases/download/rust-v1.0.0-rc.2/install-tosd.sh |
+  bash -s -- --version 1.0.0-rc.2
+```
+
+The installer verifies the release checksum and writes to `$HOME/.local/bin`;
+set `TOSD_INSTALL_DIR` to override the destination. Windows x86_64 users can
+download `tosd-1.0.0-rc.2-windows-x86_64.tar.gz` directly. All four platform
+archives and `tosd-1.0.0-rc.2-SHA256SUMS.txt` are attached to the
+`rust-v1.0.0-rc.2` GitHub Release. See the
+[Rust README](reference-implementations/rust/README.md#install-the-cli) for
+archive names, checksum verification, and inspect-before-run instructions.
+
+The CLI artifact version is `1.0.0-rc.2`; the TOML Schema language version
+embedded in schema documents remains `1.0.0`.
+
 For document-driven lookup, the CLI resolves a relative
 `[toml-schema].location` from the TOML document's directory. The document's
 `[toml-schema].version` is optional; when present, the CLI rejects a major-version

--- a/docs/editor/index.html
+++ b/docs/editor/index.html
@@ -123,6 +123,69 @@
         </div>
       </section>
 
+      <section class="editor-cli" aria-labelledby="editor-cli-title">
+        <div class="editor-section-heading">
+          <h2 id="editor-cli-title">Author visually. Validate in the terminal.</h2>
+          <p>
+            The editor and the canonical <code>tosd</code> CLI work on the same
+            <code>.tosd</code> source. Save the schema, then run the check locally
+            or in CI without converting formats.
+          </p>
+          <a class="text-link" href="/implementations/#rust">Open the complete CLI documentation <span aria-hidden="true">→</span></a>
+        </div>
+        <div class="editor-cli-workflow">
+          <ol class="cli-steps">
+            <li>
+              <span>1</span>
+              <div>
+                <strong>Install the release</strong>
+                <small>The verified installer supports Linux and Apple Silicon macOS and writes to <code>$HOME/.local/bin</code>.</small>
+              </div>
+            </li>
+            <li>
+              <span>2</span>
+              <div>
+                <strong>Save the schema</strong>
+                <small>Use the editor to review the live TOML, resolve structural issues, and save the canonical <code>.tosd</code> file.</small>
+              </div>
+            </li>
+            <li>
+              <span>3</span>
+              <div>
+                <strong>Validate the document</strong>
+                <small>Pass the schema explicitly or let <code>tosd</code> discover it from <code>[toml-schema].location</code>.</small>
+              </div>
+            </li>
+          </ol>
+
+          <div class="cli-command-set">
+            <div class="command-block">
+              <div class="panel-header">
+                <strong>Install version 1.0.0-rc.2</strong>
+              </div>
+              <pre><code>curl --proto '=https' --tlsv1.2 -sSfL \
+  https://github.com/brunoborges/toml-schema/releases/download/rust-v1.0.0-rc.2/install-tosd.sh |
+  bash -s -- --version 1.0.0-rc.2</code></pre>
+            </div>
+            <div class="cli-command-grid">
+              <div class="command-block">
+                <div class="panel-header"><strong>Explicit schema</strong></div>
+                <pre><code>tosd validate config.tosd config.toml</code></pre>
+              </div>
+              <div class="command-block">
+                <div class="panel-header"><strong>Schema discovery</strong></div>
+                <pre><code>tosd validate config.toml</code></pre>
+              </div>
+            </div>
+            <p class="cli-platform-note">
+              Windows users install from the release archive. Checksums, destination
+              overrides, extraction, and all supported commands are covered in the
+              <a href="/implementations/#rust">Rust reference implementation guide</a>.
+            </p>
+          </div>
+        </div>
+      </section>
+
       <section class="editor-open" id="how-to-open">
         <div>
           <h2>Open the canvas in three moves.</h2>

--- a/docs/index.html
+++ b/docs/index.html
@@ -122,6 +122,30 @@ uniqueitems = true</code></pre>
         </a>
       </section>
 
+      <section class="cli-spotlight" aria-labelledby="cli-spotlight-title">
+        <div class="cli-spotlight-copy">
+          <h2 id="cli-spotlight-title">Validate from the command line.</h2>
+          <p>
+            The canonical <code>tosd</code> CLI validates TOML against an explicit
+            schema or follows the document's <code>[toml-schema].location</code>.
+            Release downloads support Linux x86_64 and arm64, Apple Silicon macOS,
+            and Windows x86_64.
+          </p>
+          <a class="text-link" href="/implementations/#rust">See every install option and CLI command <span aria-hidden="true">→</span></a>
+        </div>
+        <div class="cli-spotlight-terminal" aria-label="Install and validate with the tosd CLI">
+          <div class="panel-header">
+            <strong>Install, then validate</strong>
+            <span class="badge">tosd 1.0.0-rc.2</span>
+          </div>
+          <pre><code>curl --proto '=https' --tlsv1.2 -sSfL \
+  https://github.com/brunoborges/toml-schema/releases/download/rust-v1.0.0-rc.2/install-tosd.sh |
+  bash -s -- --version 1.0.0-rc.2
+
+tosd validate config.tosd config.toml</code></pre>
+        </div>
+      </section>
+
       <section class="section" id="tour">
         <h2>A Quick Tour of TOML Schema</h2>
         <p class="section-intro">

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -436,6 +436,36 @@ footer {
   height: auto;
   width: 100%;
 }
+.cli-spotlight {
+  align-items: center;
+  border-bottom: 1px solid var(--cp-border-strong);
+  display: grid;
+  gap: 48px;
+  grid-template-columns: minmax(260px, 0.72fr) minmax(0, 1.28fr);
+  padding: 64px 0;
+}
+.cli-spotlight-copy h2 {
+  max-width: 11ch;
+}
+.cli-spotlight-copy p {
+  color: var(--cp-text-muted);
+  font-size: 18px;
+  margin: 18px 0 20px;
+  max-width: 46ch;
+}
+.cli-spotlight-terminal {
+  background: var(--cp-surface);
+  border: 1px solid var(--cp-border-strong);
+  box-shadow: 10px 12px 0 var(--cp-accent-soft);
+  min-width: 0;
+  overflow: hidden;
+}
+.cli-spotlight-terminal .panel-header {
+  gap: 16px;
+}
+.cli-spotlight-terminal pre {
+  font-size: 14px;
+}
 
 .editor-hero {
   align-items: end;
@@ -583,6 +613,67 @@ footer {
   content: "✓";
   left: 0;
   position: absolute;
+}
+.editor-cli {
+  display: grid;
+  gap: 64px;
+  grid-template-columns: minmax(260px, 0.7fr) minmax(0, 1.3fr);
+  padding: 112px 0;
+}
+.editor-cli .editor-section-heading .text-link {
+  display: inline-block;
+  margin-top: 14px;
+}
+.editor-cli-workflow {
+  min-width: 0;
+}
+.cli-steps {
+  border-top: 1px solid var(--cp-border-strong);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.cli-steps li {
+  align-items: start;
+  border-bottom: 1px solid var(--cp-border);
+  display: grid;
+  gap: 18px;
+  grid-template-columns: 28px minmax(0, 1fr);
+  padding: 20px 0;
+}
+.cli-steps li > span {
+  color: var(--cp-accent);
+  font-family: Consolas, "Courier New", Courier, monospace;
+  font-size: 13px;
+  padding-top: 2px;
+}
+.cli-steps li div {
+  display: grid;
+  gap: 5px;
+}
+.cli-steps small {
+  color: var(--cp-text-muted);
+  font-size: 15px;
+}
+.cli-command-set {
+  display: grid;
+  gap: 14px;
+  margin-top: 32px;
+}
+.cli-command-grid {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+.cli-command-grid > * {
+  min-width: 0;
+}
+.cli-command-set pre {
+  font-size: 13px;
+}
+.cli-platform-note {
+  color: var(--cp-text-muted);
+  margin: 4px 0 0;
 }
 .editor-open {
   padding: 104px 0 96px;
@@ -957,9 +1048,11 @@ footer {
     flex-direction: column;
   }
   .editor-promo,
+  .cli-spotlight,
   .editor-hero,
   .editor-feature-ledger,
   .editor-copilot,
+  .editor-cli,
   .editor-open > div:first-child {
     grid-template-columns: 1fr;
   }
@@ -982,6 +1075,10 @@ footer {
     gap: 36px;
     padding: 80px 0;
   }
+  .editor-cli {
+    gap: 36px;
+    padding: 80px 0;
+  }
   .editor-section-heading {
     position: static;
   }
@@ -993,6 +1090,9 @@ footer {
   }
   .editor-copilot {
     gap: 36px;
+  }
+  .cli-command-grid {
+    grid-template-columns: 1fr;
   }
   .editor-open > div:first-child {
     gap: 18px;
@@ -1057,6 +1157,7 @@ footer {
   }
   .editor-atlas-frame,
   .editor-promo-image,
+  .cli-spotlight-terminal,
   .editor-copilot-image {
     box-shadow: 6px 7px 0 var(--cp-accent-soft);
   }

--- a/reference-implementations/rust/README.md
+++ b/reference-implementations/rust/README.md
@@ -11,6 +11,71 @@ canonical `tosd` CLI, and can be used as a library.
 
 All commands below assume you run them from the repository root.
 
+## Install the CLI
+
+The canonical CLI is distributed through
+[GitHub Releases](https://github.com/brunoborges/toml-schema/releases).
+Install `1.0.0-rc.2` on Linux or Apple Silicon macOS:
+
+```shell
+curl --proto '=https' --tlsv1.2 -sSfL \
+  https://github.com/brunoborges/toml-schema/releases/download/rust-v1.0.0-rc.2/install-tosd.sh |
+  bash -s -- --version 1.0.0-rc.2
+```
+
+The installer downloads the matching release archive, verifies its SHA-256
+checksum, and atomically installs `tosd` to `$HOME/.local/bin/tosd`. Ensure that
+directory is on `PATH`. Override the destination when needed:
+
+```shell
+curl --proto '=https' --tlsv1.2 -sSfL \
+  https://github.com/brunoborges/toml-schema/releases/download/rust-v1.0.0-rc.2/install-tosd.sh |
+  TOSD_INSTALL_DIR="$HOME/bin" bash -s -- --version 1.0.0-rc.2
+```
+
+To inspect the installer before running it:
+
+```shell
+curl --proto '=https' --tlsv1.2 -sSfLo install-tosd.sh \
+  https://github.com/brunoborges/toml-schema/releases/download/rust-v1.0.0-rc.2/install-tosd.sh
+less install-tosd.sh
+bash install-tosd.sh --version 1.0.0-rc.2
+```
+
+Release assets use these names:
+
+| Platform | Archive |
+| --- | --- |
+| Linux x86_64 | `tosd-1.0.0-rc.2-linux-x86_64.tar.gz` |
+| Linux arm64 | `tosd-1.0.0-rc.2-linux-arm64.tar.gz` |
+| macOS arm64 | `tosd-1.0.0-rc.2-macos-arm64.tar.gz` |
+| Windows x86_64 | `tosd-1.0.0-rc.2-windows-x86_64.tar.gz` |
+
+Windows users download and extract the Windows archive directly, then place
+`tosd.exe` on `PATH`. Every release includes
+`tosd-1.0.0-rc.2-SHA256SUMS.txt`; verify the selected archive before extracting
+it. For example, on Windows PowerShell:
+
+```powershell
+$archive = "tosd-1.0.0-rc.2-windows-x86_64.tar.gz"
+$expected = ((Select-String " $archive$" tosd-1.0.0-rc.2-SHA256SUMS.txt).Line -split "\s+")[0]
+$actual = (Get-FileHash -Algorithm SHA256 $archive).Hash.ToLowerInvariant()
+if ($actual -ne $expected) { throw "Checksum verification failed" }
+tar -xzf $archive
+```
+
+On Linux:
+
+```shell
+grep ' tosd-1.0.0-rc.2-linux-x86_64.tar.gz$' \
+  tosd-1.0.0-rc.2-SHA256SUMS.txt > selected-SHA256SUMS.txt
+sha256sum -c selected-SHA256SUMS.txt
+```
+
+CLI releases use `rust-v<version>` tags. The CLI artifact version
+`1.0.0-rc.2` identifies this implementation prerelease; schemas continue to
+declare the TOML Schema language version `1.0.0`.
+
 ## Build and test
 
 Run the test suite:
@@ -26,6 +91,12 @@ cargo build --manifest-path reference-implementations/rust/Cargo.toml --release 
 ```
 
 ## CLI usage
+
+Display the installed CLI version:
+
+```shell
+tosd --version
+```
 
 Validate with an explicit schema:
 

--- a/reference-implementations/rust/src/cli.rs
+++ b/reference-implementations/rust/src/cli.rs
@@ -14,6 +14,10 @@ pub fn run(args: &[String], out: &mut dyn Write, err: &mut dyn Write) -> u8 {
         usage(out);
         return 0;
     }
+    if args[0] == "--version" || args[0] == "-V" {
+        let _ = writeln!(out, "tosd {}", env!("CARGO_PKG_VERSION"));
+        return 0;
+    }
     match args[0].as_str() {
         "validate" => match args.len() {
             2 => validate_with_embedded_schema(&args[1], out, err),

--- a/reference-implementations/rust/tests/integration.rs
+++ b/reference-implementations/rust/tests/integration.rs
@@ -50,15 +50,27 @@ fn capture(args: &[&str]) -> (u8, String, String) {
 
 #[test]
 fn canonical_binary_is_named_tosd() {
-    let output = Command::new(env!("CARGO_BIN_EXE_tosd"))
+    let help = Command::new(env!("CARGO_BIN_EXE_tosd"))
         .arg("--help")
         .output()
         .expect("run tosd binary");
-    assert!(output.status.success());
+    assert!(help.status.success());
 
-    let stdout = String::from_utf8(output.stdout).expect("stdout utf-8");
-    assert!(stdout.contains("tosd validate"));
-    assert!(!stdout.contains("toml-schema validate"));
+    let help_stdout = String::from_utf8(help.stdout).expect("stdout utf-8");
+    assert!(help_stdout.contains("tosd validate"));
+    assert!(!help_stdout.contains("toml-schema validate"));
+
+    let version = Command::new(env!("CARGO_BIN_EXE_tosd"))
+        .arg("--version")
+        .output()
+        .expect("run tosd binary");
+    assert!(version.status.success());
+
+    let version_stdout = String::from_utf8(version.stdout).expect("stdout utf-8");
+    assert_eq!(
+        version_stdout.trim(),
+        format!("tosd {}", env!("CARGO_PKG_VERSION"))
+    );
 }
 
 #[test]

--- a/scripts/install-tosd.sh
+++ b/scripts/install-tosd.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly DEFAULT_VERSION="1.0.0-rc.2"
+readonly REPOSITORY="${TOSD_GITHUB_REPOSITORY:-brunoborges/toml-schema}"
+readonly RELEASE_BASE_URL="${TOSD_RELEASE_BASE_URL:-https://github.com/${REPOSITORY}/releases/download}"
+
+usage() {
+    cat <<'EOF'
+Usage: install-tosd.sh [--version <version>]
+
+Environment:
+  TOSD_INSTALL_DIR       Installation directory (default: $HOME/.local/bin)
+  TOSD_VERSION           Version to install when --version is omitted
+EOF
+}
+
+version="${TOSD_VERSION:-$DEFAULT_VERSION}"
+while (($# > 0)); do
+    case "$1" in
+        --version)
+            if (($# < 2)); then
+                echo "error: --version requires a value" >&2
+                exit 2
+            fi
+            version="$2"
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "error: unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+    echo "error: invalid tosd version: $version" >&2
+    exit 2
+fi
+
+os="${TOSD_UNAME_S:-$(uname -s)}"
+arch="${TOSD_UNAME_M:-$(uname -m)}"
+case "$os" in
+    Linux)
+        platform="linux"
+        ;;
+    Darwin)
+        platform="macos"
+        ;;
+    *)
+        echo "error: unsupported operating system: $os" >&2
+        exit 1
+        ;;
+esac
+
+case "$arch" in
+    x86_64|amd64)
+        architecture="x86_64"
+        ;;
+    arm64|aarch64)
+        architecture="arm64"
+        ;;
+    *)
+        echo "error: unsupported architecture: $arch" >&2
+        exit 1
+        ;;
+esac
+
+if [[ "$platform" == "macos" && "$architecture" != "arm64" ]]; then
+    echo "error: tosd releases support macOS on arm64 only" >&2
+    exit 1
+fi
+
+asset="tosd-${version}-${platform}-${architecture}.tar.gz"
+checksums="tosd-${version}-SHA256SUMS.txt"
+release_url="${RELEASE_BASE_URL}/rust-v${version}"
+install_dir="${TOSD_INSTALL_DIR:-${HOME}/.local/bin}"
+archive_root="${asset%.tar.gz}"
+
+temporary_directory="$(mktemp -d)"
+temporary_target=""
+cleanup() {
+    rm -rf "$temporary_directory"
+    if [[ -n "$temporary_target" ]]; then
+        rm -f "$temporary_target"
+    fi
+}
+trap cleanup EXIT
+
+curl --fail --location --silent --show-error \
+    --output "${temporary_directory}/${asset}" \
+    "${release_url}/${asset}"
+curl --fail --location --silent --show-error \
+    --output "${temporary_directory}/${checksums}" \
+    "${release_url}/${checksums}"
+
+checksum_entry="$(
+    awk -v asset="$asset" '
+        $2 == asset {
+            if (found) exit 2
+            print
+            found = 1
+        }
+        END {
+            if (!found) exit 1
+        }
+    ' "${temporary_directory}/${checksums}"
+)" || {
+    echo "error: checksum manifest does not contain exactly one entry for ${asset}" >&2
+    exit 1
+}
+printf '%s\n' "$checksum_entry" > "${temporary_directory}/selected-SHA256SUMS.txt"
+
+if command -v sha256sum >/dev/null 2>&1; then
+    (
+        cd "$temporary_directory"
+        sha256sum -c selected-SHA256SUMS.txt >/dev/null
+    ) || {
+        echo "error: checksum verification failed for ${asset}" >&2
+        exit 1
+    }
+elif command -v shasum >/dev/null 2>&1; then
+    (
+        cd "$temporary_directory"
+        shasum -a 256 -c selected-SHA256SUMS.txt >/dev/null
+    ) || {
+        echo "error: checksum verification failed for ${asset}" >&2
+        exit 1
+    }
+else
+    echo "error: sha256sum or shasum is required" >&2
+    exit 1
+fi
+
+archive_listing="$(tar -tzf "${temporary_directory}/${asset}")"
+if [[ "$archive_listing" != "${archive_root}/tosd" ]]; then
+    echo "error: ${asset} must contain only ${archive_root}/tosd" >&2
+    exit 1
+fi
+
+tar -xzf "${temporary_directory}/${asset}" \
+    -C "$temporary_directory" \
+    "${archive_root}/tosd"
+if [[ ! -f "${temporary_directory}/${archive_root}/tosd" ||
+    -L "${temporary_directory}/${archive_root}/tosd" ]]; then
+    echo "error: ${asset} does not contain a regular tosd executable" >&2
+    exit 1
+fi
+
+mkdir -p "$install_dir"
+temporary_target="$(mktemp "${install_dir}/.tosd.XXXXXX")"
+install -m 0755 "${temporary_directory}/${archive_root}/tosd" "$temporary_target"
+mv -f "$temporary_target" "${install_dir}/tosd"
+temporary_target=""
+
+echo "Installed tosd ${version} to ${install_dir}/tosd"
+case ":${PATH}:" in
+    *":${install_dir}:"*) ;;
+    *) echo "Add ${install_dir} to PATH to run tosd." ;;
+esac

--- a/scripts/test-install-tosd.sh
+++ b/scripts/test-install-tosd.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly REPOSITORY_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly INSTALLER="${REPOSITORY_ROOT}/scripts/install-tosd.sh"
+readonly VERSION="1.0.0-rc.2"
+
+temporary_directory="$(mktemp -d)"
+trap 'rm -rf "$temporary_directory"' EXIT
+
+release_directory="${temporary_directory}/releases/download/rust-v${VERSION}"
+mkdir -p "$release_directory"
+
+create_archive() {
+    local platform="$1"
+    local asset="tosd-${VERSION}-${platform}"
+    local root="${temporary_directory}/${asset}"
+
+    mkdir -p "$root"
+    printf '#!/usr/bin/env sh\nprintf "tosd fixture\\n"\n' > "${root}/tosd"
+    chmod 0755 "${root}/tosd"
+    tar -C "$temporary_directory" -czf "${release_directory}/${asset}.tar.gz" "${asset}/tosd"
+    rm -rf "$root"
+}
+
+create_archive "linux-x86_64"
+create_archive "linux-arm64"
+create_archive "macos-arm64"
+
+(
+    cd "$release_directory"
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum *.tar.gz
+    else
+        shasum -a 256 *.tar.gz
+    fi
+) > "${release_directory}/tosd-${VERSION}-SHA256SUMS.txt"
+
+install_directory="${temporary_directory}/installed"
+TOSD_RELEASE_BASE_URL="file://${temporary_directory}/releases/download" \
+TOSD_INSTALL_DIR="$install_directory" \
+TOSD_UNAME_S="Linux" \
+TOSD_UNAME_M="x86_64" \
+    "$INSTALLER" --version "$VERSION"
+[[ "$("${install_directory}/tosd")" == "tosd fixture" ]]
+
+arm_install_directory="${temporary_directory}/installed-arm"
+TOSD_RELEASE_BASE_URL="file://${temporary_directory}/releases/download" \
+TOSD_INSTALL_DIR="$arm_install_directory" \
+TOSD_UNAME_S="Linux" \
+TOSD_UNAME_M="aarch64" \
+    "$INSTALLER"
+[[ "$("${arm_install_directory}/tosd")" == "tosd fixture" ]]
+
+mac_install_directory="${temporary_directory}/installed-mac"
+TOSD_RELEASE_BASE_URL="file://${temporary_directory}/releases/download" \
+TOSD_INSTALL_DIR="$mac_install_directory" \
+TOSD_UNAME_S="Darwin" \
+TOSD_UNAME_M="arm64" \
+    "$INSTALLER"
+[[ "$("${mac_install_directory}/tosd")" == "tosd fixture" ]]
+
+if TOSD_RELEASE_BASE_URL="file://${temporary_directory}/releases/download" \
+    TOSD_INSTALL_DIR="${temporary_directory}/unsupported" \
+    TOSD_UNAME_S="Darwin" \
+    TOSD_UNAME_M="x86_64" \
+    "$INSTALLER" >/dev/null 2>&1; then
+    echo "expected macOS x86_64 installation to fail" >&2
+    exit 1
+fi
+
+printf 'corrupt\n' >> "${release_directory}/tosd-${VERSION}-linux-x86_64.tar.gz"
+if TOSD_RELEASE_BASE_URL="file://${temporary_directory}/releases/download" \
+    TOSD_INSTALL_DIR="${temporary_directory}/corrupt" \
+    TOSD_UNAME_S="Linux" \
+    TOSD_UNAME_M="x86_64" \
+    "$INSTALLER" >/dev/null 2>&1; then
+    echo "expected checksum verification to fail" >&2
+    exit 1
+fi
+
+echo "Installer tests passed"


### PR DESCRIPTION
The canonical `tosd` CLI needs a secure, repeatable installation path without depending on package-manager channels for the `1.0.0-rc.2` prerelease. This adds GitHub Releases as the sole CLI distribution channel while keeping the TOML Schema language version at `1.0.0`.

## Summary

- hardens the release workflow with tag/version guards, immutable Action pins, native smoke tests, archive inspection, checksums, and a protected `cli-release` publish job
- publishes Linux x86_64, Linux arm64, macOS arm64, and Windows x86_64 archives
- adds a checksum-verifying Linux/macOS installer that defaults to `$HOME/.local/bin` and supports pinned versions and `TOSD_INSTALL_DIR`
- adds `tosd --version` and coverage for the canonical executable identity
- adds quick CLI installation and usage to the website landing page, an editor-to-terminal workflow to the Editor page, and complete guidance under Reference Implementations
- documents direct downloads, Windows checksum verification, supported platforms, and artifact-versus-language versioning

Repository maintainers must configure the protected `cli-release` GitHub environment before creating the release tag.

## Validation

- `cargo test --locked --manifest-path reference-implementations/rust/Cargo.toml`
- `scripts/test-install-tosd.sh`
- `npm --prefix scripts run render-docs`
- Rust formatting, shell syntax, workflow YAML, pinned-Action checks, and website design checks

Fixes: #139