### PR TITLE
Accept highlighted website code blocks

### DIFF
--- a/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
+++ b/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
@@ -1681,7 +1681,7 @@ class TomlSchemaTest {
     @Test
     void validatesWebsiteExamples() throws IOException {
         String page = Files.readString(fixture("docs/index.html"), StandardCharsets.UTF_8);
-        Pattern codeBlock = Pattern.compile("<pre><code>(.*?)</code></pre>", Pattern.DOTALL);
+        Pattern codeBlock = Pattern.compile("<pre><code(?:\\s+[^>]*)?>(.*?)</code></pre>", Pattern.DOTALL);
 
         Matcher hero = Pattern.compile("<aside class=\"panel\".*?</aside>", Pattern.DOTALL).matcher(page);
         assertTrue(hero.find(), "Website hero example is missing");


### PR DESCRIPTION
The website now adds syntax-highlighting attributes to TOML code elements, but the Java conformance test only recognized bare `<code>` tags. This updates the matcher to accept code attributes while preserving the distinction between schema and document examples.

The focused website-example test and full Java suite pass.