### PR TITLE
Simplify CLI installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,7 @@ status, CLI usage, schema extraction, and conformance expectations.
 Install the `1.0.0-rc.2` CLI on Linux or Apple Silicon macOS:
 
 ```shell
-curl --proto '=https' --tlsv1.2 -sSfL \
-  https://tomlschema.org/cli/releases/rust-v1.0.0-rc.2/install-tosd.sh |
-  bash -s -- --version 1.0.0-rc.2
+curl -fsSL https://tomlschema.org/cli/releases/rust-v1.0.0-rc.2/install-tosd.sh | bash
 ```
 
 The installer verifies the release checksum and writes to `$HOME/.local/bin`

--- a/REFERENCE_IMPLEMENTATIONS.md
+++ b/REFERENCE_IMPLEMENTATIONS.md
@@ -236,9 +236,7 @@ Install CLI artifact version `1.0.0-rc.2` on Linux x86_64, Linux arm64, or
 Apple Silicon macOS from GitHub Releases:
 
 ```shell
-curl --proto '=https' --tlsv1.2 -sSfL \
-  https://github.com/brunoborges/toml-schema/releases/download/rust-v1.0.0-rc.2/install-tosd.sh |
-  bash -s -- --version 1.0.0-rc.2
+curl -fsSL https://tomlschema.org/cli/releases/rust-v1.0.0-rc.2/install-tosd.sh | bash
 ```
 
 The installer verifies the release checksum and writes to `$HOME/.local/bin`;

--- a/docs/editor/index.html
+++ b/docs/editor/index.html
@@ -169,9 +169,7 @@
               <div class="panel-header">
                 <strong>Install version 1.0.0-rc.2</strong>
               </div>
-              <pre><code>curl --proto '=https' --tlsv1.2 -sSfL \
-  https://tomlschema.org/cli/releases/rust-v1.0.0-rc.2/install-tosd.sh |
-  bash -s -- --version 1.0.0-rc.2</code></pre>
+              <pre><code>curl -fsSL https://tomlschema.org/cli/releases/rust-v1.0.0-rc.2/install-tosd.sh | bash</code></pre>
             </div>
             <div class="cli-command-grid">
               <div class="command-block">

--- a/docs/index.html
+++ b/docs/index.html
@@ -144,9 +144,7 @@ uniqueitems = true</code></pre>
             <strong>Install, then validate</strong>
             <span class="badge">tosd 1.0.0-rc.2</span>
           </div>
-          <pre><code>curl --proto '=https' --tlsv1.2 -sSfL \
-  https://tomlschema.org/cli/releases/rust-v1.0.0-rc.2/install-tosd.sh |
-  bash -s -- --version 1.0.0-rc.2
+          <pre><code>curl -fsSL https://tomlschema.org/cli/releases/rust-v1.0.0-rc.2/install-tosd.sh | bash
 
 tosd validate config.tosd config.toml</code></pre>
         </div>

--- a/reference-implementations/rust/README.md
+++ b/reference-implementations/rust/README.md
@@ -19,9 +19,7 @@ The canonical CLI is distributed through the
 Install `1.0.0-rc.2` on Linux or Apple Silicon macOS:
 
 ```shell
-curl --proto '=https' --tlsv1.2 -sSfL \
-  https://tomlschema.org/cli/releases/rust-v1.0.0-rc.2/install-tosd.sh |
-  bash -s -- --version 1.0.0-rc.2
+curl -fsSL https://tomlschema.org/cli/releases/rust-v1.0.0-rc.2/install-tosd.sh | bash
 ```
 
 The installer downloads the matching release archive, verifies its SHA-256
@@ -29,15 +27,14 @@ checksum, and atomically installs `tosd` to `$HOME/.local/bin/tosd`. Ensure that
 directory is on `PATH`. Override the destination when needed:
 
 ```shell
-curl --proto '=https' --tlsv1.2 -sSfL \
-  https://tomlschema.org/cli/releases/rust-v1.0.0-rc.2/install-tosd.sh |
-  TOSD_INSTALL_DIR="$HOME/bin" bash -s -- --version 1.0.0-rc.2
+curl -fsSL https://tomlschema.org/cli/releases/rust-v1.0.0-rc.2/install-tosd.sh |
+  TOSD_INSTALL_DIR="$HOME/bin" bash
 ```
 
 To inspect the installer before running it:
 
 ```shell
-curl --proto '=https' --tlsv1.2 -sSfLo install-tosd.sh \
+curl -fsSLo install-tosd.sh \
   https://tomlschema.org/cli/releases/rust-v1.0.0-rc.2/install-tosd.sh
 less install-tosd.sh
 bash install-tosd.sh --version 1.0.0-rc.2

--- a/scripts/render-cli-releases.mjs
+++ b/scripts/render-cli-releases.mjs
@@ -161,9 +161,7 @@ const heroContent = latest
             <strong>Install ${escapeHtml(latest.version)}</strong>
             <span class="badge">${latest.release.prerelease ? "Prerelease" : "Latest"}</span>
           </div>
-          <pre><code>curl --proto '=https' --tlsv1.2 -sSfL \\
-  https://tomlschema.org/cli/releases/${escapeHtml(latest.release.tag_name)}/install-tosd.sh |
-  bash -s -- --version ${escapeHtml(latest.version)}</code></pre>
+          <pre><code>curl -fsSL https://tomlschema.org/cli/releases/${escapeHtml(latest.release.tag_name)}/install-tosd.sh | bash</code></pre>
         </div>`
   : `<div class="card install-panel">
           <h2>Downloads are coming soon</h2>


### PR DESCRIPTION
## Summary
- replace the verbose installer invocation with `curl -fsSL … | bash`
- rely on the versioned installer’s built-in default version
- keep the custom install directory and inspect-before-run examples
- update generated CLI release pages to use the concise form

## Validation
- executed the simplified command against the live release
- rendered documentation and CLI release pages