### PR TITLE
Add schema extraction to Python, Java, and .NET

### DIFF
--- a/REFERENCE_IMPLEMENTATIONS.md
+++ b/REFERENCE_IMPLEMENTATIONS.md
@@ -9,10 +9,10 @@ command-line interface for validation, schema discovery through
 
 | Language | Location | Requires | Interfaces |
 | --- | --- | --- | --- |
-| Java | [`reference-implementations/java`](reference-implementations/java) | Java 25 and Maven | Library, schema discovery |
+| Java | [`reference-implementations/java`](reference-implementations/java) | Java 25 and Maven | Library, schema discovery, schema extraction |
 | Go | [`reference-implementations/go`](reference-implementations/go) | Go 1.27.0 | Library, schema discovery, schema extraction |
-| .NET | [`reference-implementations/dotnet`](reference-implementations/dotnet) | .NET 10.0 | Library, schema discovery |
-| Python | [`reference-implementations/python`](reference-implementations/python) | Python 3.11+ | Library, schema discovery |
+| .NET | [`reference-implementations/dotnet`](reference-implementations/dotnet) | .NET 10.0 | Library, schema discovery, schema extraction |
+| Python | [`reference-implementations/python`](reference-implementations/python) | Python 3.11+ | Library, schema discovery, schema extraction |
 | Rust | [`reference-implementations/rust`](reference-implementations/rust) | Rust 1.97.1 and Cargo | Library, canonical CLI, schema discovery, schema extraction |
 | Node.js / TypeScript | [`reference-implementations/typescript`](reference-implementations/typescript) | Node.js 26.7+ and TypeScript 7 | Library, schema discovery, schema extraction |
 
