### PR TITLE
Test Python implementation on Python 3.14

### DIFF
--- a/.github/workflows/reference-implementations.yml
+++ b/.github/workflows/reference-implementations.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
-          python-version: "3.11"
+          python-version: "3.14"
 
       - name: Install library
         run: python -m pip install reference-implementations/python

--- a/reference-implementations/python/pyproject.toml
+++ b/reference-implementations/python/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Text Processing :: Markup",
 ]


### PR DESCRIPTION
Updates the Python reference implementation's CI runtime to the latest stable Python release so compatibility is continuously exercised on Python 3.14.

The package metadata now also advertises Python 3.14 support while preserving the existing Python 3.11 minimum version.