### PR TITLE
Upgrade Go reference implementation to 1.27

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Reference implementations](https://github.com/brunoborges/toml-schema/actions/workflows/reference-implementations.yml/badge.svg)](https://github.com/brunoborges/toml-schema/actions/workflows/reference-implementations.yml)
 [![Rust 1.75](https://img.shields.io/badge/Rust-1.75-dea584)](REFERENCE_IMPLEMENTATIONS.md#rust)
 [![Java 25](https://img.shields.io/badge/Java-25-007396)](REFERENCE_IMPLEMENTATIONS.md#java)
-[![Go 1.26.6](https://img.shields.io/badge/Go-1.26.6-00ADD8)](REFERENCE_IMPLEMENTATIONS.md#go)
+[![Go 1.27.0](https://img.shields.io/badge/Go-1.27.0-00ADD8)](REFERENCE_IMPLEMENTATIONS.md#go)
 [![.NET 9](https://img.shields.io/badge/.NET-9.0-512BD4)](REFERENCE_IMPLEMENTATIONS.md#net)
 [![Python 3.11](https://img.shields.io/badge/Python-3.11+-3776AB)](REFERENCE_IMPLEMENTATIONS.md#python)
 [![TypeScript 6](https://img.shields.io/badge/TypeScript-6-3178C6)](REFERENCE_IMPLEMENTATIONS.md#nodejs--typescript)

--- a/REFERENCE_IMPLEMENTATIONS.md
+++ b/REFERENCE_IMPLEMENTATIONS.md
@@ -10,7 +10,7 @@ command-line interface for validation, schema discovery through
 | Language | Location | Requires | Interfaces |
 | --- | --- | --- | --- |
 | Java | [`reference-implementations/java`](reference-implementations/java) | Java 25 and Maven | Library, schema discovery |
-| Go | [`reference-implementations/go`](reference-implementations/go) | Go 1.26.6 | Library, schema discovery, schema extraction |
+| Go | [`reference-implementations/go`](reference-implementations/go) | Go 1.27.0 | Library, schema discovery, schema extraction |
 | .NET | [`reference-implementations/dotnet`](reference-implementations/dotnet) | .NET 9.0 | Library, schema discovery |
 | Python | [`reference-implementations/python`](reference-implementations/python) | Python 3.11+ | Library, schema discovery |
 | Rust | [`reference-implementations/rust`](reference-implementations/rust) | Rust 1.75 and Cargo | Library, canonical CLI, schema discovery, schema extraction |

--- a/reference-implementations/go/abnf_conformance_test.go
+++ b/reference-implementations/go/abnf_conformance_test.go
@@ -58,7 +58,7 @@ func abnfPath() string {
 func alternativesFor(ruleName, abnf string) []string {
 	expression := ruleExpression(ruleName, abnf)
 	tokens := []string{}
-	for _, token := range strings.Split(expression, "/") {
+	for token := range strings.SplitSeq(expression, "/") {
 		token = strings.TrimSpace(token)
 		if token == "" || token == "version" {
 			continue
@@ -71,7 +71,7 @@ func alternativesFor(ruleName, abnf string) []string {
 func ruleExpression(ruleName, abnf string) string {
 	var expression strings.Builder
 	inRule := false
-	for _, line := range strings.Split(abnf, "\n") {
+	for line := range strings.SplitSeq(abnf, "\n") {
 		if strings.HasPrefix(line, ruleName+" =") {
 			_, value, _ := strings.Cut(line, "=")
 			expression.WriteString(strings.TrimSpace(value))
@@ -92,7 +92,7 @@ func ruleExpression(ruleName, abnf string) string {
 
 func builtInTypeTokens(abnf string) []string {
 	tokens := []string{}
-	for _, line := range strings.Split(abnf, "\n") {
+	for line := range strings.SplitSeq(abnf, "\n") {
 		matches := tokenCommentPattern.FindStringSubmatch(line)
 		if len(matches) != 2 {
 			continue

--- a/reference-implementations/go/go.mod
+++ b/reference-implementations/go/go.mod
@@ -1,5 +1,5 @@
 module tomlschema.org/go
 
-go 1.26.6
+go 1.27.0
 
 require github.com/pelletier/go-toml/v2 v2.3.1

--- a/reference-implementations/go/schema.go
+++ b/reference-implementations/go/schema.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -878,10 +879,8 @@ func parseDefinition(name string, path []string, table map[string]any, source *s
 	for property, references := range map[string][]string{
 		"items": items, "oneof": oneOf, "anyof": anyOf, "allof": allOf,
 	} {
-		for _, reference := range references {
-			if reference == "" {
-				return Definition{}, fmt.Errorf("%s %s references must not be blank", name, property)
-			}
+		if slices.Contains(references, "") {
+			return Definition{}, fmt.Errorf("%s %s references must not be blank", name, property)
 		}
 	}
 	if hasOneOf && len(oneOf) == 0 {
@@ -2040,7 +2039,7 @@ func (v *validator) validateArray(path string, array []any, definition Definitio
 	v.validateLength(path, len(array), definition)
 	if definition.uniqueItems != nil && *definition.uniqueItems {
 		for index := range array {
-			for previous := 0; previous < index; previous++ {
+			for previous := range index {
 				if valuesEqual(array[previous], array[index]) {
 					v.add(fmt.Sprintf("%s[%d]", path, index),
 						fmt.Sprintf("duplicate item equals item at index %d", previous))
@@ -2125,10 +2124,7 @@ func (v *validator) validateTupleArray(path string, array []any, definition Defi
 	if len(array) != len(definition.items) {
 		v.add(path, fmt.Sprintf("expected array length %d but found %d", len(definition.items), len(array)))
 	}
-	upperBound := len(array)
-	if len(definition.items) < upperBound {
-		upperBound = len(definition.items)
-	}
+	upperBound := min(len(definition.items), len(array))
 	for i := range upperBound {
 		itemPath := fmt.Sprintf("%s[%d]", path, i)
 		itemDefinition, err := v.resolveReference(definition.items[i], map[string]bool{})


### PR DESCRIPTION
Go 1.27 is now the current toolchain release, so the reference implementation should target it and benefit from its updated tooling.

This updates the module requirement and project documentation to Go 1.27.0, then applies the modernizations selected by Go 1.27's `go fix`, including iterator-based string splitting, integer ranges, `min`, and `slices.Contains`. Experimental APIs are intentionally not adopted.

Validated with `go test ./...` using Go 1.27.0.