### PR TITLE
Highlight TOSD examples as TOML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ target/
 docs/spec/
 docs/implementations/
 docs/cli/releases/
+docs/assets/highlight.min.js
 scripts/node_modules/
 reference-implementations/dotnet/**/bin/
 reference-implementations/dotnet/**/obj/

--- a/docs/highlight-toml.js
+++ b/docs/highlight-toml.js
@@ -1,0 +1,5 @@
+document.addEventListener("DOMContentLoaded", () => {
+  document
+    .querySelectorAll("code.language-toml")
+    .forEach((block) => window.hljs.highlightElement(block));
+});

--- a/docs/index.html
+++ b/docs/index.html
@@ -15,6 +15,8 @@
     })();
   </script>
   <link rel="stylesheet" href="./styles.css">
+  <script defer src="/assets/highlight.min.js"></script>
+  <script defer src="/highlight-toml.js"></script>
 </head>
 <body>
   <div class="page">
@@ -61,7 +63,7 @@
             <strong>config.tosd</strong>
             <span class="dots" aria-hidden="true"><span class="dot"></span><span class="dot"></span><span class="dot"></span></span>
           </div>
-          <pre><code>[toml-schema]
+          <pre><code class="language-toml">[toml-schema]
 version = "1.0.0"
 
 [elements.title]
@@ -168,12 +170,12 @@ tosd validate config.tosd config.toml</code></pre>
             <div class="tour-examples">
               <div>
                 <span class="tour-code-label">Schema (.tosd)</span>
-                <pre><code>[toml-schema]
+                <pre><code class="language-toml">[toml-schema]
 version = "1.0.0"</code></pre>
               </div>
               <div>
                 <span class="tour-code-label">TOML</span>
-                <pre class="toml-example"><code>[toml-schema]
+                <pre class="toml-example"><code class="language-toml">[toml-schema]
 location = "config.tosd"
 version = "1.0.0"</code></pre>
               </div>
@@ -188,7 +190,7 @@ version = "1.0.0"</code></pre>
             <div class="tour-examples">
               <div>
                 <span class="tour-code-label">Schema (.tosd)</span>
-                <pre><code>[elements.title]
+                <pre><code class="language-toml">[elements.title]
 type = "string"
 
 [elements.database]
@@ -199,7 +201,7 @@ type = "boolean"</code></pre>
               </div>
               <div>
                 <span class="tour-code-label">TOML</span>
-                <pre class="toml-example"><code>title = "Example"
+                <pre class="toml-example"><code class="language-toml">title = "Example"
 
 [database]
 enabled = true</code></pre>
@@ -215,14 +217,14 @@ enabled = true</code></pre>
             <div class="tour-examples">
               <div>
                 <span class="tour-code-label">Schema (.tosd)</span>
-                <pre><code>[elements.database.ports]
+                <pre><code class="language-toml">[elements.database.ports]
 type = "array"
 itemtype = "integer"
 minlength = 1</code></pre>
               </div>
               <div>
                 <span class="tour-code-label">TOML</span>
-                <pre class="toml-example"><code>[database]
+                <pre class="toml-example"><code class="language-toml">[database]
 ports = [8000, 8001]</code></pre>
               </div>
             </div>
@@ -236,7 +238,7 @@ ports = [8000, 8001]</code></pre>
             <div class="tour-examples">
               <div>
                 <span class="tour-code-label">Schema (.tosd)</span>
-                <pre><code>[types.server]
+                <pre><code class="language-toml">[types.server]
 type = "table"
 
 [types.server.ip]
@@ -248,7 +250,7 @@ type = "string"</code></pre>
               </div>
               <div>
                 <span class="tour-code-label">TOML</span>
-                <pre class="toml-example"><code>[servers.primary]
+                <pre class="toml-example"><code class="language-toml">[servers.primary]
 ip = "10.0.0.1"
 role = "frontend"</code></pre>
               </div>
@@ -263,7 +265,7 @@ role = "frontend"</code></pre>
             <div class="tour-examples">
               <div>
                 <span class="tour-code-label">Schema (.tosd)</span>
-                <pre><code>[types.sqliteDatabase]
+                <pre><code class="language-toml">[types.sqliteDatabase]
 type = "table"
 
 [types.sqliteDatabase.engine]
@@ -295,7 +297,7 @@ optional = true</code></pre>
               </div>
               <div>
                 <span class="tour-code-label">TOML</span>
-                <pre class="toml-example"><code>[storage]
+                <pre class="toml-example"><code class="language-toml">[storage]
 engine = "postgresql"
 host = "db.internal"
 port = 5432</code></pre>
@@ -311,14 +313,14 @@ port = 5432</code></pre>
             <div class="tour-examples">
               <div>
                 <span class="tour-code-label">Schema (.tosd)</span>
-                <pre><code>[elements.servers]
+                <pre><code class="language-toml">[elements.servers]
 type = "collection"
 itemtype = "types.server"
 minlength = 1</code></pre>
               </div>
               <div>
                 <span class="tour-code-label">TOML</span>
-                <pre class="toml-example"><code>[servers.primary]
+                <pre class="toml-example"><code class="language-toml">[servers.primary]
 ip = "10.0.0.1"
 role = "frontend"
 
@@ -337,7 +339,7 @@ role = "backend"</code></pre>
             <div class="tour-examples">
               <div>
                 <span class="tour-code-label">Schema (.tosd)</span>
-                <pre><code>[elements.environment]
+                <pre><code class="language-toml">[elements.environment]
 type = "string"
 allowedvalues = ["dev", "stage", "prod"]
 
@@ -348,7 +350,7 @@ max = 10</code></pre>
               </div>
               <div>
                 <span class="tour-code-label">TOML</span>
