### PR TITLE
Make tomlschema.org the canonical site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -79,3 +79,13 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
+
+      - name: Record publication targets
+        run: |
+          {
+            echo "### Documentation publication"
+            echo
+            echo "- Canonical: https://toml-schema.org/"
+            echo "- Alias: https://tomlschema.org/"
+            echo "- Alias publisher: https://github.com/brunoborges/tomlschema.org"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ TOML Schema is a TOML-based schema language for describing and validating the st
 
 A TOML Schema document is itself a valid TOML document. Validators can use it to catch misconfiguration before production and tooling can use it for editor validation, completion, and hints.
 
+The documentation site is published canonically at
+[toml-schema.org](https://toml-schema.org/) and mirrored at
+[tomlschema.org](https://tomlschema.org/) by the
+[`brunoborges/tomlschema.org`](https://github.com/brunoborges/tomlschema.org)
+GitHub Pages repository. Canonical metadata continues to identify
+`toml-schema.org`.
+
 ## Documentation
 
 - [Specification](SPEC.md) - the TOML Schema language, validation semantics, file extension, MIME type, and TOML schema-reference metadata.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,10 @@
 # Site build scripts
 
-Tooling for the [toml-schema.org](https://toml-schema.org) static site published from `docs/`.
+Tooling for the [toml-schema.org](https://toml-schema.org) static site published
+from `docs/`. The [`brunoborges/tomlschema.org`](https://github.com/brunoborges/tomlschema.org)
+repository also builds this canonical repository's `main` branch and publishes
+the same site at [tomlschema.org](https://tomlschema.org/). Canonical links and
+metadata intentionally continue to use `toml-schema.org`.
 
 ## `render-docs.mjs`
 


### PR DESCRIPTION
The project package identities already use `tomlschema.org` and `org.tomlschema`, so the documentation site should use the same canonical domain. The repository remains `brunoborges/toml-schema`.

This change moves canonical metadata, generated documentation URLs, site-build descriptions, and Pages deployment summaries to `https://tomlschema.org/`. It retains `https://toml-schema.org/` as a temporary mirror published by `brunoborges/tomlschema.org` until path-preserving permanent redirects are configured through Cloudflare.

The live GitHub Pages custom-domain assignments have also been swapped: the canonical repository now owns `tomlschema.org`, and the secondary Pages repository temporarily owns `toml-schema.org`.