@@ -25,7 +25,7 @@ package-registry releases.
 The Java 25 reference library uses [Tomlj](https://github.com/tomlj/tomlj) to
 parse TOML and validates the parsed data model against a `.tosd` schema. Its
 library API also supports document-driven schema discovery through
-`[toml-schema].location`.
+`[toml-schema].location` and starter-schema extraction.
 
 Run the full Java test suite:
 
@@ -65,6 +65,12 @@ import org.tomlschema.TomlSchema;
 import org.tomlschema.ValidationResult;
 
 ValidationResult result = TomlSchema.validateDocument(Path.of("config.toml"));
+```
+
+Extract a starter schema:
+
+```java
+TomlSchema.extractSchemaFile(Path.of("config.toml"), Path.of("config.generated.tosd"));
 ```
 
 `TomlSchema.discover(...)` resolves a relative `[toml-schema].location` from the
@@ -116,7 +122,7 @@ The Go test suite includes an ABNF conformance test (`abnf_conformance_test.go`)
 The .NET 10.0 reference library uses [Tomlyn](https://github.com/xoofx/Tomlyn)
 to parse TOML and validates the parsed data model against a `.tosd` schema.
 Its library API also supports document-driven schema discovery through
-`[toml-schema].location`.
+`[toml-schema].location` and starter-schema extraction.
 
 Run the full .NET test suite:
 
@@ -159,6 +165,12 @@ using TomlSchema;
 var result = TomlSchema.TomlSchema.ValidateDocument("config.toml");
 ```
 
+Extract a starter schema:
+
+```csharp
+TomlSchema.TomlSchema.ExtractSchemaFile("config.toml", "config.generated.tosd");
+```
+
 `TomlSchema.Discover(...)` resolves a relative `[toml-schema].location` from
 the document's parent directory, also accepts an absolute local path or a
 hierarchical `file` URI, and rejects unsupported URI schemes, opaque `file`
@@ -174,7 +186,8 @@ The .NET test suite reads `toml-schema.abnf` as a conformance guard and checks t
 The Python 3.11+ reference library uses the standard-library
 [`tomllib`](https://docs.python.org/3/library/tomllib.html) parser to validate
 parsed TOML documents against a `.tosd` schema. Its library API also supports
-document-driven schema discovery through `[toml-schema].location`.
+document-driven schema discovery through `[toml-schema].location` and
+starter-schema extraction.
 
 Run the full Python test suite:
 
@@ -201,6 +214,14 @@ Validate using `[toml-schema].location` from the TOML document:
 from toml_schema import validate_document
 
 result = validate_document("config.toml")
+```
+
+Extract a starter schema:
+
+```python
+from toml_schema import extract_schema_file
+
+extract_schema_file("config.toml", "config.generated.tosd")
 ```
 
 Schema discovery resolves relative locations from the document's parent

--- a/reference-implementations/dotnet/README.md
+++ b/reference-implementations/dotnet/README.md
@@ -90,6 +90,20 @@ document `[toml-schema].version` is compared against the resolved schema's
 declared version: a major-version mismatch fails discovery, while any other
 difference is reported as a warning rather than an error.
 
+## Schema extraction
+
+```csharp
+TomlSchema.TomlSchema.ExtractSchemaFile(
+    "config.toml",
+    "config.generated.tosd"
+);
+```
+
+`TomlSchema.GenerateSchema(TomlTable)` provides the same inference for an
+already parsed document. Extraction infers structure and built-in types, uses
+`any` for empty or heterogeneous array item types, skips reserved root
+`[toml-schema]` metadata, and never invents defaults.
+
 ## Conformance
 
 The test suite includes `AbnfConformanceTests`, which reads [`toml-schema.abnf`](../../toml-schema.abnf) and asserts that the implementation's supported schema keys and built-in type names match the grammar.

--- a/reference-implementations/dotnet/TomlSchema.Tests/SchemaExtractionTests.cs
+++ b/reference-implementations/dotnet/TomlSchema.Tests/SchemaExtractionTests.cs
@@ -1,0 +1,67 @@
+namespace TomlSchema.Tests;
+
+using Tomlyn;
+using Tomlyn.Model;
+using Xunit;
+
+public class SchemaExtractionTests
+{
+    [Fact]
+    public void GeneratesDeterministicSchemaWithQuotedKeys()
+    {
+        var document = TomlSerializer.Deserialize<TomlTable>("""
+            zebra = "last"
+            alpha = 1
+            ratio = 1.5
+            flag = true
+            numbers = [1, 2]
+            mixed = [1, "two"]
+            [nested]
+            "google.com" = "value"
+            [toml-schema]
+            location = "ignored.tosd"
+            """)!;
+
+        var schema = TomlSchema.GenerateSchema(document);
+
+        Assert.Contains("[elements.alpha]\ntype = \"integer\"", schema);
+        Assert.Contains("[elements.numbers]\ntype = \"array\"\nitemtype = \"integer\"", schema);
+        Assert.Contains("[elements.mixed]\ntype = \"array\"\nitemtype = \"any\"", schema);
+        Assert.Contains("[elements.nested.\"google.com\"]\ntype = \"string\"", schema);
+        Assert.DoesNotContain("[elements.toml-schema]", schema);
+        Assert.DoesNotContain("default =", schema);
+        Assert.True(schema.IndexOf("[elements.alpha]", StringComparison.Ordinal)
+            < schema.IndexOf("[elements.zebra]", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ExtractsReloadableSchemaWithAllTemporalTypes()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "toml-schema-extraction-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        var documentPath = Path.Combine(directory, "source.toml");
+        File.WriteAllText(documentPath, """
+            title = "Example"
+            offset = 1979-05-27T07:32:00-08:00
+            local_datetime = 1979-05-27T07:32:00
+            local_date = 1979-05-27
+            local_time = 07:32:00
+            ports = [8080, 8081]
+            [owner]
+            name = "Ada"
+            [toml-schema]
+            location = "ignored.tosd"
+            """);
+        var schemaPath = Path.Combine(directory, "generated.tosd");
+
+        TomlSchema.ExtractSchemaFile(documentPath, schemaPath);
+
+        var schema = File.ReadAllText(schemaPath);
+        Assert.Contains("type = \"offset-date-time\"", schema);
+        Assert.Contains("type = \"local-date-time\"", schema);
+        Assert.Contains("type = \"local-date\"", schema);
+        Assert.Contains("type = \"local-time\"", schema);
+        var result = TomlSchema.Load(schemaPath).Validate(documentPath);
+        Assert.True(result.IsValid, $"Validation failed: {string.Join(", ", result.Errors.Select(error => error.Message))}");
+    }
+}

--- a/reference-implementations/dotnet/TomlSchema/SchemaExtractor.cs
+++ b/reference-implementations/dotnet/TomlSchema/SchemaExtractor.cs
@@ -1,0 +1,114 @@
+namespace TomlSchema;
+
+using System.Text;
+using Tomlyn;
+using Tomlyn.Model;
+
+internal static class SchemaExtractor
+{
+    private const string CurrentSchemaVersion = "1.0.0";
+
+    public static string Generate(TomlTable document)
+    {
+        var schema = new StringBuilder()
+            .Append("[toml-schema]\n")
+            .Append($"version = \"{CurrentSchemaVersion}\"\n\n")
+            .Append("[elements]\n");
+        foreach (var key in document.Keys.Order(StringComparer.Ordinal))
+        {
+            if (key != "toml-schema")
+                AppendDefinition(schema, ["elements", key], document[key]);
+        }
+        return schema.ToString();
+    }
+
+    public static void ExtractFile(string documentPath, string schemaPath)
+    {
+        var document = TomlSerializer.Deserialize<TomlTable>(File.ReadAllText(documentPath))
+            ?? throw new InvalidOperationException($"Failed to parse document: {documentPath}");
+        File.WriteAllText(schemaPath, Generate(document), new UTF8Encoding(false));
+    }
+
+    private static void AppendDefinition(StringBuilder schema, IReadOnlyList<string> path, object? value)
+    {
+        schema.Append('\n').Append('[')
+            .Append(string.Join(".", path.Select(EncodeKey)))
+            .Append("]\n");
+        var type = SchemaTypeOf(value);
+        schema.Append("type = \"").Append(type).Append("\"\n");
+        if (value is TomlArray array)
+            schema.Append("itemtype = \"").Append(InferItemType(array.Cast<object?>())).Append("\"\n");
+        else if (value is TomlTableArray tableArray)
+            schema.Append("itemtype = \"").Append(InferItemType(tableArray.Cast<object?>())).Append("\"\n");
+        if (value is TomlTable table)
+        {
+            foreach (var key in table.Keys.Order(StringComparer.Ordinal))
+                AppendDefinition(schema, [.. path, key], table[key]);
+        }
+    }
+
+    private static string InferItemType(IEnumerable<object?> items)
+    {
+        using var enumerator = items.GetEnumerator();
+        if (!enumerator.MoveNext())
+            return "any";
+        var first = SchemaTypeOf(enumerator.Current);
+        while (enumerator.MoveNext())
+        {
+            if (SchemaTypeOf(enumerator.Current) != first)
+                return "any";
+        }
+        return first;
+    }
+
+    private static string SchemaTypeOf(object? value) => value switch
+    {
+        string => "string",
+        long => "integer",
+        double => "float",
+        bool => "boolean",
+        DateTime dt when dt.Kind == DateTimeKind.Utc => "offset-date-time",
+        DateTime => "local-date-time",
+        DateOnly => "local-date",
+        TimeOnly => "local-time",
+        TomlDateTime { Kind: TomlDateTimeKind.OffsetDateTimeByZ or TomlDateTimeKind.OffsetDateTimeByNumber } => "offset-date-time",
+        TomlDateTime { Kind: TomlDateTimeKind.LocalDateTime } => "local-date-time",
+        TomlDateTime { Kind: TomlDateTimeKind.LocalDate } => "local-date",
+        TomlDateTime { Kind: TomlDateTimeKind.LocalTime } => "local-time",
+        TomlArray or TomlTableArray => "array",
+        TomlTable => "table",
+        _ => "any"
+    };
+
+    private static string EncodeKey(string key)
+    {
+        if (key.Length > 0 && key.All(character =>
+                character is >= 'A' and <= 'Z'
+                    or >= 'a' and <= 'z'
+                    or >= '0' and <= '9'
+                    or '_' or '-'))
+            return key;
+
+        var encoded = new StringBuilder("\"");
+        foreach (var character in key)
+        {
+            switch (character)
+            {
+                case '\\': encoded.Append("\\\\"); break;
+                case '"': encoded.Append("\\\""); break;
+                case '\b': encoded.Append("\\b"); break;
+                case '\t': encoded.Append("\\t"); break;
+                case '\n': encoded.Append("\\n"); break;
+                case '\f': encoded.Append("\\f"); break;
+                case '\r': encoded.Append("\\r"); break;
+                default:
+                    if (character < 0x20 || character == 0x7f)
+                        encoded.Append($"\\u{(int)character:X4}");
+                    else
+                        encoded.Append(character);
+                    break;
+            }
+        }
+        return encoded.Append('"').ToString();
+    }
+}

--- a/reference-implementations/dotnet/TomlSchema/TomlSchema.cs
+++ b/reference-implementations/dotnet/TomlSchema/TomlSchema.cs
@@ -82,6 +82,13 @@ public class TomlSchema
     /// <returns>The validation result, including any discovery version-compatibility warnings.</returns>
     public static ValidationResult ValidateDocument(string documentPath) => Discover(documentPath).Validate();
 
+    /// <summary>Generates a draft TOML Schema describing a parsed TOML document.</summary>
+    public static string GenerateSchema(TomlTable document) => SchemaExtractor.Generate(document);
+
+    /// <summary>Reads a TOML document and writes its inferred draft schema.</summary>
+    public static void ExtractSchemaFile(string documentPath, string schemaPath) =>
+        SchemaExtractor.ExtractFile(documentPath, schemaPath);
+
     /// <summary>Gets the schema language version.</summary>
     public string Version => _version;
 

--- a/reference-implementations/java/README.md
+++ b/reference-implementations/java/README.md
@@ -80,6 +80,20 @@ document `[toml-schema].version` is compared against the resolved schema's
 declared version: a major-version mismatch fails discovery, while any other
 difference is reported as a warning rather than an error.
 
+### Schema extraction
+
+```java
+TomlSchema.extractSchemaFile(
+    Path.of("config.toml"),
+    Path.of("config.generated.tosd")
+);
+```
+
+`TomlSchema.generateSchema(TomlTable)` provides the same inference for an
+already parsed document. Extraction infers structure and built-in types, uses
+`any` for empty or heterogeneous array item types, skips reserved root
+`[toml-schema]` metadata, and never invents defaults.
+
 ## Conformance
 
 The test suite includes `AbnfConformanceTest`, which reads [`toml-schema.abnf`](../../toml-schema.abnf) and asserts that the implementation's supported schema keys and built-in type names match the grammar.

--- a/reference-implementations/java/src/main/java/org/tomlschema/SchemaExtractor.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/SchemaExtractor.java
@@ -1,0 +1,117 @@
+package org.tomlschema;
+
+import org.tomlj.TomlArray;
+import org.tomlj.TomlTable;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+final class SchemaExtractor {
+    private SchemaExtractor() {
+    }
+
+    static String generate(TomlTable document) {
+        StringBuilder schema = new StringBuilder()
+                .append("[toml-schema]\n")
+                .append("version = \"").append(TomlSchemaVersion.CURRENT).append("\"\n\n")
+                .append("[elements]\n");
+        for (String key : sortedKeys(document)) {
+            if (!key.equals("toml-schema")) {
+                appendDefinition(schema, List.of("elements", key), document.get(List.of(key)));
+            }
+        }
+        return schema.toString();
+    }
+
+    private static void appendDefinition(StringBuilder schema, List<String> path, Object value) {
+        schema.append("\n[");
+        for (int index = 0; index < path.size(); index++) {
+            if (index > 0) {
+                schema.append('.');
+            }
+            schema.append(encodeKey(path.get(index)));
+        }
+        String type = schemaType(value);
+        schema.append("]\ntype = \"").append(type).append("\"\n");
+        if (value instanceof TomlArray array) {
+            schema.append("itemtype = \"").append(inferItemType(array)).append("\"\n");
+        }
+        if (value instanceof TomlTable table) {
+            for (String key : sortedKeys(table)) {
+                List<String> childPath = new ArrayList<>(path);
+                childPath.add(key);
+                appendDefinition(schema, childPath, table.get(List.of(key)));
+            }
+        }
+    }
+
+    private static String schemaType(Object value) {
+        return switch (value) {
+            case null -> "any";
+            case String _ -> "string";
+            case Long _ -> "integer";
+            case Double _ -> "float";
+            case Boolean _ -> "boolean";
+            case OffsetDateTime _ -> "offset-date-time";
+            case LocalDateTime _ -> "local-date-time";
+            case LocalDate _ -> "local-date";
+            case LocalTime _ -> "local-time";
+            case TomlArray _ -> "array";
+            case TomlTable _ -> "table";
+            default -> "any";
+        };
+    }
+
+    private static String inferItemType(TomlArray array) {
+        if (array.isEmpty()) {
+            return "any";
+        }
+        String first = schemaType(array.get(0));
+        for (int index = 1; index < array.size(); index++) {
+            if (!schemaType(array.get(index)).equals(first)) {
+                return "any";
+            }
+        }
+        return first;
+    }
+
+    private static List<String> sortedKeys(TomlTable table) {
+        List<String> keys = new ArrayList<>(table.keySet());
+        Collections.sort(keys);
+        return keys;
+    }
+
+    private static String encodeKey(String key) {
+        if (!key.isEmpty() && key.chars().allMatch(character ->
+                Character.isLetterOrDigit(character) && character < 128
+                        || character == '_' || character == '-')) {
+            return key;
+        }
+        StringBuilder encoded = new StringBuilder("\"");
+        for (int index = 0; index < key.length(); index++) {
+            char character = key.charAt(index);
+            switch (character) {
+                case '\\' -> encoded.append("\\\\");
+                case '"' -> encoded.append("\\\"");
+                case '\b' -> encoded.append("\\b");
+                case '\t' -> encoded.append("\\t");
+                case '\n' -> encoded.append("\\n");
+                case '\f' -> encoded.append("\\f");
+                case '\r' -> encoded.append("\\r");
+                default -> {
+                    if (character < 0x20 || character == 0x7f) {
+                        encoded.append(String.format("\\u%04X", (int) character));
+                    } else {
+                        encoded.append(character);
+                    }
+                }
+            }
+        }
+        return encoded.append('"').toString();
+    }
+}

--- a/reference-implementations/java/src/main/java/org/tomlschema/TomlSchema.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/TomlSchema.java
@@ -6,6 +6,8 @@ import org.tomlj.TomlParseResult;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Files;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -104,6 +106,34 @@ public final class TomlSchema {
      */
     public static ValidationResult validateDocument(Path documentPath) throws IOException {
         return discover(documentPath).validate();
+    }
+
+    /**
+     * Generates a draft TOML Schema describing an already parsed TOML document.
+     *
+     * @param document the parsed TOML document
+     * @return deterministic TOML Schema source text
+     */
+    public static String generateSchema(org.tomlj.TomlTable document) {
+        return SchemaExtractor.generate(document);
+    }
+
+    /**
+     * Reads a TOML document and writes its inferred draft schema.
+     *
+     * @param documentPath the source TOML document
+     * @param schemaPath the draft schema destination
+     * @throws IOException if either file cannot be read or written
+     * @throws SchemaException if the source document is invalid TOML
+     */
+    public static void extractSchemaFile(Path documentPath, Path schemaPath) throws IOException {
+        TomlParseResult document = Toml.parse(documentPath);
+        if (document.hasErrors()) {
+            throw new SchemaException("Unable to parse document " + documentPath + ": "
+                    + document.errors().stream().map(Object::toString)
+                    .collect(Collectors.joining("; ")));
+        }
+        Files.writeString(schemaPath, generateSchema(document), StandardCharsets.UTF_8);
     }
 
     Path source() {

--- a/reference-implementations/java/src/test/java/org/tomlschema/SchemaExtractionTest.java
+++ b/reference-implementations/java/src/test/java/org/tomlschema/SchemaExtractionTest.java
@@ -1,0 +1,72 @@
+package org.tomlschema;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.tomlj.Toml;
+import org.tomlj.TomlParseResult;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SchemaExtractionTest {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void generatesDeterministicSchemaWithQuotedKeys() {
+        TomlParseResult document = Toml.parse("""
+                zebra = "last"
+                alpha = 1
+                ratio = 1.5
+                flag = true
+                numbers = [1, 2]
+                mixed = [1, "two"]
+                [nested]
+                "google.com" = "value"
+                [toml-schema]
+                location = "ignored.tosd"
+                """);
+
+        String schema = TomlSchema.generateSchema(document);
+
+        assertTrue(schema.contains("[elements.alpha]\ntype = \"integer\""));
+        assertTrue(schema.contains("[elements.numbers]\ntype = \"array\"\nitemtype = \"integer\""));
+        assertTrue(schema.contains("[elements.mixed]\ntype = \"array\"\nitemtype = \"any\""));
+        assertTrue(schema.contains("[elements.nested.\"google.com\"]\ntype = \"string\""));
+        assertFalse(schema.contains("[elements.toml-schema]"));
+        assertFalse(schema.contains("default ="));
+        assertTrue(schema.indexOf("[elements.alpha]") < schema.indexOf("[elements.zebra]"));
+    }
+
+    @Test
+    void extractsReloadableSchemaWithAllTemporalTypes() throws IOException {
+        Path document = tempDir.resolve("source.toml");
+        Files.writeString(document, """
+                title = "Example"
+                offset = 1979-05-27T07:32:00-08:00
+                local_datetime = 1979-05-27T07:32:00
+                local_date = 1979-05-27
+                local_time = 07:32:00
+                ports = [8080, 8081]
+                [owner]
+                name = "Ada"
+                [toml-schema]
+                location = "ignored.tosd"
+                """);
+        Path extracted = tempDir.resolve("generated.tosd");
+
+        TomlSchema.extractSchemaFile(document, extracted);
+
+        String schema = Files.readString(extracted);
+        assertTrue(schema.contains("type = \"offset-date-time\""));
+        assertTrue(schema.contains("type = \"local-date-time\""));
+        assertTrue(schema.contains("type = \"local-date\""));
+        assertTrue(schema.contains("type = \"local-time\""));
+        ValidationResult result = TomlSchema.load(extracted).validate(document);
+        assertTrue(result.isValid(), () -> "Validation failed: " + result.errors());
+    }
+}

--- a/reference-implementations/python/README.md
+++ b/reference-implementations/python/README.md
@@ -69,6 +69,18 @@ result = schema.validate(document)
 print(schema.warnings)  # e.g. schema-version compatibility notices
 ```
 
+Extract a starter schema from a TOML document:
+
+```python
+from toml_schema import extract_schema_file
+
+extract_schema_file("config.toml", "config.generated.tosd")
+```
+
+Extraction infers structure and built-in types, uses `any` for empty or
+heterogeneous array item types, skips reserved root `[toml-schema]` metadata,
+and never invents defaults.
+
 Schema discovery resolves relative `location` values against the document's
 own directory, accepts absolute local paths, and accepts hierarchical
 `file://` URIs (rejecting opaque `file:` URIs, non-local hosts, and
@@ -93,6 +105,8 @@ child = element.child("host")    # nested Definition, or None
   schema file, raising `toml_schema.SchemaError` on any structural or
   semantic problem.
 - `load_document(path) -> dict` — parses a TOML document with `tomllib`.
+- `generate_schema(document: dict) -> str` — infers starter-schema source text.
+- `extract_schema_file(document_path, schema_path)` — writes an inferred schema.
 - `Schema.validate(document: dict) -> ValidationResult`
 - `Schema.validate_file(path) -> ValidationResult`
 - `Schema.element(name) / Schema.type(name) -> Definition | None` — schema

--- a/reference-implementations/python/src/toml_schema/__init__.py
+++ b/reference-implementations/python/src/toml_schema/__init__.py
@@ -30,6 +30,7 @@ from ._discovery import (
     validate_document,
 )
 from ._errors import DiscoveryError, SchemaError
+from ._extract import extract_schema_file, generate_schema
 from ._schema import Schema, load_document, load_schema
 from ._types import Diagnostic, Severity, SchemaType, ValidationError, ValidationResult
 
@@ -39,6 +40,8 @@ __all__ = [
     "__version__",
     "load_schema",
     "load_document",
+    "generate_schema",
+    "extract_schema_file",
     "schema_from_document",
     "validate_document",
     "resolve_schema_location",

--- a/reference-implementations/python/src/toml_schema/_extract.py
+++ b/reference-implementations/python/src/toml_schema/_extract.py
@@ -1,0 +1,79 @@
+"""Starter-schema extraction from parsed TOML documents."""
+
+from __future__ import annotations
+
+import datetime
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from ._schema import CURRENT_TOML_SCHEMA_VERSION, load_document
+
+_BARE_KEY = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def generate_schema(document: dict[str, Any]) -> str:
+    """Generates a draft TOML Schema describing a parsed TOML document."""
+    lines = [
+        "[toml-schema]",
+        f'version = "{CURRENT_TOML_SCHEMA_VERSION}"',
+        "",
+        "[elements]",
+    ]
+    for key in sorted(document):
+        if key != "toml-schema":
+            _append_definition(lines, ("elements", key), document[key])
+    return "\n".join(lines) + "\n"
+
+
+def extract_schema_file(document_path: str, schema_path: str) -> None:
+    """Reads a TOML document and writes its inferred draft schema."""
+    schema = generate_schema(load_document(document_path))
+    Path(schema_path).write_text(schema, encoding="utf-8")
+
+
+def _append_definition(lines: list[str], path: tuple[str, ...], value: Any) -> None:
+    lines.extend(("", f"[{'.'.join(_encode_key(part) for part in path)}]"))
+    type_name = _schema_type(value)
+    lines.append(f'type = "{type_name}"')
+    if type_name == "array":
+        lines.append(f'itemtype = "{_infer_item_type(value)}"')
+    if isinstance(value, dict):
+        for key in sorted(value):
+            _append_definition(lines, path + (key,), value[key])
+
+
+def _schema_type(value: Any) -> str:
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, int):
+        return "integer"
+    if isinstance(value, float):
+        return "float"
+    if isinstance(value, datetime.datetime):
+        return "offset-date-time" if value.utcoffset() is not None else "local-date-time"
+    if isinstance(value, datetime.date):
+        return "local-date"
+    if isinstance(value, datetime.time):
+        return "local-time"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, dict):
+        return "table"
+    return "any"
+
+
+def _infer_item_type(items: list[Any]) -> str:
+    if not items:
+        return "any"
+    first = _schema_type(items[0])
+    return first if all(_schema_type(item) == first for item in items[1:]) else "any"
+
+
+def _encode_key(key: str) -> str:
+    if _BARE_KEY.fullmatch(key):
+        return key
+    return json.dumps(key, ensure_ascii=False)

--- a/reference-implementations/python/tests/test_extraction.py
+++ b/reference-implementations/python/tests/test_extraction.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from helpers import write_file
+from toml_schema import extract_schema_file, generate_schema, load_document, load_schema
+
+
+class SchemaExtractionTests(unittest.TestCase):
+    def test_generates_deterministic_schema_for_parsed_values(self) -> None:
+        document = {
+            "zebra": "last",
+            "alpha": 1,
+            "ratio": 1.5,
+            "flag": True,
+            "numbers": [1, 2],
+            "mixed": [1, "two"],
+            "nested": {"google.com": "value"},
+            "toml-schema": {"location": "ignored.tosd"},
+        }
+
+        schema = generate_schema(document)
+
+        self.assertIn('[elements.alpha]\ntype = "integer"', schema)
+        self.assertIn('[elements.flag]\ntype = "boolean"', schema)
+        self.assertIn('[elements.ratio]\ntype = "float"', schema)
+        self.assertIn('[elements.numbers]\ntype = "array"\nitemtype = "integer"', schema)
+        self.assertIn('[elements.mixed]\ntype = "array"\nitemtype = "any"', schema)
+        self.assertIn('[elements.nested."google.com"]\ntype = "string"', schema)
+        self.assertNotIn("[elements.toml-schema]", schema)
+        self.assertNotIn("default =", schema)
+        self.assertLess(schema.index("[elements.alpha]"), schema.index("[elements.zebra]"))
+
+    def test_extracts_reloadable_schema_with_all_temporal_types(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            document_path = write_file(
+                directory,
+                "source.toml",
+                """
+title = "Example"
+offset = 1979-05-27T07:32:00-08:00
+local_datetime = 1979-05-27T07:32:00
+local_date = 1979-05-27
+local_time = 07:32:00
+ports = [8080, 8081]
+
+[owner]
+name = "Ada"
+
+[toml-schema]
+location = "ignored.tosd"
+""",
+            )
+            schema_path = f"{directory}/generated.tosd"
+
+            extract_schema_file(document_path, schema_path)
+
+            schema_text = Path(schema_path).read_text(encoding="utf-8")
+            self.assertIn('type = "offset-date-time"', schema_text)
+            self.assertIn('type = "local-date-time"', schema_text)
+            self.assertIn('type = "local-date"', schema_text)
+            self.assertIn('type = "local-time"', schema_text)
+            result = load_schema(schema_path).validate(load_document(document_path))
+            self.assertTrue(result.valid, result.errors)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Schema extraction is currently available in the Go, Rust, and TypeScript reference implementations, leaving Python, Java, and .NET without equivalent starter-schema generation APIs. This adds consistent extraction support across those three libraries.

## Summary

- Add in-memory schema generation and file-to-file extraction APIs for Python, Java, and .NET.
- Infer scalar, temporal, table, and array types with deterministic key ordering.
- Quote TOML keys when required, omit reserved root `[toml-schema]` metadata, and avoid inventing defaults.
- Add end-to-end tests that reload generated schemas and validate their source documents.
- Update implementation status and usage documentation.

## Validation

- Python full test suite passes (79 tests).
- .NET full test suite passes (52 tests).
- Java schema extraction tests pass.
- The Java full suite still reports the unrelated pre-existing `validatesWebsiteExamples` failure because the website hero schema fixture is absent.