-                <pre class="toml-example"><code>environment = "prod"
+                <pre class="toml-example"><code class="language-toml">environment = "prod"
 retries = 3</code></pre>
               </div>
             </div>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -24,6 +24,11 @@
   --cp-panel-strong: rgba(255, 255, 255, 0.96);
   --cp-sheen: rgba(255, 255, 255, 0.55);
   --cp-highlight: rgba(177, 31, 75, 0.12);
+  --syntax-comment: #656d76;
+  --syntax-key: #005ea8;
+  --syntax-literal: #754800;
+  --syntax-section: #9a1a41;
+  --syntax-string: #0f6b35;
   --toml-logo-red: #9c4221;
 }
 html[data-theme="dark"] {
@@ -52,6 +57,11 @@ html[data-theme="dark"] {
   --cp-panel-strong: rgba(41, 41, 41, 0.96);
   --cp-sheen: rgba(255, 255, 255, 0.04);
   --cp-highlight: rgba(253, 142, 161, 0.12);
+  --syntax-comment: #b0b0b0;
+  --syntax-key: #79b8ff;
+  --syntax-literal: #fbbf24;
+  --syntax-section: #fd8ea1;
+  --syntax-string: #7ee787;
   --toml-logo-red: #9c4221;
 }
 * {
@@ -79,6 +89,24 @@ a:focus-visible {
 code,
 pre {
   font-family: Consolas, "Courier New", Courier, monospace;
+}
+.hljs-comment {
+  color: var(--syntax-comment);
+  font-style: italic;
+}
+.hljs-attr {
+  color: var(--syntax-key);
+}
+.hljs-literal,
+.hljs-number {
+  color: var(--syntax-literal);
+}
+.hljs-section {
+  color: var(--syntax-section);
+  font-weight: 700;
+}
+.hljs-string {
+  color: var(--syntax-string);
 }
 .page {
   margin: 0 auto;

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -6,8 +6,18 @@
     "": {
       "name": "toml-schema-site-build",
       "dependencies": {
+        "@highlightjs/cdn-assets": "^11.12.0",
         "github-slugger": "^2.0.0",
         "marked": "^12.0.2"
+      }
+    },
+    "node_modules/@highlightjs/cdn-assets": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/@highlightjs/cdn-assets/-/cdn-assets-11.12.0.tgz",
+      "integrity": "sha512-KvOKXODaiFmId9xaq3xc5xCL66wVLUuOngDbO9B/kewbFTqdGbn2nJxNhN3H5R1cgDTVj6R8vH0zgiNDEGjpDw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/github-slugger": {

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -8,6 +8,7 @@
     "render-cli-releases": "node render-cli-releases.mjs"
   },
   "dependencies": {
+    "@highlightjs/cdn-assets": "^11.12.0",
     "github-slugger": "^2.0.0",
     "marked": "^12.0.2"
   }

--- a/scripts/render-docs.mjs
+++ b/scripts/render-docs.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // Render the long-form Markdown documentation into styled on-site pages.
 
-import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { copyFile, readFile, writeFile, mkdir } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { marked } from "marked";
@@ -10,6 +10,12 @@ import GithubSlugger from "github-slugger";
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(here, "..");
 const repositoryUrl = "https://github.com/brunoborges/toml-schema";
+const highlightAssets = join(
+  here,
+  "node_modules",
+  "@highlightjs",
+  "cdn-assets",
+);
 const repositoryDirectories = new Set([
   "reference-implementations/java",
   "reference-implementations/go",
@@ -80,6 +86,16 @@ const renderMarkdown = (markdown) => {
     return `<a href="${escapeHtml(resolvedHref)}"${titleAttribute}>${text}</a>`;
   };
 
+  renderer.code = (code, infoString = "") => {
+    const requestedLanguage = infoString.trim().split(/\s+/, 1)[0].toLowerCase();
+    const language =
+      requestedLanguage === "tosd" ? "toml" : requestedLanguage;
+    const languageClass = language
+      ? ` class="language-${escapeHtml(language)}"`
+      : "";
+    return `<pre><code${languageClass}>${escapeHtml(code)}</code></pre>\n`;
+  };
+
   return marked.parse(markdown, {
     renderer,
     gfm: true,
@@ -87,6 +103,15 @@ const renderMarkdown = (markdown) => {
     mangle: false,
   });
 };
+
+const assetsDirectory = join(repoRoot, "docs", "assets");
+await mkdir(assetsDirectory, { recursive: true });
+await Promise.all([
+  copyFile(
+    join(highlightAssets, "highlight.min.js"),
+    join(assetsDirectory, "highlight.min.js"),
+  ),
+]);
 
 for (const pageConfig of pages) {
   const sourcePath = join(repoRoot, pageConfig.source);
@@ -115,6 +140,8 @@ for (const pageConfig of pages) {
     })();
   </script>
   <link rel="stylesheet" href="../styles.css">
+  <script defer src="/assets/highlight.min.js"></script>
+  <script defer src="/highlight-toml.js"></script>
 </head>
 <body>
   <div class="page">


### PR DESCRIPTION
`.tosd` schemas are valid TOML, but website examples were rendered as untyped code and received no TOML syntax highlighting.

This change marks hand-authored schema examples as `language-toml`, normalizes future `tosd` Markdown fences to TOML in the documentation renderer, and ships local Highlight.js assets with light and dark theme token colors. The generated specification and implementation pages load the same highlighter, so highlighting remains consistent across the site.

**Validation**
- Rendered the generated documentation pages
- Confirmed every labeled `.tosd` example uses `language-toml`
- Confirmed the bundled TOML grammar emits section, key, and string tokens