### PR TITLE
Fix canonical CLI release URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ repository remains `brunoborges/toml-schema`.
   Cloudflare Wrangler.
 - [Validation report](https://tomlschema.org/validation-report/) - results from
   validating representative real-world TOML documents.
-- [CLI releases](https://toml-schema.org/cli/releases/) - versioned `tosd`
+- [CLI releases](https://tomlschema.org/cli/releases/) - versioned `tosd`
   binaries, checksums, and installer downloads.
 - [Reference implementations](REFERENCE_IMPLEMENTATIONS.md) - canonical CLI and reference library usage, status, and conformance expectations.
 
@@ -92,7 +92,7 @@ Install the `1.0.0-rc.2` CLI on Linux or Apple Silicon macOS:
 
 ```shell
 curl --proto '=https' --tlsv1.2 -sSfL \
-  https://toml-schema.org/cli/releases/rust-v1.0.0-rc.2/install-tosd.sh |
+  https://tomlschema.org/cli/releases/rust-v1.0.0-rc.2/install-tosd.sh |
   bash -s -- --version 1.0.0-rc.2
 ```
 

--- a/docs/editor/index.html
+++ b/docs/editor/index.html
@@ -170,7 +170,7 @@
                 <strong>Install version 1.0.0-rc.2</strong>
               </div>
               <pre><code>curl --proto '=https' --tlsv1.2 -sSfL \
-  https://toml-schema.org/cli/releases/rust-v1.0.0-rc.2/install-tosd.sh |
+  https://tomlschema.org/cli/releases/rust-v1.0.0-rc.2/install-tosd.sh |
   bash -s -- --version 1.0.0-rc.2</code></pre>
             </div>
             <div class="cli-command-grid">

--- a/docs/index.html
+++ b/docs/index.html
@@ -145,7 +145,7 @@ uniqueitems = true</code></pre>
             <span class="badge">tosd 1.0.0-rc.2</span>
           </div>
           <pre><code>curl --proto '=https' --tlsv1.2 -sSfL \
-  https://toml-schema.org/cli/releases/rust-v1.0.0-rc.2/install-tosd.sh |
+  https://tomlschema.org/cli/releases/rust-v1.0.0-rc.2/install-tosd.sh |
   bash -s -- --version 1.0.0-rc.2
 
 tosd validate config.tosd config.toml</code></pre>

--- a/reference-implementations/rust/README.md
+++ b/reference-implementations/rust/README.md
@@ -14,13 +14,13 @@ All commands below assume you run them from the repository root.
 ## Install the CLI
 
 The canonical CLI is distributed through the
-[TOML Schema CLI releases page](https://toml-schema.org/cli/releases/) and
+[TOML Schema CLI releases page](https://tomlschema.org/cli/releases/) and
 [GitHub Releases](https://github.com/brunoborges/toml-schema/releases).
 Install `1.0.0-rc.2` on Linux or Apple Silicon macOS:
 
 ```shell
 curl --proto '=https' --tlsv1.2 -sSfL \
-  https://toml-schema.org/cli/releases/rust-v1.0.0-rc.2/install-tosd.sh |
+  https://tomlschema.org/cli/releases/rust-v1.0.0-rc.2/install-tosd.sh |
   bash -s -- --version 1.0.0-rc.2
 ```
 
@@ -30,7 +30,7 @@ directory is on `PATH`. Override the destination when needed:
 
 ```shell
 curl --proto '=https' --tlsv1.2 -sSfL \
-  https://toml-schema.org/cli/releases/rust-v1.0.0-rc.2/install-tosd.sh |
+  https://tomlschema.org/cli/releases/rust-v1.0.0-rc.2/install-tosd.sh |
   TOSD_INSTALL_DIR="$HOME/bin" bash -s -- --version 1.0.0-rc.2
 ```
 
@@ -38,7 +38,7 @@ To inspect the installer before running it:
 
 ```shell
 curl --proto '=https' --tlsv1.2 -sSfLo install-tosd.sh \
-  https://toml-schema.org/cli/releases/rust-v1.0.0-rc.2/install-tosd.sh
+  https://tomlschema.org/cli/releases/rust-v1.0.0-rc.2/install-tosd.sh
 less install-tosd.sh
 bash install-tosd.sh --version 1.0.0-rc.2
 ```

--- a/scripts/render-cli-releases.mjs
+++ b/scripts/render-cli-releases.mjs
@@ -162,7 +162,7 @@ const heroContent = latest
             <span class="badge">${latest.release.prerelease ? "Prerelease" : "Latest"}</span>
           </div>
           <pre><code>curl --proto '=https' --tlsv1.2 -sSfL \\
-  https://toml-schema.org/cli/releases/${escapeHtml(latest.release.tag_name)}/install-tosd.sh |
+  https://tomlschema.org/cli/releases/${escapeHtml(latest.release.tag_name)}/install-tosd.sh |
   bash -s -- --version ${escapeHtml(latest.version)}</code></pre>
         </div>`
   : `<div class="card install-panel">
@@ -175,7 +175,7 @@ const page = `<!doctype html>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="description" content="Download versioned tosd CLI binaries for Linux, macOS, and Windows.">
-  <link rel="canonical" href="https://toml-schema.org/cli/releases/">
+  <link rel="canonical" href="https://tomlschema.org/cli/releases/">
   <title>tosd CLI releases — TOML Schema</title>
   <script>
     (() => {


### PR DESCRIPTION
## Summary
- point CLI release and installer links at the canonical `tomlschema.org` domain
- update generated release-page canonical metadata
- keep homepage and editor install commands aligned

## Validation
- `scripts/test-install-tosd.sh`
- `cargo test --locked --manifest-path reference-implementations/rust/Cargo.toml`
- `npm --prefix scripts run render-docs`
- `npm --prefix scripts run render-cli-releases`