### PR TITLE
Upgrade .NET reference implementation to .NET 10

### DIFF
--- a/.github/workflows/reference-implementations.yml
+++ b/.github/workflows/reference-implementations.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Set up .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
-          dotnet-version: "9.0.x"
+          dotnet-version: "10.0.x"
 
       - name: Test
         run: dotnet test reference-implementations/dotnet/TomlSchema.sln -v normal

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Rust 1.97.1](https://img.shields.io/badge/Rust-1.97.1-dea584)](REFERENCE_IMPLEMENTATIONS.md#rust)
 [![Java 25](https://img.shields.io/badge/Java-25-007396)](REFERENCE_IMPLEMENTATIONS.md#java)
 [![Go 1.27.0](https://img.shields.io/badge/Go-1.27.0-00ADD8)](REFERENCE_IMPLEMENTATIONS.md#go)
-[![.NET 9](https://img.shields.io/badge/.NET-9.0-512BD4)](REFERENCE_IMPLEMENTATIONS.md#net)
+[![.NET 10](https://img.shields.io/badge/.NET-10.0-512BD4)](REFERENCE_IMPLEMENTATIONS.md#net)
 [![Python 3.11](https://img.shields.io/badge/Python-3.11+-3776AB)](REFERENCE_IMPLEMENTATIONS.md#python)
 [![TypeScript 6](https://img.shields.io/badge/TypeScript-6-3178C6)](REFERENCE_IMPLEMENTATIONS.md#nodejs--typescript)
 

--- a/REFERENCE_IMPLEMENTATIONS.md
+++ b/REFERENCE_IMPLEMENTATIONS.md
@@ -11,7 +11,7 @@ command-line interface for validation, schema discovery through
 | --- | --- | --- | --- |
 | Java | [`reference-implementations/java`](reference-implementations/java) | Java 25 and Maven | Library, schema discovery |
 | Go | [`reference-implementations/go`](reference-implementations/go) | Go 1.27.0 | Library, schema discovery, schema extraction |
-| .NET | [`reference-implementations/dotnet`](reference-implementations/dotnet) | .NET 9.0 | Library, schema discovery |
+| .NET | [`reference-implementations/dotnet`](reference-implementations/dotnet) | .NET 10.0 | Library, schema discovery |
 | Python | [`reference-implementations/python`](reference-implementations/python) | Python 3.11+ | Library, schema discovery |
 | Rust | [`reference-implementations/rust`](reference-implementations/rust) | Rust 1.97.1 and Cargo | Library, canonical CLI, schema discovery, schema extraction |
 | Node.js / TypeScript | [`reference-implementations/typescript`](reference-implementations/typescript) | Node.js 20.11+ and TypeScript 6 | Library, schema discovery, schema extraction |
@@ -113,7 +113,7 @@ The Go test suite includes an ABNF conformance test (`abnf_conformance_test.go`)
 
 ## .NET
 
-The .NET 9.0 reference library uses [Tomlyn](https://github.com/xoofx/Tomlyn)
+The .NET 10.0 reference library uses [Tomlyn](https://github.com/xoofx/Tomlyn)
 to parse TOML and validates the parsed data model against a `.tosd` schema.
 Its library API also supports document-driven schema discovery through
 `[toml-schema].location`.

--- a/reference-implementations/dotnet/README.md
+++ b/reference-implementations/dotnet/README.md
@@ -1,6 +1,6 @@
 # TOML Schema — .NET reference implementation
 
-.NET 9.0 reference library targeting the current, unreleased
+.NET 10.0 reference library targeting the current, unreleased
 [TOML Schema 1.0.0](../../SPEC.md). It parses TOML with
 [Tomlyn](https://github.com/xoofx/Tomlyn) `2.10.1` (TOML 1.0) and validates the
 parsed data model against a `.tosd` schema, including document-driven schema
@@ -32,7 +32,7 @@ dotnet build reference-implementations/dotnet
 ```
 
 The compiled assembly is written to
-`reference-implementations/dotnet/bin/Debug/net9.0/TomlSchema.dll`.
+`reference-implementations/dotnet/bin/Debug/net10.0/TomlSchema.dll`.
 
 ## Library usage
 

--- a/reference-implementations/dotnet/TomlSchema.Tests/TomlSchema.Tests.csproj
+++ b/reference-implementations/dotnet/TomlSchema.Tests/TomlSchema.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>TomlSchema.Tests</RootNamespace>
     <AssemblyName>TomlSchema.Tests</AssemblyName>
     <IsTestProject>true</IsTestProject>

--- a/reference-implementations/dotnet/TomlSchema.csproj
+++ b/reference-implementations/dotnet/TomlSchema.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>TomlSchema</RootNamespace>
     <AssemblyName>TomlSchema</AssemblyName>
     <Version>1.0.0-rc.2</Version>

--- a/reference-implementations/dotnet/TomlSchema/TomlSchema.csproj
+++ b/reference-implementations/dotnet/TomlSchema/TomlSchema.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>TomlSchema</RootNamespace>
     <AssemblyName>TomlSchema</AssemblyName>
     <Version>1.0.0-rc.2</Version>


### PR DESCRIPTION
The .NET reference implementation should track the current .NET release used by maintainers and CI.

This upgrades the library and test projects to `net10.0`, provisions the .NET 10 SDK in CI, and updates the public badges and documentation to reflect the new target. The existing 50-test suite passes on .NET SDK 10.0.400.