### PR TITLE
Add standardized string format assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ TOML document:
 title = "TOML Example"
 
 [database]
+server = "192.0.2.10"
 enabled = true
 ports = [8000, 8001, 8002]
 ```
@@ -70,6 +71,10 @@ type = "string"
 
 [elements.database]
 type = "table"
+
+    [elements.database.server]
+    type = "string"
+    format = "ipv4"
 
     [elements.database.enabled]
     type = "boolean"

--- a/REFERENCE_IMPLEMENTATIONS.md
+++ b/REFERENCE_IMPLEMENTATIONS.md
@@ -341,8 +341,8 @@ Every reference implementation should:
 1. Validate `toml-schema.tosd` against itself.
 1. Keep supported schema vocabulary aligned with `toml-schema.abnf` and `toml-schema.tosd`.
 1. Implement the TOML Schema 1.0 semantic vocabulary, including sibling
-   presence rules, conjunctive composition, array uniqueness, defaults, and
-   deprecation warnings.
+   presence rules, conjunctive composition, array uniqueness, standardized
+   string formats, defaults, and deprecation warnings.
 1. Keep validation non-mutating and expose warnings separately from errors;
    warning-only validation remains valid.
 
@@ -388,5 +388,5 @@ TOML document path. Every implementation should include:
 
 1. Tests for the checked-in example, self-schema validation, schema-location
    lookup, unions, composition, arrays, collections, sibling rules,
-   annotations, diagnostics, and key-escaping behavior.
+   string formats, annotations, diagnostics, and key-escaping behavior.
 1. A vocabulary conformance check against `toml-schema.abnf` or an equivalent generated/derived assertion.

--- a/SPEC.md
+++ b/SPEC.md
@@ -37,6 +37,7 @@ command.
   - [Quoted and Special Keys](#quoted-and-special-keys)
   - [Scalar and Unconstrained Built-in Types](#scalar-and-unconstrained-built-in-types)
     - [Allowed Values - `allowedvalues`](#allowed-values---allowedvalues)
+    - [String Format - `format`](#string-format---format)
   - [Minimum Value / Maximum Value - `min` and `max`](#minimum-value--maximum-value---min-and-max)
   - [Length - `minlength` and `maxlength`](#length---minlength-and-maxlength)
   - [Container Types](#container-types)
@@ -111,7 +112,7 @@ type="table"
 
     [types.serverType.ip]
     type="string"
-    pattern='^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$'
+    format="ipv4"
     [types.serverType.role]
     type="string"
 
@@ -340,6 +341,7 @@ because each recursive step consumes a nested document value.
 [types.<typename>]
 type = "<type-reference>"
 description = "<human-readable description>"
+format = "<email|uuid|uri|hostname|ipv4|ipv6>"
 itemtype = "<type-reference>"
 items = [ "<type-reference>", ... ]
 oneof = [ "<type-reference>", ... ]
@@ -374,6 +376,7 @@ detailed sections below remain authoritative.
 | `if`, `then`, `else` | Exhaustively select one of two named table-like definitions from a direct child's parsed value |
 | `allof` | Conjunctively applies one or more compatible type references in addition to the local definition |
 | `description`, `optional`, `default`, `deprecated` | Any definition, including a named reference or alternative selector |
+| `format` | A definition with built-in `type = "string"` |
 | `itemtype` | A definition with built-in `type = "array"` or `type = "collection"` |
 | `items` | A definition with built-in `type = "array"`; mutually exclusive with `itemtype`, `allowedvalues`, `min`, `max`, `minlength`, and `maxlength` |
 | `allowedvalues` | A scalar or unconstrained built-in type, or the items of a non-tuple `array` |
@@ -471,7 +474,7 @@ equality between integers and floats does not make their TOML kinds
 interchangeable for this schema-load check. A malformed enumeration MUST be
 rejected at schema-load time.
 
-For a non-array definition, when `allowedvalues` is combined with `pattern`,
+For a non-array definition, when `allowedvalues` is combined with `pattern`, `format`,
 `min`, `max`, `minlength`, or `maxlength`, every entry in `allowedvalues` MUST
 satisfy every applicable constraint. A schema containing an entry that violates
 one of those constraints is malformed, and schema loaders MUST reject it at
@@ -493,6 +496,70 @@ Example:
 [types.colorType]
 type="string"
 allowedvalues=[ "red", "black", "blue" ]
+```
+
+#### String Format - `format`
+
+`format` applies a standardized semantic assertion to a parsed TOML string.
+It MUST be one of the following case-sensitive names:
+
+| Format | Required syntax |
+| --- | --- |
+| `email` | An ASCII SMTP `Mailbox` as defined by [RFC 5321, section 4.1.2](https://www.rfc-editor.org/rfc/rfc5321#section-4.1.2), with the length limits from section 4.5.3.1 |
+| `uuid` | The hexadecimal-and-dash UUID representation defined by [RFC 9562, section 4](https://www.rfc-editor.org/rfc/rfc9562#section-4) |
+| `uri` | An absolute `URI` as defined by [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986), including a scheme |
+| `hostname` | The preferred ASCII host-name syntax from [RFC 1123, section 2.1](https://www.rfc-editor.org/rfc/rfc1123#section-2.1) |
+| `ipv4` | IPv4 dotted-decimal notation |
+| `ipv6` | IPv6 text representation as defined by [RFC 4291, section 2.2](https://www.rfc-editor.org/rfc/rfc4291#section-2.2) |
+
+The formats use the following portable rules:
+
+- `email` accepts the RFC 5321 dot-string and quoted-string local-part forms.
+  It is not an internationalized mailbox format: every character MUST be ASCII.
+  The local-part MUST be at most 64 octets and the complete mailbox MUST be at
+  most 254 octets. The domain MUST be an RFC 1123 host name or an RFC 5321
+  `address-literal` as defined by RFC 5321, including IPv4, IPv6, and registered
+  General-address-literal forms. Validators MUST parse these structures and
+  MUST NOT substitute a simplified `text@text` regular expression.
+- `uuid` consists of exactly 32 hexadecimal digits, case-insensitive, displayed
+  in groups of 8, 4, 4, 4, and 12 digits separated by hyphens.
+- `uri` MUST match the RFC 3986 `URI` production rather than `relative-ref`.
+  It is ASCII; non-ASCII components must be percent-encoded. Every percent
+  escape MUST contain exactly two hexadecimal digits.
+- `hostname` is ASCII and case-insensitive. After excluding one optional final
+  root dot, its total length MUST be from 1 through 253 characters. Each
+  dot-separated label MUST contain 1 through 63 ASCII letters, digits, or
+  hyphens, MUST begin and end with a letter or digit, and MAY be entirely
+  numeric.
+- `ipv4` contains exactly four decimal octets from 0 through 255 separated by
+  dots. An octet MUST NOT contain a leading zero unless the octet is exactly
+  `0`.
+- `ipv6` accepts the compressed and IPv4-embedded forms defined by RFC 4291.
+  It does not accept a URI host's brackets or a zone identifier. An embedded
+  IPv4 suffix follows the `ipv4` rules above.
+
+`format` is valid only on a definition whose selected type is the built-in
+`string`. It cannot be attached to another built-in type, an alternative
+selector, or a named type reference. A schema loader MUST reject an unsupported
+format name or incompatible use at schema-load time rather than ignoring it.
+
+When `format` is combined with `allowedvalues`, every allowed string MUST
+satisfy the format at schema-load time. `format` is independent of `pattern`,
+`minlength`, and `maxlength`; a document string MUST satisfy every declared
+constraint.
+
+```toml
+[elements.contact]
+type = "string"
+format = "email"
+
+[elements.endpoint]
+type = "string"
+format = "uri"
+
+[elements.instance-id]
+type = "string"
+format = "uuid"
 ```
 
 ### Minimum Value / Maximum Value - `min` and `max`
@@ -1515,6 +1582,8 @@ patterns used by major configuration formats, including:
   `anyof`;
 - table shapes selected from a direct child's value with `if`, `then`, and
   `else`;
+- standardized email, UUID, URI, host-name, and IP-address strings with
+  `format`;
 - single-table-or-array-of-table representations through named container
   alternatives;
 - fixed-length heterogeneous arrays with `items`; and

--- a/config.toml
+++ b/config.toml
@@ -59,11 +59,11 @@ enabled = true
 		  		[serverGroups.group1.servers.beta.replicas]
 
 		  			[serverGroups.group1.servers.beta.replicas.rp1]
-		  			ip = "..."
+					ip = "10.0.1.1"
 		  			dc = "..."
 
 		  			[serverGroups.group1.servers.beta.replicas.rp2]
-		  			ip = "..."
+					ip = "10.0.1.2"
 		  			dc = "..."
 
 [clients]

--- a/config.tosd
+++ b/config.tosd
@@ -10,6 +10,7 @@ version = "1.0.0"
 
         [types.databaseType.server]
         type = "string"
+        format = "ipv4"
 
         [types.databaseType.ports]
         type = "array"
@@ -26,6 +27,7 @@ version = "1.0.0"
 
         [types.serverType.ip]
         type = "string"
+        format = "ipv4"
 
         [types.serverType.dc]
         type = "string"

--- a/reference-implementations/dotnet/TomlSchema.Tests/StringFormatTests.cs
+++ b/reference-implementations/dotnet/TomlSchema.Tests/StringFormatTests.cs
@@ -1,0 +1,169 @@
+namespace TomlSchema.Tests;
+
+using Tomlyn.Model;
+using Xunit;
+
+public class StringFormatTests : TestBase
+{
+    public static TheoryData<string, string, string> FormatCases => new()
+    {
+        { "email", "simple@example.com", "simple..dot@example.com" },
+        { "uuid", "01234567-89ab-cdef-0123-456789abcdef", "{01234567-89ab-cdef-0123-456789abcdef}" },
+        { "uri", "https://example.com/a%20b?x=1", "relative/path" },
+        { "hostname", "www.example.com.", "-bad.example" },
+        { "ipv4", "192.0.2.1", "192.168.001.1" },
+        { "ipv6", "2001:db8::192.0.2.1", "2001:db8::192.168.001.1" }
+    };
+
+    [Theory]
+    [MemberData(nameof(FormatCases))]
+    public void ValidatesSupportedFormats(string format, string valid, string invalid)
+    {
+        var schema = Schema(format);
+
+        Assert.True(Validate(schema, valid).IsValid);
+        var result = Validate(schema, invalid);
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, error => error.Code == "format"
+            && error.Message.Contains(format, StringComparison.Ordinal));
+    }
+
+    public static TheoryData<string, bool> EmailCases => new()
+    {
+        { "first.last+tag@example.com", true },
+        { "\"quoted local\"@example.com", true },
+        { "\"contains@sign\"@example.com", true },
+        { "\"escaped\\\"quote\"@example.com", true },
+        { "postmaster@[192.0.2.1]", true },
+        { "postmaster@[IPv6:2001:db8::1]", true },
+        { "postmaster@[TAG:value]", true },
+        { "postmaster@[TAG-:value]", false },
+        { ".leading@example.com", false },
+        { "trailing.@example.com", false },
+        { "two..dots@example.com", false },
+        { "unquoted space@example.com", false },
+        { "\"unterminated@example.com", false },
+        { "nonascii-é@example.com", false },
+        { "user@example..com", false },
+        { "user@[IPv6:192.0.2.1]", false }
+    };
+
+    [Theory]
+    [MemberData(nameof(EmailCases))]
+    public void ValidatesRfc5321MailboxCases(string mailbox, bool expected) =>
+        Assert.Equal(expected, Validate(Schema("email"), mailbox).IsValid);
+
+    [Fact]
+    public void EnforcesEmailOctetLimits()
+    {
+        Assert.True(Validate(Schema("email"), $"{new string('a', 64)}@example.com").IsValid);
+        Assert.False(Validate(Schema("email"), $"{new string('a', 65)}@example.com").IsValid);
+
+        var domain = string.Join(".", Enumerable.Repeat(new string('a', 63), 3))
+            + "." + new string('b', 61);
+        Assert.Equal(253, domain.Length);
+        Assert.False(Validate(Schema("email"), $"a@{domain}").IsValid);
+    }
+
+    [Theory]
+    [InlineData("urn:isbn:9780131103627", true)]
+    [InlineData("mailto:user@example.com", true)]
+    [InlineData("https://example.com/bad%2", false)]
+    [InlineData("https://example.com/{bad}", false)]
+    [InlineData("http://example.com/#first#second", false)]
+    public void ValidatesAbsoluteRfc3986Uris(string uri, bool expected) =>
+        Assert.Equal(expected, Validate(Schema("uri"), uri).IsValid);
+
+    [Theory]
+    [InlineData("integer", "email", "format is valid only")]
+    [InlineData("types.text", "email", "format is valid only")]
+    [InlineData("string", "date", "unknown string format")]
+    public void RejectsIncompatibleOrUnknownFormatsAtSchemaLoad(
+        string type, string format, string expectedMessage)
+    {
+        var schemaPath = Write($"invalid-format-{Guid.NewGuid():N}.tosd", $$"""
+            [toml-schema]
+            version = "1.0.0"
+
+            [types.text]
+            type = "string"
+
+            [elements.value]
+            type = "{{type}}"
+            format = "{{format}}"
+            """);
+
+        var error = Assert.Throws<InvalidOperationException>(() => TomlSchema.Load(schemaPath));
+        Assert.Contains(expectedMessage, error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RejectsNonStringFormatAtSchemaLoad()
+    {
+        var schemaPath = Write($"non-string-format-{Guid.NewGuid():N}.tosd", """
+            [toml-schema]
+            version = "1.0.0"
+
+            [elements.value]
+            type = "string"
+            format = 42
+            """);
+
+        var error = Assert.Throws<InvalidOperationException>(() => TomlSchema.Load(schemaPath));
+        Assert.Contains("format must be a string", error.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("allowedvalues = [\"192.168.001.1\"]")]
+    [InlineData("default = \"192.168.001.1\"")]
+    public void RejectsFormattedAnnotationsThatViolateTheFormat(string annotation)
+    {
+        var schemaPath = Write($"invalid-format-annotation-{Guid.NewGuid():N}.tosd", $$"""
+            [toml-schema]
+            version = "1.0.0"
+
+            [elements.value]
+            type = "string"
+            format = "ipv4"
+            {{annotation}}
+            """);
+
+        var error = Assert.Throws<InvalidOperationException>(() => TomlSchema.Load(schemaPath));
+        Assert.Contains("does not satisfy format ipv4", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RejectsFormattedDefaultOutsideAllowedValues()
+    {
+        var schemaPath = Write($"invalid-format-default-{Guid.NewGuid():N}.tosd", """
+            [toml-schema]
+            version = "1.0.0"
+
+            [elements.value]
+            type = "string"
+            format = "ipv4"
+            allowedvalues = ["192.0.2.1"]
+            default = "198.51.100.1"
+            """);
+
+        var error = Assert.Throws<InvalidOperationException>(() => TomlSchema.Load(schemaPath));
+        Assert.Contains("default is not included in allowedvalues", error.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("scheme:")]
+    [InlineData("http://[v1.fe]/")]
+    public void AcceptsRfc3986UriEdgeCases(string value) =>
+        Assert.True(Validate(Schema("uri"), value).IsValid);
+
+    private static TomlSchema Schema(string format) => new(
+        "1.0.0",
+        new Dictionary<string, SchemaDefinition>(),
+        new Dictionary<string, SchemaDefinition>
+        {
+            ["value"] = new() { Type = SchemaType.String, Format = format }
+        });
+
+    private static ValidationResult Validate(TomlSchema schema, string value) =>
+        schema.Validate(new TomlTable { ["value"] = value });
+}

--- a/reference-implementations/dotnet/TomlSchema/SchemaDefinition.cs
+++ b/reference-implementations/dotnet/TomlSchema/SchemaDefinition.cs
@@ -26,6 +26,9 @@ public record SchemaDefinition
     /// <summary>Regex pattern for string validation</summary>
     public string? Pattern { get; init; }
 
+    /// <summary>Well-known format for string validation</summary>
+    public string? Format { get; init; }
+
     /// <summary>Regex pattern for collection dynamic key validation</summary>
     public string? KeyPattern { get; init; }
 

--- a/reference-implementations/dotnet/TomlSchema/SchemaLoader.cs
+++ b/reference-implementations/dotnet/TomlSchema/SchemaLoader.cs
@@ -12,7 +12,7 @@ public class SchemaLoader
     /// <summary>All allowed schema property keys</summary>
     public static readonly HashSet<string> DefinitionKeys = new()
     {
-        "type", "description", "itemtype", "items", "allowedvalues", "pattern", "keypattern",
+        "type", "description", "itemtype", "items", "allowedvalues", "pattern", "format", "keypattern",
         "optional", "min", "max", "minlength", "maxlength", "oneof", "anyof", "allof",
         "dependentrequired", "mutuallyexclusive", "exactlyone", "uniqueitems", "default",
         "deprecated", "if", "then", "else"
@@ -149,6 +149,15 @@ public class SchemaLoader
         var hasAnyOf = table.ContainsKey("anyof");
         var hasConditional = table.ContainsKey("if");
 
+        var format = GetString(table, "format");
+        if (format != null)
+        {
+            if (type != SchemaType.String || reference != null)
+                throw new InvalidOperationException($"{location} format is valid only with a locally selected built-in string type");
+            if (!StringFormatValidator.IsSupported(format))
+                throw new InvalidOperationException($"{location} contains unknown string format: {format}");
+        }
+
         // Enforce allowed keys based on definition type
         foreach (var key in table.Keys)
         {
@@ -198,6 +207,30 @@ public class SchemaLoader
         var allowedValues = table.TryGetValue("allowedvalues", out var avValue) && avValue is TomlArray avArray
             ? avArray.Cast<object?>().ToList()
             : null;
+        var defaultValue = GetValue(table, "default");
+
+        if (format != null)
+        {
+            if (allowedValues != null)
+            {
+                foreach (var allowedValue in allowedValues)
+                {
+                    if (allowedValue is not string text || !StringFormatValidator.IsValid(format, text))
+                        throw new InvalidOperationException(
+                            $"{location}.allowedvalues contains a value that does not satisfy format {format}");
+                }
+            }
+            if (table.ContainsKey("default")
+                && (defaultValue is not string defaultText
+                    || !StringFormatValidator.IsValid(format, defaultText)))
+                throw new InvalidOperationException(
+                    $"{location}.default does not satisfy format {format}");
+            if (defaultValue is string formattedDefault
+                && allowedValues != null
+                && !allowedValues.OfType<string>().Contains(formattedDefault, StringComparer.Ordinal))
+                throw new InvalidOperationException(
+                    $"{location}.default is not included in allowedvalues");
+        }
 
         var mutuallyExclusive = table.TryGetValue("mutuallyexclusive", out var meValue) && meValue is TomlArray meArray
             ? ParseNameGroups(meArray)
@@ -216,6 +249,7 @@ public class SchemaLoader
             Items = GetStringArray(table, "items"),
             AllowedValues = allowedValues,
             Pattern = GetString(table, "pattern"),
+            Format = format,
             KeyPattern = GetString(table, "keypattern"),
             Optional = GetBool(table, "optional") ?? false,
             Min = GetNumber(table, "min"),
@@ -226,7 +260,7 @@ public class SchemaLoader
             OneOf = oneOf,
             AnyOf = anyOf,
             AllOf = allOf,
-            Default = GetValue(table, "default"),
+            Default = defaultValue,
             Deprecated = GetBool(table, "deprecated") ?? false,
             Condition = condition,
             Children = children,

--- a/reference-implementations/dotnet/TomlSchema/SchemaValidator.cs
+++ b/reference-implementations/dotnet/TomlSchema/SchemaValidator.cs
@@ -198,6 +198,10 @@ internal class SchemaValidator
                     _errors.Add(new ValidationError(path, $"invalid regex pattern", "pattern"));
                 }
             }
+
+            if (effectiveSchema.Format != null && !StringFormatValidator.IsValid(effectiveSchema.Format, strVal))
+                _errors.Add(new ValidationError(path,
+                    $"string is not a valid {effectiveSchema.Format}", "format"));
         }
 
         // Numeric constraints

--- a/reference-implementations/dotnet/TomlSchema/StringFormatValidator.cs
+++ b/reference-implementations/dotnet/TomlSchema/StringFormatValidator.cs
@@ -1,0 +1,234 @@
+namespace TomlSchema;
+
+using System.Net;
+using System.Net.Sockets;
+using System.Text.RegularExpressions;
+
+internal static partial class StringFormatValidator
+{
+    private static readonly HashSet<string> Supported =
+        ["email", "uuid", "uri", "hostname", "ipv4", "ipv6"];
+
+    public static bool IsSupported(string format) => Supported.Contains(format);
+
+    public static bool IsValid(string format, string value) => format switch
+    {
+        "email" => IsEmail(value),
+        "uuid" => UuidPattern().IsMatch(value),
+        "uri" => IsUri(value),
+        "hostname" => IsHostname(value),
+        "ipv4" => IsIpv4(value),
+        "ipv6" => IsIpv6(value),
+        _ => false
+    };
+
+    private static bool IsEmail(string value)
+    {
+        if (!IsAscii(value) || value.Length > 254)
+            return false;
+
+        var at = FindMailboxSeparator(value);
+        if (at <= 0 || at == value.Length - 1)
+            return false;
+
+        var local = value[..at];
+        var domain = value[(at + 1)..];
+        return local.Length <= 64
+            && (IsDotString(local) || IsQuotedString(local))
+            && IsEmailDomain(domain);
+    }
+
+    private static int FindMailboxSeparator(string value)
+    {
+        var quoted = false;
+        var escaped = false;
+        var separator = -1;
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c = value[i];
+            if (escaped)
+            {
+                escaped = false;
+                continue;
+            }
+            if (quoted && c == '\\')
+            {
+                escaped = true;
+                continue;
+            }
+            if (c == '"')
+                quoted = !quoted;
+            else if (c == '@' && !quoted)
+            {
+                if (separator >= 0)
+                    return -1;
+                separator = i;
+            }
+        }
+        return quoted || escaped ? -1 : separator;
+    }
+
+    private static bool IsDotString(string local) =>
+        local.Length > 0
+        && local[0] != '.'
+        && local[^1] != '.'
+        && !local.Contains("..", StringComparison.Ordinal)
+        && local.All(c => char.IsAsciiLetterOrDigit(c)
+            || "!#$%&'*+-/=?^_`{|}~.".Contains(c));
+
+    private static bool IsQuotedString(string local)
+    {
+        if (local.Length < 2 || local[0] != '"' || local[^1] != '"')
+            return false;
+        for (var i = 1; i < local.Length - 1; i++)
+        {
+            var c = local[i];
+            if (c == '\\')
+            {
+                if (++i >= local.Length - 1 || local[i] is < (char)32 or > (char)126)
+                    return false;
+            }
+            else if (c is < (char)32 or > (char)126 || c is '"' or '\\')
+                return false;
+        }
+        return true;
+    }
+
+    private static bool IsEmailDomain(string domain)
+    {
+        if (domain.Length >= 2 && domain[0] == '[' && domain[^1] == ']')
+        {
+            var literal = domain[1..^1];
+            if (IsIpv4(literal))
+                return true;
+            if (literal.StartsWith("IPv6:", StringComparison.OrdinalIgnoreCase))
+                return IsIpv6(literal[5..]);
+
+            var colon = literal.IndexOf(':');
+            return colon > 0
+                && char.IsAsciiLetterOrDigit(literal[0])
+                && char.IsAsciiLetterOrDigit(literal[colon - 1])
+                && literal[..colon].All(c => char.IsAsciiLetterOrDigit(c) || c == '-')
+                && literal[(colon + 1)..].Length > 0
+                && literal[(colon + 1)..].All(c => c is >= (char)33 and <= (char)90
+                    || c is >= (char)94 and <= (char)126);
+        }
+        return IsHostname(domain, allowTrailingDot: false);
+    }
+
+    private static bool IsUri(string value)
+    {
+        if (value.Length == 0 || !IsAscii(value) || value.Count(c => c == '#') > 1
+            || value.Any(c => !IsUriCharacter(c)))
+            return false;
+
+        for (var i = 0; i < value.Length; i++)
+        {
+            if (value[i] != '%')
+                continue;
+            if (i + 2 >= value.Length || !char.IsAsciiHexDigit(value[i + 1])
+                || !char.IsAsciiHexDigit(value[i + 2]))
+                return false;
+            i += 2;
+        }
+
+        var colon = value.IndexOf(':');
+        if (colon <= 0 || !char.IsAsciiLetter(value[0])
+            || !value[1..colon].All(c => char.IsAsciiLetterOrDigit(c) || c is '+' or '-' or '.'))
+            return false;
+
+        return IsAbsoluteUri(value, value[..colon])
+            || TryNormalizeIpvFuture(value, out var normalized)
+                && IsAbsoluteUri(normalized, value[..colon]);
+    }
+
+    private static bool IsAbsoluteUri(string value, string scheme) =>
+        Uri.TryCreate(value, UriKind.Absolute, out var uri)
+        && uri.IsAbsoluteUri
+        && string.Equals(uri.Scheme, scheme, StringComparison.OrdinalIgnoreCase);
+
+    private static bool TryNormalizeIpvFuture(string value, out string normalized)
+    {
+        normalized = "";
+        var schemeEnd = value.IndexOf(':');
+        if (schemeEnd < 0 || !value.AsSpan(schemeEnd + 1).StartsWith("//"))
+            return false;
+        var authorityStart = schemeEnd + 3;
+        var authorityEnd = value.IndexOfAny(['/', '?', '#'], authorityStart);
+        if (authorityEnd < 0)
+            authorityEnd = value.Length;
+        var at = value.LastIndexOf('@', authorityEnd - 1, authorityEnd - authorityStart);
+        var hostStart = at >= authorityStart ? at + 1 : authorityStart;
+        if (hostStart >= authorityEnd || value[hostStart] != '[')
+            return false;
+        var close = value.IndexOf(']', hostStart + 1);
+        if (close < 0 || close >= authorityEnd || !IsIpvFuture(value[(hostStart + 1)..close]))
+            return false;
+        normalized = string.Concat(value.AsSpan(0, hostStart + 1), "::1", value.AsSpan(close));
+        return true;
+    }
+
+    private static bool IsIpvFuture(string value)
+    {
+        if (value.Length < 4 || value[0] is not ('v' or 'V'))
+            return false;
+        var dot = value.IndexOf('.', 1);
+        return dot > 1
+            && dot < value.Length - 1
+            && value[1..dot].All(char.IsAsciiHexDigit)
+            && value[(dot + 1)..].All(c => char.IsAsciiLetterOrDigit(c)
+                || "-._~!$&'()*+,;=:".Contains(c));
+    }
+
+    private static bool IsHostname(string value, bool allowTrailingDot = true)
+    {
+        if (!IsAscii(value) || value.Length == 0)
+            return false;
+        var hostname = allowTrailingDot && value.EndsWith('.') ? value[..^1] : value;
+        if (hostname.Length == 0 || hostname.Length > 253)
+            return false;
+
+        return hostname.Split('.').All(label =>
+            label.Length is >= 1 and <= 63
+            && char.IsAsciiLetterOrDigit(label[0])
+            && char.IsAsciiLetterOrDigit(label[^1])
+            && label.All(c => char.IsAsciiLetterOrDigit(c) || c == '-'));
+    }
+
+    private static bool IsIpv4(string value)
+    {
+        var parts = value.Split('.');
+        if (parts.Length != 4)
+            return false;
+        foreach (var part in parts)
+        {
+            if (part.Length == 0 || part.Length > 3
+                || (part.Length > 1 && part[0] == '0')
+                || !part.All(char.IsAsciiDigit)
+                || !int.TryParse(part, out var octet) || octet > 255)
+                return false;
+        }
+        return true;
+    }
+
+    private static bool IsIpv6(string value)
+    {
+        if (!value.Contains(':') || value.Contains('%') || !IsAscii(value))
+            return false;
+        if (value.Contains('.'))
+        {
+            var start = value.LastIndexOf(':') + 1;
+            if (!IsIpv4(value[start..]))
+                return false;
+        }
+        return IPAddress.TryParse(value, out var address)
+            && address.AddressFamily == AddressFamily.InterNetworkV6;
+    }
+
+    private static bool IsAscii(string value) => value.All(c => c <= 127);
+    private static bool IsUriCharacter(char c) =>
+        char.IsAsciiLetterOrDigit(c) || "-._~:/?#[]@!$&'()*+,;=%".Contains(c);
+
+    [GeneratedRegex("^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$")]
+    private static partial Regex UuidPattern();
+}

--- a/reference-implementations/dotnet/src/SchemaDefinition.cs
+++ b/reference-implementations/dotnet/src/SchemaDefinition.cs
@@ -12,6 +12,7 @@ public class SchemaDefinition
     public object? DefaultValue { get; set; }
     public bool Deprecated { get; set; }
     public string? Pattern { get; set; }
+    public string? Format { get; set; }
     public string? KeyPattern { get; set; }
     public long? Min { get; set; }
     public long? Max { get; set; }

--- a/reference-implementations/dotnet/src/SchemaLoader.cs
+++ b/reference-implementations/dotnet/src/SchemaLoader.cs
@@ -9,7 +9,7 @@ internal class SchemaLoader
 {
     public static readonly HashSet<string> DefinitionKeys = new()
     {
-        "type", "description", "itemtype", "items", "allowedvalues", "pattern", "keypattern",
+        "type", "description", "itemtype", "items", "allowedvalues", "pattern", "format", "keypattern",
         "optional", "min", "max", "minlength", "maxlength", "oneof", "anyof", "allof",
         "dependentrequired", "mutuallyexclusive", "exactlyone", "uniqueitems", "default",
         "deprecated", "if", "then", "else"
@@ -112,6 +112,17 @@ internal class SchemaLoader
         if (table.TryGetValue("pattern", out var pat) && pat is string patStr)
             def.Pattern = patStr;
 
+        if (table.TryGetValue("format", out var formatValue))
+        {
+            if (formatValue is not string format)
+                throw new InvalidOperationException("format must be a string");
+            if (table["type"] is not string localType || localType != "string")
+                throw new InvalidOperationException("format is valid only with a locally selected built-in string type");
+            if (!StringFormatValidator.IsSupported(format))
+                throw new InvalidOperationException($"unknown string format: {format}");
+            def.Format = format;
+        }
+
         if (table.TryGetValue("keypattern", out var keyPat) && keyPat is string keyPatStr)
             def.KeyPattern = keyPatStr;
 
@@ -137,6 +148,24 @@ internal class SchemaLoader
         if (table.TryGetValue("allowedvalues", out var allowedVals) && allowedVals is TomlArray allowedArray)
         {
             def.AllowedValues = new List<object>(allowedArray.Cast<object>().Where(x => x != null));
+        }
+        if (def.Format != null)
+        {
+            if (def.AllowedValues != null
+                && def.AllowedValues.Any(value =>
+                    value is not string text || !StringFormatValidator.IsValid(def.Format, text)))
+                throw new InvalidOperationException(
+                    $"allowedvalues contains a value that does not satisfy format {def.Format}");
+            if (table.ContainsKey("default")
+                && (def.DefaultValue is not string defaultText
+                    || !StringFormatValidator.IsValid(def.Format, defaultText)))
+                throw new InvalidOperationException(
+                    $"default does not satisfy format {def.Format}");
+            if (def.DefaultValue is string formattedDefault
+                && def.AllowedValues != null
+                && !def.AllowedValues.OfType<string>().Contains(formattedDefault, StringComparer.Ordinal))
+                throw new InvalidOperationException(
+                    "default is not included in allowedvalues");
         }
 
         // Union/composition

--- a/reference-implementations/dotnet/src/SchemaValidator.cs
+++ b/reference-implementations/dotnet/src/SchemaValidator.cs
@@ -138,6 +138,10 @@ internal class SchemaValidator
                     _errors.Add(new ValidationError(path, $"Invalid regex pattern: {ex.Message}", "pattern-error"));
                 }
             }
+
+            if (schema.Format != null && !StringFormatValidator.IsValid(schema.Format, strVal))
+                _errors.Add(new ValidationError(path,
+                    $"String is not a valid {schema.Format}", "format"));
         }
 
         // Numeric constraints

--- a/reference-implementations/dotnet/src/StringFormatValidator.cs
+++ b/reference-implementations/dotnet/src/StringFormatValidator.cs
@@ -1,0 +1,234 @@
+namespace TomlSchema;
+
+using System.Net;
+using System.Net.Sockets;
+using System.Text.RegularExpressions;
+
+internal static partial class StringFormatValidator
+{
+    private static readonly HashSet<string> Supported =
+        ["email", "uuid", "uri", "hostname", "ipv4", "ipv6"];
+
+    public static bool IsSupported(string format) => Supported.Contains(format);
+
+    public static bool IsValid(string format, string value) => format switch
+    {
+        "email" => IsEmail(value),
+        "uuid" => UuidPattern().IsMatch(value),
+        "uri" => IsUri(value),
+        "hostname" => IsHostname(value),
+        "ipv4" => IsIpv4(value),
+        "ipv6" => IsIpv6(value),
+        _ => false
+    };
+
+    private static bool IsEmail(string value)
+    {
+        if (!IsAscii(value) || value.Length > 254)
+            return false;
+
+        var at = FindMailboxSeparator(value);
+        if (at <= 0 || at == value.Length - 1)
+            return false;
+
+        var local = value[..at];
+        var domain = value[(at + 1)..];
+        return local.Length <= 64
+            && (IsDotString(local) || IsQuotedString(local))
+            && IsEmailDomain(domain);
+    }
+
+    private static int FindMailboxSeparator(string value)
+    {
+        var quoted = false;
+        var escaped = false;
+        var separator = -1;
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c = value[i];
+            if (escaped)
+            {
+                escaped = false;
+                continue;
+            }
+            if (quoted && c == '\\')
+            {
+                escaped = true;
+                continue;
+            }
+            if (c == '"')
+                quoted = !quoted;
+            else if (c == '@' && !quoted)
+            {
+                if (separator >= 0)
+                    return -1;
+                separator = i;
+            }
+        }
+        return quoted || escaped ? -1 : separator;
+    }
+
+    private static bool IsDotString(string local) =>
+        local.Length > 0
+        && local[0] != '.'
+        && local[^1] != '.'
+        && !local.Contains("..", StringComparison.Ordinal)
+        && local.All(c => char.IsAsciiLetterOrDigit(c)
+            || "!#$%&'*+-/=?^_`{|}~.".Contains(c));
+
+    private static bool IsQuotedString(string local)
+    {
+        if (local.Length < 2 || local[0] != '"' || local[^1] != '"')
+            return false;
+        for (var i = 1; i < local.Length - 1; i++)
+        {
+            var c = local[i];
+            if (c == '\\')
+            {
+                if (++i >= local.Length - 1 || local[i] is < (char)32 or > (char)126)
+                    return false;
+            }
+            else if (c is < (char)32 or > (char)126 || c is '"' or '\\')
+                return false;
+        }
+        return true;
+    }
+
+    private static bool IsEmailDomain(string domain)
+    {
+        if (domain.Length >= 2 && domain[0] == '[' && domain[^1] == ']')
+        {
+            var literal = domain[1..^1];
+            if (IsIpv4(literal))
+                return true;
+            if (literal.StartsWith("IPv6:", StringComparison.OrdinalIgnoreCase))
+                return IsIpv6(literal[5..]);
+
+            var colon = literal.IndexOf(':');
+            return colon > 0
+                && char.IsAsciiLetterOrDigit(literal[0])
+                && char.IsAsciiLetterOrDigit(literal[colon - 1])
+                && literal[..colon].All(c => char.IsAsciiLetterOrDigit(c) || c == '-')
+                && literal[(colon + 1)..].Length > 0
+                && literal[(colon + 1)..].All(c => c is >= (char)33 and <= (char)90
+                    || c is >= (char)94 and <= (char)126);
+        }
+        return IsHostname(domain, allowTrailingDot: false);
+    }
+
+    private static bool IsUri(string value)
+    {
+        if (value.Length == 0 || !IsAscii(value) || value.Count(c => c == '#') > 1
+            || value.Any(c => !IsUriCharacter(c)))
+            return false;
+
+        for (var i = 0; i < value.Length; i++)
+        {
+            if (value[i] != '%')
+                continue;
+            if (i + 2 >= value.Length || !char.IsAsciiHexDigit(value[i + 1])
+                || !char.IsAsciiHexDigit(value[i + 2]))
+                return false;
+            i += 2;
+        }
+
+        var colon = value.IndexOf(':');
+        if (colon <= 0 || !char.IsAsciiLetter(value[0])
+            || !value[1..colon].All(c => char.IsAsciiLetterOrDigit(c) || c is '+' or '-' or '.'))
+            return false;
+
+        return IsAbsoluteUri(value, value[..colon])
+            || TryNormalizeIpvFuture(value, out var normalized)
+                && IsAbsoluteUri(normalized, value[..colon]);
+    }
+
+    private static bool IsAbsoluteUri(string value, string scheme) =>
+        Uri.TryCreate(value, UriKind.Absolute, out var uri)
+        && uri.IsAbsoluteUri
+        && string.Equals(uri.Scheme, scheme, StringComparison.OrdinalIgnoreCase);
+
+    private static bool TryNormalizeIpvFuture(string value, out string normalized)
+    {
+        normalized = "";
+        var schemeEnd = value.IndexOf(':');
+        if (schemeEnd < 0 || !value.AsSpan(schemeEnd + 1).StartsWith("//"))
+            return false;
+        var authorityStart = schemeEnd + 3;
+        var authorityEnd = value.IndexOfAny(['/', '?', '#'], authorityStart);
+        if (authorityEnd < 0)
+            authorityEnd = value.Length;
+        var at = value.LastIndexOf('@', authorityEnd - 1, authorityEnd - authorityStart);
+        var hostStart = at >= authorityStart ? at + 1 : authorityStart;
+        if (hostStart >= authorityEnd || value[hostStart] != '[')
+            return false;
+        var close = value.IndexOf(']', hostStart + 1);
+        if (close < 0 || close >= authorityEnd || !IsIpvFuture(value[(hostStart + 1)..close]))
+            return false;
+        normalized = string.Concat(value.AsSpan(0, hostStart + 1), "::1", value.AsSpan(close));
+        return true;
+    }
+
+    private static bool IsIpvFuture(string value)
+    {
+        if (value.Length < 4 || value[0] is not ('v' or 'V'))
+            return false;
+        var dot = value.IndexOf('.', 1);
+        return dot > 1
+            && dot < value.Length - 1
+            && value[1..dot].All(char.IsAsciiHexDigit)
+            && value[(dot + 1)..].All(c => char.IsAsciiLetterOrDigit(c)
+                || "-._~!$&'()*+,;=:".Contains(c));
+    }
+
+    private static bool IsHostname(string value, bool allowTrailingDot = true)
+    {
+        if (!IsAscii(value) || value.Length == 0)
+            return false;
+        var hostname = allowTrailingDot && value.EndsWith('.') ? value[..^1] : value;
+        if (hostname.Length == 0 || hostname.Length > 253)
+            return false;
+
+        return hostname.Split('.').All(label =>
+            label.Length is >= 1 and <= 63
+            && char.IsAsciiLetterOrDigit(label[0])
+            && char.IsAsciiLetterOrDigit(label[^1])
+            && label.All(c => char.IsAsciiLetterOrDigit(c) || c == '-'));
+    }
+
+    private static bool IsIpv4(string value)
+    {
+        var parts = value.Split('.');
+        if (parts.Length != 4)
+            return false;
+        foreach (var part in parts)
+        {
+            if (part.Length == 0 || part.Length > 3
+                || (part.Length > 1 && part[0] == '0')
+                || !part.All(char.IsAsciiDigit)
+                || !int.TryParse(part, out var octet) || octet > 255)
+                return false;
+        }
+        return true;
+    }
+
+    private static bool IsIpv6(string value)
+    {
+        if (!value.Contains(':') || value.Contains('%') || !IsAscii(value))
+            return false;
+        if (value.Contains('.'))
+        {
+            var start = value.LastIndexOf(':') + 1;
+            if (!IsIpv4(value[start..]))
+                return false;
+        }
+        return IPAddress.TryParse(value, out var address)
+            && address.AddressFamily == AddressFamily.InterNetworkV6;
+    }
+
+    private static bool IsAscii(string value) => value.All(c => c <= 127);
+    private static bool IsUriCharacter(char c) =>
+        char.IsAsciiLetterOrDigit(c) || "-._~:/?#[]@!$&'()*+,;=%".Contains(c);
+
+    [GeneratedRegex("^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$")]
+    private static partial Regex UuidPattern();
+}

--- a/reference-implementations/dotnet/tests/StringFormatTests.cs
+++ b/reference-implementations/dotnet/tests/StringFormatTests.cs
@@ -1,0 +1,169 @@
+namespace TomlSchema.Tests;
+
+using Tomlyn.Model;
+using Xunit;
+
+public class StringFormatTests : TestBase
+{
+    public static TheoryData<string, string, string> FormatCases => new()
+    {
+        { "email", "simple@example.com", "simple..dot@example.com" },
+        { "uuid", "01234567-89ab-cdef-0123-456789abcdef", "{01234567-89ab-cdef-0123-456789abcdef}" },
+        { "uri", "https://example.com/a%20b?x=1", "relative/path" },
+        { "hostname", "www.example.com.", "-bad.example" },
+        { "ipv4", "192.0.2.1", "192.168.001.1" },
+        { "ipv6", "2001:db8::192.0.2.1", "2001:db8::192.168.001.1" }
+    };
+
+    [Theory]
+    [MemberData(nameof(FormatCases))]
+    public void ValidatesSupportedFormats(string format, string valid, string invalid)
+    {
+        var schema = Schema(format);
+
+        Assert.True(Validate(schema, valid).IsValid);
+        var result = Validate(schema, invalid);
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, error => error.Code == "format"
+            && error.Message.Contains(format, StringComparison.Ordinal));
+    }
+
+    public static TheoryData<string, bool> EmailCases => new()
+    {
+        { "first.last+tag@example.com", true },
+        { "\"quoted local\"@example.com", true },
+        { "\"contains@sign\"@example.com", true },
+        { "\"escaped\\\"quote\"@example.com", true },
+        { "postmaster@[192.0.2.1]", true },
+        { "postmaster@[IPv6:2001:db8::1]", true },
+        { "postmaster@[TAG:value]", true },
+        { "postmaster@[TAG-:value]", false },
+        { ".leading@example.com", false },
+        { "trailing.@example.com", false },
+        { "two..dots@example.com", false },
+        { "unquoted space@example.com", false },
+        { "\"unterminated@example.com", false },
+        { "nonascii-é@example.com", false },
+        { "user@example..com", false },
+        { "user@[IPv6:192.0.2.1]", false }
+    };
+
+    [Theory]
+    [MemberData(nameof(EmailCases))]
+    public void ValidatesRfc5321MailboxCases(string mailbox, bool expected) =>
+        Assert.Equal(expected, Validate(Schema("email"), mailbox).IsValid);
+
+    [Fact]
+    public void EnforcesEmailOctetLimits()
+    {
+        Assert.True(Validate(Schema("email"), $"{new string('a', 64)}@example.com").IsValid);
+        Assert.False(Validate(Schema("email"), $"{new string('a', 65)}@example.com").IsValid);
+
+        var domain = string.Join(".", Enumerable.Repeat(new string('a', 63), 3))
+            + "." + new string('b', 61);
+        Assert.Equal(253, domain.Length);
+        Assert.False(Validate(Schema("email"), $"a@{domain}").IsValid);
+    }
+
+    [Theory]
+    [InlineData("urn:isbn:9780131103627", true)]
+    [InlineData("mailto:user@example.com", true)]
+    [InlineData("https://example.com/bad%2", false)]
+    [InlineData("https://example.com/{bad}", false)]
+    [InlineData("http://example.com/#first#second", false)]
+    public void ValidatesAbsoluteRfc3986Uris(string uri, bool expected) =>
+        Assert.Equal(expected, Validate(Schema("uri"), uri).IsValid);
+
+    [Theory]
+    [InlineData("integer", "email", "format is valid only")]
+    [InlineData("types.text", "email", "format is valid only")]
+    [InlineData("string", "date", "unknown string format")]
+    public void RejectsIncompatibleOrUnknownFormatsAtSchemaLoad(
+        string type, string format, string expectedMessage)
+    {
+        var schemaPath = Write($"invalid-format-{Guid.NewGuid():N}.tosd", $$"""
+            [toml-schema]
+            version = "1.0.0"
+
+            [types.text]
+            type = "string"
+
+            [elements.value]
+            type = "{{type}}"
+            format = "{{format}}"
+            """);
+
+        var error = Assert.Throws<InvalidOperationException>(() => TomlSchema.Load(schemaPath));
+        Assert.Contains(expectedMessage, error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RejectsNonStringFormatAtSchemaLoad()
+    {
+        var schemaPath = Write($"non-string-format-{Guid.NewGuid():N}.tosd", """
+            [toml-schema]
+            version = "1.0.0"
+
+            [elements.value]
+            type = "string"
+            format = 42
+            """);
+
+        var error = Assert.Throws<InvalidOperationException>(() => TomlSchema.Load(schemaPath));
+        Assert.Contains("format must be a string", error.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("allowedvalues = [\"192.168.001.1\"]")]
+    [InlineData("default = \"192.168.001.1\"")]
+    public void RejectsFormattedAnnotationsThatViolateTheFormat(string annotation)
+    {
+        var schemaPath = Write($"invalid-format-annotation-{Guid.NewGuid():N}.tosd", $$"""
+            [toml-schema]
+            version = "1.0.0"
+
+            [elements.value]
+            type = "string"
+            format = "ipv4"
+            {{annotation}}
+            """);
+
+        var error = Assert.Throws<InvalidOperationException>(() => TomlSchema.Load(schemaPath));
+        Assert.Contains("does not satisfy format ipv4", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RejectsFormattedDefaultOutsideAllowedValues()
+    {
+        var schemaPath = Write($"invalid-format-default-{Guid.NewGuid():N}.tosd", """
+            [toml-schema]
+            version = "1.0.0"
+
+            [elements.value]
+            type = "string"
+            format = "ipv4"
+            allowedvalues = ["192.0.2.1"]
+            default = "198.51.100.1"
+            """);
+
+        var error = Assert.Throws<InvalidOperationException>(() => TomlSchema.Load(schemaPath));
+        Assert.Contains("default is not included in allowedvalues", error.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("scheme:")]
+    [InlineData("http://[v1.fe]/")]
+    public void AcceptsRfc3986UriEdgeCases(string value) =>
+        Assert.True(Validate(Schema("uri"), value).IsValid);
+
+    private static TomlSchema Schema(string format) => new(
+        "1.0.0",
+        new Dictionary<string, SchemaDefinition>(),
+        new Dictionary<string, SchemaDefinition>
+        {
+            ["value"] = new() { Type = SchemaType.String, Format = format }
+        });
+
+    private static ValidationResult Validate(TomlSchema schema, string value) =>
+        schema.Validate(new TomlTable { ["value"] = value });
+}

--- a/reference-implementations/go/formats.go
+++ b/reference-implementations/go/formats.go
@@ -1,0 +1,324 @@
+package tomlschema
+
+import (
+	"net"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+var supportedStringFormats = map[string]bool{
+	"email": true, "uuid": true, "uri": true, "hostname": true, "ipv4": true, "ipv6": true,
+}
+
+var uuidFormatPattern = regexp.MustCompile(`^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$`)
+
+func validateStringFormat(format, value string) bool {
+	switch format {
+	case "email":
+		return validEmail(value)
+	case "uuid":
+		return uuidFormatPattern.MatchString(value)
+	case "uri":
+		return validURI(value)
+	case "hostname":
+		return validHostname(value)
+	case "ipv4":
+		return validIPv4(value)
+	case "ipv6":
+		return validIPv6(value)
+	default:
+		return false
+	}
+}
+
+func validEmail(value string) bool {
+	if len(value) > 254 || !asciiOnly(value) {
+		return false
+	}
+	at := emailAt(value)
+	if at <= 0 || at > 64 || at == len(value)-1 {
+		return false
+	}
+	local, domain := value[:at], value[at+1:]
+	if !validEmailLocal(local) {
+		return false
+	}
+	if strings.HasPrefix(domain, "[") && strings.HasSuffix(domain, "]") {
+		return validAddressLiteral(domain[1 : len(domain)-1])
+	}
+	return validHostnameWithTrailingDot(domain, false)
+}
+
+func emailAt(value string) int {
+	quoted, escaped := false, false
+	at := -1
+	for i := 0; i < len(value); i++ {
+		switch {
+		case escaped:
+			escaped = false
+		case quoted && value[i] == '\\':
+			escaped = true
+		case value[i] == '"':
+			quoted = !quoted
+		case value[i] == '@' && !quoted:
+			if at >= 0 {
+				return -1
+			}
+			at = i
+		}
+	}
+	if quoted || escaped {
+		return -1
+	}
+	return at
+}
+
+func validEmailLocal(local string) bool {
+	if len(local) >= 2 && local[0] == '"' && local[len(local)-1] == '"' {
+		for i := 1; i < len(local)-1; i++ {
+			c := local[i]
+			if c == '\\' {
+				i++
+				if i >= len(local)-1 || local[i] < 32 || local[i] > 126 {
+					return false
+				}
+			} else if c < 32 || c > 126 || c == '"' || c == '\\' {
+				return false
+			}
+		}
+		return true
+	}
+	if local == "" || local[0] == '.' || local[len(local)-1] == '.' {
+		return false
+	}
+	previousDot := false
+	for i := 0; i < len(local); i++ {
+		c := local[i]
+		if c == '.' {
+			if previousDot {
+				return false
+			}
+			previousDot = true
+			continue
+		}
+		previousDot = false
+		if !isEmailAtom(c) {
+			return false
+		}
+	}
+	return true
+}
+
+func isEmailAtom(c byte) bool {
+	return isASCIIAlnum(c) || strings.ContainsRune("!#$%&'*+-/=?^_`{|}~", rune(c))
+}
+
+func validAddressLiteral(value string) bool {
+	if validIPv4(value) {
+		return true
+	}
+	if len(value) > 5 && strings.EqualFold(value[:5], "IPv6:") {
+		return validIPv6(value[5:])
+	}
+	colon := strings.IndexByte(value, ':')
+	if colon <= 0 || colon == len(value)-1 || !validStandardizedTag(value[:colon]) {
+		return false
+	}
+	for i := colon + 1; i < len(value); i++ {
+		if value[i] < 33 || value[i] > 126 || value[i] == '[' || value[i] == ']' || value[i] == '\\' {
+			return false
+		}
+	}
+	return true
+}
+
+func validURI(value string) bool {
+	if value == "" || !asciiOnly(value) || strings.Count(value, "#") > 1 || uriHostHasZoneIdentifier(value) {
+		return false
+	}
+	for i := 0; i < len(value); i++ {
+		c := value[i]
+		if c == '%' {
+			if i+2 >= len(value) || !isHex(value[i+1]) || !isHex(value[i+2]) {
+				return false
+			}
+			i += 2
+		} else if !isURIChar(c) {
+			return false
+		}
+	}
+	parsed, err := url.Parse(value)
+	if err == nil && parsed.Scheme != "" {
+		return true
+	}
+	normalized, ok := normalizeIPvFutureURI(value)
+	if !ok {
+		return false
+	}
+	parsed, err = url.Parse(normalized)
+	return err == nil && parsed.Scheme != ""
+}
+
+func uriHostHasZoneIdentifier(value string) bool {
+	colon := strings.IndexByte(value, ':')
+	if colon < 0 || !strings.HasPrefix(value[colon+1:], "//") {
+		return false
+	}
+	authority := value[colon+3:]
+	if end := strings.IndexAny(authority, "/?#"); end >= 0 {
+		authority = authority[:end]
+	}
+	if at := strings.LastIndexByte(authority, '@'); at >= 0 {
+		authority = authority[at+1:]
+	}
+	if !strings.HasPrefix(authority, "[") {
+		return false
+	}
+	close := strings.IndexByte(authority, ']')
+	return close > 0 && strings.Contains(authority[1:close], "%")
+}
+
+func normalizeIPvFutureURI(value string) (string, bool) {
+	colon := strings.IndexByte(value, ':')
+	if colon < 0 || !strings.HasPrefix(value[colon+1:], "//") {
+		return "", false
+	}
+	authorityStart := colon + 3
+	authorityEnd := len(value)
+	if end := strings.IndexAny(value[authorityStart:], "/?#"); end >= 0 {
+		authorityEnd = authorityStart + end
+	}
+	authority := value[authorityStart:authorityEnd]
+	hostOffset := 0
+	if at := strings.LastIndexByte(authority, '@'); at >= 0 {
+		hostOffset = at + 1
+	}
+	hostPort := authority[hostOffset:]
+	if !strings.HasPrefix(hostPort, "[") {
+		return "", false
+	}
+	close := strings.IndexByte(hostPort, ']')
+	if close < 0 || !validIPvFuture(hostPort[1:close]) {
+		return "", false
+	}
+	literalStart := authorityStart + hostOffset + 1
+	literalEnd := authorityStart + hostOffset + close
+	return value[:literalStart] + "::1" + value[literalEnd:], true
+}
+
+func validIPvFuture(value string) bool {
+	if len(value) < 4 || value[0] != 'v' && value[0] != 'V' {
+		return false
+	}
+	dot := strings.IndexByte(value, '.')
+	if dot <= 1 || dot == len(value)-1 {
+		return false
+	}
+	for i := 1; i < dot; i++ {
+		if !isHex(value[i]) {
+			return false
+		}
+	}
+	for i := dot + 1; i < len(value); i++ {
+		c := value[i]
+		if !isASCIIAlnum(c) && !strings.ContainsRune("-._~!$&'()*+,;=:", rune(c)) {
+			return false
+		}
+	}
+	return true
+}
+
+func validHostname(value string) bool {
+	return validHostnameWithTrailingDot(value, true)
+}
+
+func validHostnameWithTrailingDot(value string, allowTrailingDot bool) bool {
+	if allowTrailingDot && strings.HasSuffix(value, ".") {
+		value = value[:len(value)-1]
+	}
+	if len(value) == 0 || len(value) > 253 || !asciiOnly(value) {
+		return false
+	}
+	for _, label := range strings.Split(value, ".") {
+		if len(label) == 0 || len(label) > 63 || !isASCIIAlnum(label[0]) || !isASCIIAlnum(label[len(label)-1]) {
+			return false
+		}
+		for i := 1; i < len(label)-1; i++ {
+			if !isASCIIAlnum(label[i]) && label[i] != '-' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func validIPv4(value string) bool {
+	parts := strings.Split(value, ".")
+	if len(parts) != 4 {
+		return false
+	}
+	for _, part := range parts {
+		if part == "" || (len(part) > 1 && part[0] == '0') || len(part) > 3 {
+			return false
+		}
+		number := 0
+		for i := 0; i < len(part); i++ {
+			if part[i] < '0' || part[i] > '9' {
+				return false
+			}
+			number = number*10 + int(part[i]-'0')
+		}
+		if number > 255 {
+			return false
+		}
+	}
+	return true
+}
+
+func validIPv6(value string) bool {
+	if !strings.Contains(value, ":") || strings.Contains(value, "%") {
+		return false
+	}
+	if dot := strings.LastIndexByte(value, '.'); dot >= 0 {
+		colon := strings.LastIndexByte(value[:dot], ':')
+		if colon < 0 || !validIPv4(value[colon+1:]) {
+			return false
+		}
+	}
+	ip := net.ParseIP(value)
+	return ip != nil
+}
+
+func validStandardizedTag(value string) bool {
+	if value == "" || !isASCIIAlnum(value[len(value)-1]) {
+		return false
+	}
+	for i := 0; i < len(value)-1; i++ {
+		if !isASCIIAlnum(value[i]) && value[i] != '-' {
+			return false
+		}
+	}
+	return true
+}
+
+func asciiOnly(value string) bool {
+	for i := 0; i < len(value); i++ {
+		if value[i] > 127 {
+			return false
+		}
+	}
+	return true
+}
+
+func isASCIIAlnum(c byte) bool {
+	return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9'
+}
+
+func isHex(c byte) bool {
+	return c >= '0' && c <= '9' || c >= 'a' && c <= 'f' || c >= 'A' && c <= 'F'
+}
+
+func isURIChar(c byte) bool {
+	return isASCIIAlnum(c) || strings.ContainsRune("-._~:/?#[]@!$&'()*+,;=", rune(c))
+}

--- a/reference-implementations/go/schema.go
+++ b/reference-implementations/go/schema.go
@@ -36,7 +36,7 @@ const (
 
 var definitionKeys = map[string]bool{
 	"type": true, "description": true, "itemtype": true, "items": true,
-	"allowedvalues": true, "pattern": true, "keypattern": true, "optional": true, "min": true,
+	"allowedvalues": true, "pattern": true, "format": true, "keypattern": true, "optional": true, "min": true,
 	"max": true, "minlength": true, "maxlength": true,
 	"oneof": true, "anyof": true, "dependentrequired": true, "mutuallyexclusive": true,
 	"exactlyone": true, "allof": true, "uniqueitems": true, "default": true, "deprecated": true,
@@ -112,6 +112,7 @@ type Definition struct {
 	optional          bool
 	allowedValues     []any
 	pattern           *regexp.Regexp
+	format            string
 	keyPattern        *regexp.Regexp
 	min               any
 	max               any
@@ -838,6 +839,15 @@ func parseDefinition(name string, path []string, table map[string]any, source *s
 	if err != nil {
 		return Definition{}, err
 	}
+	format, err := getString(table, "format")
+	if err != nil {
+		return Definition{}, err
+	}
+	if propertyValue(table, "format") != nil {
+		if !supportedStringFormats[format] {
+			return Definition{}, fmt.Errorf("%s contains unknown string format: %q", name, format)
+		}
+	}
 	keyPattern, err := getPatternKey(name, table, "keypattern")
 	if err != nil {
 		return Definition{}, err
@@ -1002,6 +1012,9 @@ func parseDefinition(name string, path []string, table map[string]any, source *s
 	if pattern != nil && typeName != TypeString {
 		return Definition{}, fmt.Errorf("%s can only define pattern when type is string", name)
 	}
+	if format != "" && typeName != TypeString {
+		return Definition{}, fmt.Errorf("%s can only define format when type is string", name)
+	}
 	if hasAllowedValues && (typeName == TypeTable || typeName == TypeCollection) {
 		return Definition{}, fmt.Errorf("%s can only define allowedvalues for scalar, unconstrained, or array types", name)
 	}
@@ -1018,7 +1031,7 @@ func parseDefinition(name string, path []string, table map[string]any, source *s
 	if err := validateRangeConstraints(name, typeName, min, max); err != nil {
 		return Definition{}, err
 	}
-	if err := validateAllowedValuesConstraints(name, typeName, allowedValues, pattern, min, max, minLength, maxLength); err != nil {
+	if err := validateAllowedValuesConstraints(name, typeName, allowedValues, pattern, format, min, max, minLength, maxLength); err != nil {
 		return Definition{}, err
 	}
 	dependentRequired, err := getDependentRequired(name, path, table, source)
@@ -1050,7 +1063,7 @@ func parseDefinition(name string, path []string, table map[string]any, source *s
 		name: name, typeName: typeName, reference: reference, description: description,
 		itemReference: normalizeReference(itemReference), optional: optional,
 		items:         normalizeReferences(items),
-		allowedValues: allowedValues, pattern: pattern, keyPattern: keyPattern, min: min, max: max,
+		allowedValues: allowedValues, pattern: pattern, format: format, keyPattern: keyPattern, min: min, max: max,
 		minLength: minLength, maxLength: maxLength, oneOf: normalizeReferences(oneOf), anyOf: normalizeReferences(anyOf),
 		condition: condition, thenReference: normalizeReference(thenReference), elseReference: normalizeReference(elseReference),
 		allOf: normalizeReferences(allOf), dependentRequired: dependentRequired,
@@ -1432,6 +1445,7 @@ func validateAllowedValuesConstraints(
 	typeName SchemaType,
 	allowedValues []any,
 	pattern *regexp.Regexp,
+	format string,
 	min, max any,
 	minLength, maxLength *int,
 ) error {
@@ -1444,6 +1458,12 @@ func validateAllowedValuesConstraints(
 			stringValue, ok := allowed.(string)
 			if !ok || !matchesPattern(pattern, stringValue) {
 				return fmt.Errorf("%s does not satisfy pattern", entry)
+			}
+		}
+		if format != "" {
+			stringValue, ok := allowed.(string)
+			if !ok || !validateStringFormat(format, stringValue) {
+				return fmt.Errorf("%s does not satisfy format %s", entry, format)
 			}
 		}
 		if (min != nil || max != nil) && isNaN(allowed) {
@@ -2156,6 +2176,9 @@ func (v *validator) validateCommonConstraints(path string, value any, definition
 		v.validateLength(path, utf8.RuneCountInString(stringValue), definition)
 		if definition.pattern != nil && !matchesPattern(definition.pattern, stringValue) {
 			v.add(path, "does not match pattern "+definition.pattern.String())
+		}
+		if definition.format != "" && !validateStringFormat(definition.format, stringValue) {
+			v.add(path, "invalid string for format "+definition.format)
 		}
 	}
 }

--- a/reference-implementations/go/schema_format_test.go
+++ b/reference-implementations/go/schema_format_test.go
@@ -1,0 +1,124 @@
+package tomlschema
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStringFormatsValidateDocuments(t *testing.T) {
+	tests := map[string]struct {
+		valid   string
+		invalid string
+	}{
+		"email":    {`"much.more unusual"@example.com`, "a..b@example.com"},
+		"uuid":     {"01234567-89ab-CDEF-8123-456789abcdef", "0123456789ab-cdef-8123-456789abcdef"},
+		"uri":      {"https://example.com/a%20b?q=x#part", "relative/path"},
+		"hostname": {"service-1.example.com.", "-service.example.com"},
+		"ipv4":     {"192.0.2.1", "192.168.001.1"},
+		"ipv6":     {"2001:db8::192.0.2.1", "2001:db8::192.168.001.1"},
+	}
+	for format, test := range tests {
+		t.Run(format, func(t *testing.T) {
+			schema := loadSemanticsSchema(t, "\n[elements.value]\ntype = \"string\"\nformat = \""+format+"\"\n")
+			if result := schema.Validate(map[string]any{"value": test.valid}); !result.Valid() {
+				t.Fatalf("expected %q to be a valid %s: %#v", test.valid, format, result.Errors)
+			}
+			result := schema.Validate(map[string]any{"value": test.invalid})
+			if result.Valid() || !strings.Contains(result.Errors[0].Message, "format "+format) {
+				t.Fatalf("expected clear %s format error for %q: %#v", format, test.invalid, result.Errors)
+			}
+		})
+	}
+}
+
+func TestEmailFormatRFC5321Cases(t *testing.T) {
+	valid := []string{
+		"simple@example.com",
+		"customer/department=shipping@example.com",
+		`"quoted local"@example.com`,
+		`"escaped\\backslash\"quote"@example.com`,
+		`"contains@sign"@example.com`,
+		"user@[192.0.2.1]",
+		"user@[IPv6:2001:db8::1]",
+		"user@[example-tag:opaque:value]",
+		strings.Repeat("a", 64) + "@example.com",
+	}
+	invalid := []string{
+		"",
+		"plainaddress",
+		".leading@example.com",
+		"trailing.@example.com",
+		"two..dots@example.com",
+		`unquoted space@example.com`,
+		`"unterminated@example.com`,
+		`"bad\` + "\n" + `"@example.com`,
+		"ü@example.com",
+		"user@-example.com",
+		"user@example..com",
+		"user@[IPv6:2001:db8:::1]",
+		"user@example.com.",
+		strings.Repeat("a", 65) + "@example.com",
+		strings.Repeat("a", 64) + "@" + strings.Repeat("b", 63) + "." +
+			strings.Repeat("c", 63) + "." + strings.Repeat("d", 62),
+	}
+
+	for _, value := range valid {
+		if !validEmail(value) {
+			t.Errorf("expected valid RFC 5321 mailbox: %q", value)
+		}
+	}
+
+	for _, value := range invalid {
+		if validEmail(value) {
+			t.Errorf("expected invalid RFC 5321 mailbox: %q", value)
+		}
+	}
+}
+
+func TestURIFormatRFC3986EdgeCases(t *testing.T) {
+	for _, value := range []string{"scheme:", "http://[v1.fe]/"} {
+		if !validURI(value) {
+			t.Errorf("expected valid absolute RFC 3986 URI: %q", value)
+		}
+	}
+	for _, value := range []string{
+		"http://example.com/#first#second",
+		"http://[fe80::1%25eth0]/",
+	} {
+		if validURI(value) {
+			t.Errorf("expected invalid RFC 3986 URI: %q", value)
+		}
+	}
+}
+
+func TestFormatSchemaLoadErrors(t *testing.T) {
+	tests := map[string]string{
+		"unknown":      "type = \"string\"\nformat = \"date\"",
+		"incompatible": "type = \"integer\"\nformat = \"uuid\"",
+		"non-string":   "type = \"string\"\nformat = 42",
+	}
+	for name, definition := range tests {
+		t.Run(name, func(t *testing.T) {
+			path := write(t, t.TempDir(), "schema.tosd",
+				"[toml-schema]\nversion = \"1.0.0\"\n\n[elements.value]\n"+definition+"\n")
+			if _, err := LoadSchema(path); err == nil {
+				t.Fatal("expected format schema-load error")
+			}
+		})
+	}
+}
+
+func TestFormatConstrainsAllowedValuesAtSchemaLoad(t *testing.T) {
+	path := write(t, t.TempDir(), "schema.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "string"
+format = "ipv4"
+allowedvalues = ["192.168.001.1"]
+`)
+	if _, err := LoadSchema(path); err == nil || !strings.Contains(err.Error(), "does not satisfy format ipv4") {
+		t.Fatalf("expected invalid formatted allowedvalue to fail schema loading, got %v", err)
+	}
+}

--- a/reference-implementations/java/src/main/java/org/tomlschema/SchemaDefinition.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/SchemaDefinition.java
@@ -14,6 +14,7 @@ record SchemaDefinition(
         boolean optional,
         List<Object> allowedValues,
         Pattern pattern,
+        SchemaStringFormat format,
         Pattern keyPattern,
         Object min,
         Object max,

--- a/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 final class SchemaLoader {
     static final Set<String> TOP_LEVEL_KEYS = Set.of("toml-schema", "types", "elements");
     static final Set<String> DEFINITION_KEYS = Set.of(
-            "type", "description", "itemtype", "items", "allowedvalues", "pattern",
+            "type", "description", "itemtype", "items", "allowedvalues", "pattern", "format",
             "keypattern", "optional", "min", "max", "minlength", "maxlength",
             "oneof", "anyof", "dependentrequired", "mutuallyexclusive", "exactlyone",
             "if", "then", "else", "allof", "uniqueitems", "default", "deprecated"
@@ -140,6 +140,9 @@ final class SchemaLoader {
         }
         Boolean optional = getBoolean(table, "optional");
         Pattern pattern = getPattern(name, table, "pattern");
+        String formatName = getString(table, "format");
+        SchemaStringFormat format = formatName == null
+                ? null : SchemaStringFormat.fromSchemaName(formatName);
         Pattern keyPattern = getPattern(name, table, "keypattern");
         Integer minLength = getInteger(table, "minlength");
         Integer maxLength = getInteger(table, "maxlength");
@@ -263,6 +266,9 @@ final class SchemaLoader {
         if (pattern != null && type != SchemaType.STRING) {
             throw new SchemaException(name + " can only define pattern when type is string");
         }
+        if (format != null && type != SchemaType.STRING) {
+            throw new SchemaException(name + " can only define format when type is string");
+        }
         if (hasAllowedValues && (type == SchemaType.TABLE || type == SchemaType.COLLECTION)) {
             throw new SchemaException(name + " can only define allowedvalues for scalar, unconstrained, or array types");
         }
@@ -279,7 +285,8 @@ final class SchemaLoader {
         Object min = getPropertyValue(table, "min");
         Object max = getPropertyValue(table, "max");
         validateRangeConstraints(name, type, itemReference, min, max);
-        validateAllowedValuesConstraints(name, type, allowedValues, pattern, min, max, minLength, maxLength);
+        validateAllowedValuesConstraints(
+                name, type, allowedValues, pattern, format, min, max, minLength, maxLength);
         return new SchemaDefinition(
                 name,
                 type,
@@ -290,6 +297,7 @@ final class SchemaLoader {
                 optional != null && optional,
                 allowedValues,
                 pattern,
+                format,
                 keyPattern,
                 min,
                 max,
@@ -824,6 +832,7 @@ final class SchemaLoader {
             SchemaType type,
             List<Object> allowedValues,
             Pattern pattern,
+            SchemaStringFormat format,
             Object min,
             Object max,
             Integer minLength,
@@ -837,6 +846,9 @@ final class SchemaLoader {
             String entry = name + " allowedvalues[" + i + "]";
             if (pattern != null && (!(allowed instanceof String stringValue) || !pattern.matcher(stringValue).find())) {
                 throw new SchemaException(entry + " does not satisfy pattern");
+            }
+            if (format != null && (!(allowed instanceof String stringValue) || !format.isValid(stringValue))) {
+                throw new SchemaException(entry + " does not satisfy format " + format.schemaName());
             }
             if ((min != null || max != null) && allowed instanceof Double doubleValue && doubleValue.isNaN()) {
                 throw new SchemaException(entry + " does not satisfy min or max");
@@ -1062,7 +1074,7 @@ final class SchemaLoader {
 
     private SchemaDefinition builtInDefinition(String name, SchemaType type) {
         return new SchemaDefinition(name, type, null, null, null, List.of(), false,
-                List.of(), null, null, null, null, null, null, List.of(), List.of(),
+                List.of(), null, null, null, null, null, null, null, List.of(), List.of(),
                 null, null, null, List.of(), Map.of(), List.of(), List.of(), null,
                 false, null, false, Map.of());
     }

--- a/reference-implementations/java/src/main/java/org/tomlschema/SchemaStringFormat.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/SchemaStringFormat.java
@@ -1,0 +1,434 @@
+package org.tomlschema;
+
+import java.util.Set;
+
+enum SchemaStringFormat {
+    EMAIL("email"),
+    UUID("uuid"),
+    URI("uri"),
+    HOSTNAME("hostname"),
+    IPV4("ipv4"),
+    IPV6("ipv6");
+
+    private static final Set<Character> ATEXT_PUNCTUATION =
+            Set.of('!', '#', '$', '%', '&', '\'', '*', '+', '-', '/', '=',
+                    '?', '^', '_', '`', '{', '|', '}', '~');
+
+    private final String schemaName;
+
+    SchemaStringFormat(String schemaName) {
+        this.schemaName = schemaName;
+    }
+
+    static SchemaStringFormat fromSchemaName(String value) {
+        for (SchemaStringFormat format : values()) {
+            if (format.schemaName.equals(value)) {
+                return format;
+            }
+        }
+        throw new SchemaException("Unsupported string format: " + value);
+    }
+
+    String schemaName() {
+        return schemaName;
+    }
+
+    boolean isValid(String value) {
+        return switch (this) {
+            case EMAIL -> isEmail(value);
+            case UUID -> isUuid(value);
+            case URI -> isUri(value);
+            case HOSTNAME -> isHostname(value, true);
+            case IPV4 -> isIpv4(value);
+            case IPV6 -> isIpv6(value);
+        };
+    }
+
+    private static boolean isEmail(String value) {
+        if (!isAscii(value) || value.length() > 254) {
+            return false;
+        }
+        int at = mailboxAt(value);
+        if (at <= 0 || at > 64 || at == value.length() - 1) {
+            return false;
+        }
+        String local = value.substring(0, at);
+        String domain = value.substring(at + 1);
+        return isLocalPart(local) && (isHostname(domain, false) || isAddressLiteral(domain));
+    }
+
+    private static int mailboxAt(String value) {
+        boolean quoted = false;
+        boolean escaped = false;
+        int at = -1;
+        for (int i = 0; i < value.length(); i++) {
+            char current = value.charAt(i);
+            if (escaped) {
+                escaped = false;
+            } else if (quoted && current == '\\') {
+                escaped = true;
+            } else if (current == '"') {
+                quoted = !quoted;
+            } else if (current == '@' && !quoted) {
+                if (at >= 0) {
+                    return -1;
+                }
+                at = i;
+            }
+        }
+        return quoted || escaped ? -1 : at;
+    }
+
+    private static boolean isLocalPart(String value) {
+        if (value.startsWith("\"")) {
+            if (value.length() < 2 || !value.endsWith("\"")) {
+                return false;
+            }
+            for (int i = 1; i < value.length() - 1; i++) {
+                char current = value.charAt(i);
+                if (current == '\\') {
+                    if (++i >= value.length() - 1 || !isPrintableAscii(value.charAt(i))) {
+                        return false;
+                    }
+                } else if (current == '"' || current < 32 || current > 126) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        String[] atoms = value.split("\\.", -1);
+        if (atoms.length == 0) {
+            return false;
+        }
+        for (String atom : atoms) {
+            if (atom.isEmpty()) {
+                return false;
+            }
+            for (int i = 0; i < atom.length(); i++) {
+                char current = atom.charAt(i);
+                if (!isAsciiLetterOrDigit(current) && !ATEXT_PUNCTUATION.contains(current)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private static boolean isAddressLiteral(String value) {
+        if (value.length() < 3 || value.charAt(0) != '[' || value.charAt(value.length() - 1) != ']') {
+            return false;
+        }
+        String literal = value.substring(1, value.length() - 1);
+        if (isIpv4(literal)) {
+            return true;
+        }
+        if (literal.regionMatches(true, 0, "IPv6:", 0, 5)) {
+            return isIpv6(literal.substring(5));
+        }
+        int colon = literal.indexOf(':');
+        if (colon <= 0 || colon == literal.length() - 1) {
+            return false;
+        }
+        String tag = literal.substring(0, colon);
+        if (!isAsciiLetterOrDigit(tag.charAt(tag.length() - 1))) {
+            return false;
+        }
+        for (int i = 0; i < tag.length(); i++) {
+            char current = tag.charAt(i);
+            if (!isAsciiLetterOrDigit(current) && current != '-') {
+                return false;
+            }
+        }
+        for (int i = colon + 1; i < literal.length(); i++) {
+            char current = literal.charAt(i);
+            if (current < 33 || current > 126
+                    || current == '[' || current == '\\' || current == ']') {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isUuid(String value) {
+        int[] hyphens = {8, 13, 18, 23};
+        if (value.length() != 36) {
+            return false;
+        }
+        for (int i = 0; i < value.length(); i++) {
+            boolean hyphen = false;
+            for (int position : hyphens) {
+                hyphen |= i == position;
+            }
+            if (hyphen ? value.charAt(i) != '-' : !isAsciiHex(value.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isUri(String value) {
+        if (value.isEmpty() || !isAscii(value)) {
+            return false;
+        }
+        for (int index = 0; index < value.length(); index++) {
+            char current = value.charAt(index);
+            if (current <= 32 || current == 127) {
+                return false;
+            }
+        }
+        int colon = value.indexOf(':');
+        if (colon <= 0 || !isAsciiLetter(value.charAt(0))) {
+            return false;
+        }
+        for (int index = 1; index < colon; index++) {
+            char current = value.charAt(index);
+            if (!isAsciiLetterOrDigit(current) && current != '+' && current != '-' && current != '.') {
+                return false;
+            }
+        }
+
+        String remainder = value.substring(colon + 1);
+        int hash = remainder.indexOf('#');
+        if (hash >= 0) {
+            if (!matchesUriComponent(remainder.substring(hash + 1), ":@/?")) {
+                return false;
+            }
+            remainder = remainder.substring(0, hash);
+        }
+        int question = remainder.indexOf('?');
+        if (question >= 0) {
+            if (!matchesUriComponent(remainder.substring(question + 1), ":@/?")) {
+                return false;
+            }
+            remainder = remainder.substring(0, question);
+        }
+
+        if (remainder.startsWith("//")) {
+            int slash = remainder.indexOf('/', 2);
+            String authority = slash < 0 ? remainder.substring(2) : remainder.substring(2, slash);
+            String path = slash < 0 ? "" : remainder.substring(slash);
+            return isUriAuthority(authority) && matchesUriComponent(path, ":@/");
+        }
+        return matchesUriComponent(remainder, ":@/");
+    }
+
+    private static boolean isUriAuthority(String authority) {
+        int at = authority.lastIndexOf('@');
+        String hostPort = at < 0 ? authority : authority.substring(at + 1);
+        if (at >= 0 && !matchesUriComponent(authority.substring(0, at), ":")) {
+            return false;
+        }
+        if (hostPort.startsWith("[")) {
+            int close = hostPort.indexOf(']');
+            if (close < 0 || !isUriPort(hostPort.substring(close + 1))) {
+                return false;
+            }
+            String literal = hostPort.substring(1, close);
+            return isIpv6(literal) || isIpvFuture(literal);
+        }
+        int colon = hostPort.lastIndexOf(':');
+        if (colon >= 0) {
+            if (hostPort.indexOf(':') != colon || !isUriPort(hostPort.substring(colon))) {
+                return false;
+            }
+            hostPort = hostPort.substring(0, colon);
+        }
+        return matchesUriComponent(hostPort, "");
+    }
+
+    private static boolean isUriPort(String value) {
+        if (value.isEmpty()) {
+            return true;
+        }
+        if (value.charAt(0) != ':') {
+            return false;
+        }
+        for (int index = 1; index < value.length(); index++) {
+            if (value.charAt(index) < '0' || value.charAt(index) > '9') {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isIpvFuture(String value) {
+        if (value.length() < 4 || value.charAt(0) != 'v' && value.charAt(0) != 'V') {
+            return false;
+        }
+        int dot = value.indexOf('.', 1);
+        if (dot <= 1 || dot == value.length() - 1) {
+            return false;
+        }
+        for (int index = 1; index < dot; index++) {
+            if (!isAsciiHex(value.charAt(index))) {
+                return false;
+            }
+        }
+        for (int index = dot + 1; index < value.length(); index++) {
+            char current = value.charAt(index);
+            if (!isUriUnreserved(current) && !isUriSubDelimiter(current) && current != ':') {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean matchesUriComponent(String value, String extra) {
+        for (int index = 0; index < value.length(); index++) {
+            char current = value.charAt(index);
+            if (current == '%') {
+                if (index + 2 >= value.length()
+                        || !isAsciiHex(value.charAt(index + 1))
+                        || !isAsciiHex(value.charAt(index + 2))) {
+                    return false;
+                }
+                index += 2;
+            } else if (!isUriUnreserved(current)
+                    && !isUriSubDelimiter(current)
+                    && extra.indexOf(current) < 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isUriUnreserved(char value) {
+        return isAsciiLetterOrDigit(value) || value == '-' || value == '.'
+                || value == '_' || value == '~';
+    }
+
+    private static boolean isUriSubDelimiter(char value) {
+        return "!$&'()*+,;=".indexOf(value) >= 0;
+    }
+
+    private static boolean isHostname(String value, boolean allowFinalDot) {
+        String hostname = value;
+        if (allowFinalDot && hostname.endsWith(".")) {
+            hostname = hostname.substring(0, hostname.length() - 1);
+        }
+        if (hostname.isEmpty() || hostname.length() > 253 || !isAscii(hostname)) {
+            return false;
+        }
+        String[] labels = hostname.split("\\.", -1);
+        for (String label : labels) {
+            if (label.isEmpty() || label.length() > 63
+                    || !isAsciiLetterOrDigit(label.charAt(0))
+                    || !isAsciiLetterOrDigit(label.charAt(label.length() - 1))) {
+                return false;
+            }
+            for (int i = 1; i < label.length() - 1; i++) {
+                char current = label.charAt(i);
+                if (!isAsciiLetterOrDigit(current) && current != '-') {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private static boolean isIpv4(String value) {
+        String[] octets = value.split("\\.", -1);
+        if (octets.length != 4) {
+            return false;
+        }
+        for (String octet : octets) {
+            if (octet.isEmpty() || octet.length() > 3
+                    || octet.length() > 1 && octet.charAt(0) == '0') {
+                return false;
+            }
+            int number = 0;
+            for (int i = 0; i < octet.length(); i++) {
+                char current = octet.charAt(i);
+                if (current < '0' || current > '9') {
+                    return false;
+                }
+                number = number * 10 + current - '0';
+            }
+            if (number > 255) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isIpv6(String value) {
+        if (value.isEmpty() || value.indexOf('%') >= 0) {
+            return false;
+        }
+        int compression = value.indexOf("::");
+        if (compression >= 0 && value.indexOf("::", compression + 2) >= 0) {
+            return false;
+        }
+        if (compression < 0) {
+            if (value.startsWith(":") || value.endsWith(":")) {
+                return false;
+            }
+            return ipv6Units(value, true) == 8;
+        }
+        String left = value.substring(0, compression);
+        String right = value.substring(compression + 2);
+        int leftUnits = ipv6Units(left, false);
+        int rightUnits = ipv6Units(right, true);
+        return leftUnits >= 0 && rightUnits >= 0 && leftUnits + rightUnits < 8;
+    }
+
+    private static int ipv6Units(String side, boolean mayContainIpv4) {
+        if (side.isEmpty()) {
+            return 0;
+        }
+        String[] groups = side.split(":", -1);
+        int units = 0;
+        for (int i = 0; i < groups.length; i++) {
+            String group = groups[i];
+            if (group.isEmpty()) {
+                return -1;
+            }
+            if (group.indexOf('.') >= 0) {
+                if (!mayContainIpv4 || i != groups.length - 1 || !isIpv4(group)) {
+                    return -1;
+                }
+                units += 2;
+            } else {
+                if (group.length() > 4) {
+                    return -1;
+                }
+                for (int j = 0; j < group.length(); j++) {
+                    if (!isAsciiHex(group.charAt(j))) {
+                        return -1;
+                    }
+                }
+                units++;
+            }
+        }
+        return units;
+    }
+
+    private static boolean isAscii(String value) {
+        for (int i = 0; i < value.length(); i++) {
+            if (value.charAt(i) > 127) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isPrintableAscii(char value) {
+        return value >= 32 && value <= 126;
+    }
+
+    private static boolean isAsciiLetterOrDigit(char value) {
+        return isAsciiLetter(value)
+                || value >= '0' && value <= '9';
+    }
+
+    private static boolean isAsciiLetter(char value) {
+        return value >= 'a' && value <= 'z'
+                || value >= 'A' && value <= 'Z';
+    }
+
+    private static boolean isAsciiHex(char value) {
+        return value >= '0' && value <= '9'
+                || value >= 'a' && value <= 'f'
+                || value >= 'A' && value <= 'F';
+    }
+}

--- a/reference-implementations/java/src/main/java/org/tomlschema/TomlSchemaValidator.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/TomlSchemaValidator.java
@@ -451,6 +451,10 @@ final class TomlSchemaValidator {
                 add("pattern", path,
                         "does not match pattern " + definition.pattern().pattern());
             }
+            if (definition.format() != null && !definition.format().isValid(stringValue)) {
+                add("format", path,
+                        "does not match format " + definition.format().schemaName());
+            }
         }
     }
 
@@ -615,7 +619,7 @@ final class TomlSchemaValidator {
 
     private SchemaDefinition builtIn(String name, SchemaType type) {
         return new SchemaDefinition(name, type, null, null, null, List.of(), false,
-                List.of(), null, null, null, null, null, null, List.of(), List.of(),
+                List.of(), null, null, null, null, null, null, null, List.of(), List.of(),
                 null, null, null, List.of(), Map.of(), List.of(), List.of(), null,
                 false, null, false, Map.of());
     }

--- a/reference-implementations/java/src/test/java/org/tomlschema/StringFormatTest.java
+++ b/reference-implementations/java/src/test/java/org/tomlschema/StringFormatTest.java
@@ -1,0 +1,192 @@
+package org.tomlschema;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StringFormatTest {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void validatesEverySupportedFormat() {
+        Map<SchemaStringFormat, List<String>> valid = Map.of(
+                SchemaStringFormat.EMAIL, List.of(
+                        "simple@example.com",
+                        "user.name+tag@example-domain.com",
+                        "\"quoted local\"@example.com",
+                        "\"quote\\\"and\\\\slash\"@example.com",
+                        "postmaster@[192.0.2.1]",
+                        "postmaster@[IPv6:2001:db8::1]",
+                        "postmaster@[TAG:opaque-data]",
+                        "a".repeat(64) + "@" + longDomain(189)),
+                SchemaStringFormat.UUID, List.of(
+                        "550e8400-e29b-41d4-a716-446655440000",
+                        "550E8400-E29B-41D4-A716-446655440000"),
+                SchemaStringFormat.URI, List.of(
+                        "https://example.com/a%20path?x=1#part",
+                        "mailto:user@example.com", "urn:isbn:9780141036144",
+                        "scheme:", "http://[v1.fe]/"),
+                SchemaStringFormat.HOSTNAME, List.of(
+                        "example.com", "a-b.example", "localhost", "example.com."),
+                SchemaStringFormat.IPV4, List.of(
+                        "0.0.0.0", "192.0.2.1", "255.255.255.255"),
+                SchemaStringFormat.IPV6, List.of(
+                        "::", "::1", "2001:db8::1", "2001:db8:0:1:2:3:4:5",
+                        "::ffff:192.0.2.128", "2001:db8::192.0.2.1"));
+        Map<SchemaStringFormat, List<String>> invalid = Map.of(
+                SchemaStringFormat.EMAIL, List.of(
+                        "josé@example.com", ".leading@example.com", "two..dots@example.com",
+                        "missing-at.example.com", "\"unterminated@example.com",
+                        "user@-example.com", "user@[300.1.1.1]", "user@[IPv6:2001:::1]",
+                        "user@[TAG:bad\\data]", "user@[TAG:bad]data]",
+                        "a".repeat(65) + "@example.com",
+                        "a".repeat(64) + "@" + longDomain(190)),
+                SchemaStringFormat.UUID, List.of(
+                        "550e8400e29b41d4a716446655440000",
+                        "550e8400-e29b-41d4-a716-44665544000g",
+                        "550e8400-e29b-41d4-a716-4466554400000"),
+                SchemaStringFormat.URI, List.of(
+                        "/relative/path", "example.com/path", "https://example.com/%zz",
+                        "https://example.com/é", "http://example.com/#first#second"),
+                SchemaStringFormat.HOSTNAME, List.of(
+                        "-example.com", "example-.com", "two..dots",
+                        "a".repeat(64) + ".example", "éxample.com"),
+                SchemaStringFormat.IPV4, List.of(
+                        "192.168.1", "192.168.01.1", "256.0.0.1", "1.2.3.4.5", "1.2.3.-1"),
+                SchemaStringFormat.IPV6, List.of(
+                        "2001:db8:0:1:2:3:4", "2001:db8:0:1:2:3:4:5:6",
+                        "2001:::1", "2001:db8::1::2", "fe80::1%eth0",
+                        "::ffff:192.168.01.1", "::ffff:256.1.1.1"));
+
+        valid.forEach((format, values) -> values.forEach(value ->
+                assertTrue(format.isValid(value), () -> format + " should accept " + value)));
+        invalid.forEach((format, values) -> values.forEach(value ->
+                assertFalse(format.isValid(value), () -> format + " should reject " + value)));
+    }
+
+    @Test
+    void validatesFormatsThroughLoadedSchema() throws IOException {
+        Path schemaPath = write("formats.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.email]
+                type = "string"
+                format = "email"
+                [elements.uuid]
+                type = "string"
+                format = "uuid"
+                [elements.uri]
+                type = "string"
+                format = "uri"
+                [elements.hostname]
+                type = "string"
+                format = "hostname"
+                [elements.ipv4]
+                type = "string"
+                format = "ipv4"
+                [elements.ipv6]
+                type = "string"
+                format = "ipv6"
+                """);
+        TomlSchema schema = TomlSchema.load(schemaPath);
+
+        ValidationResult valid = schema.validate(write("valid.toml", """
+                email = '"quoted local"@example.com'
+                uuid = "550e8400-e29b-41d4-a716-446655440000"
+                uri = "https://example.com/a%20path"
+                hostname = "example.com."
+                ipv4 = "192.0.2.1"
+                ipv6 = "2001:db8::1"
+                """));
+        assertTrue(valid.isValid(), () -> valid.errors().toString());
+
+        ValidationResult invalid = schema.validate(write("invalid.toml", """
+                email = "two..dots@example.com"
+                uuid = "not-a-uuid"
+                uri = "../relative"
+                hostname = "-example.com"
+                ipv4 = "192.168.01.1"
+                ipv6 = "2001:::1"
+                """));
+        assertEquals(6, invalid.errors().size(), () -> invalid.errors().toString());
+        assertTrue(invalid.errors().stream().allMatch(error ->
+                error.code().equals("format") && error.message().startsWith("does not match format ")));
+    }
+
+    @Test
+    void rejectsUnknownAndInapplicableFormatsAtSchemaLoad() throws IOException {
+        Path unknown = schemaWithDefinition("type = \"string\"\nformat = \"date\"");
+        Path incompatible = schemaWithDefinition("type = \"integer\"\nformat = \"uuid\"");
+        Path namedReference = write("named-format.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+                [types.text]
+                type = "string"
+                [elements.value]
+                type = "types.text"
+                format = "email"
+                """);
+
+        assertTrue(assertThrows(SchemaException.class, () -> TomlSchema.load(unknown))
+                .getMessage().contains("Unsupported string format"));
+        assertTrue(assertThrows(SchemaException.class, () -> TomlSchema.load(incompatible))
+                .getMessage().contains("only define format when type is string"));
+        assertThrows(SchemaException.class, () -> TomlSchema.load(namedReference));
+    }
+
+    @Test
+    void formattedAllowedValuesAndDefaultsMustBeValid() throws IOException {
+        Path allowed = schemaWithDefinition("""
+                type = "string"
+                format = "ipv4"
+                allowedvalues = ["192.168.01.1"]
+                """);
+        Path defaulted = schemaWithDefinition("""
+                type = "string"
+                format = "email"
+                default = "two..dots@example.com"
+                """);
+
+        assertThrows(SchemaException.class, () -> TomlSchema.load(allowed));
+        assertThrows(SchemaException.class, () -> TomlSchema.load(defaulted));
+    }
+
+    private Path schemaWithDefinition(String definition) throws IOException {
+        return write("schema-" + Math.abs(definition.hashCode()) + ".tosd", """
+                [toml-schema]
+                version = "1.0.0"
+                [elements.value]
+                """ + definition);
+    }
+
+    private Path write(String name, String content) throws IOException {
+        return Files.writeString(tempDir.resolve(name), content);
+    }
+
+    private static String longDomain(int length) {
+        StringBuilder result = new StringBuilder();
+        while (result.length() < length) {
+            int remaining = length - result.length();
+            int labelLength = Math.min(63, remaining);
+            if (result.length() > 0) {
+                result.append('.');
+                remaining--;
+                labelLength = Math.min(63, remaining);
+            }
+            result.append("a".repeat(labelLength));
+        }
+        return result.toString();
+    }
+}

--- a/reference-implementations/python/src/toml_schema/_definition.py
+++ b/reference-implementations/python/src/toml_schema/_definition.py
@@ -39,6 +39,7 @@ class Definition:
     optional: bool = False
     allowed_values: Tuple[Any, ...] = ()
     pattern: Optional[Pattern[str]] = None
+    format: str = ""
     key_pattern: Optional[Pattern[str]] = None
     min: Any = None
     max: Any = None

--- a/reference-implementations/python/src/toml_schema/_formats.py
+++ b/reference-implementations/python/src/toml_schema/_formats.py
@@ -1,0 +1,207 @@
+"""Validation for the string formats supported by the Python implementation."""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+import urllib.parse
+
+SUPPORTED_FORMATS = frozenset({"email", "uuid", "uri", "hostname", "ipv4", "ipv6"})
+
+_ATEXT = frozenset("!#$%&'*+-/=?^_`{|}~")
+_UUID_RE = re.compile(
+    r"^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-"
+    r"[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
+)
+_SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*:")
+_URI_PATH_RE = re.compile(r"^[A-Za-z0-9\-._~!$&'()*+,;=:@%/]*$")
+_URI_QUERY_RE = re.compile(r"^[A-Za-z0-9\-._~!$&'()*+,;=:@%/?]*$")
+_URI_AUTHORITY_RE = re.compile(r"^[A-Za-z0-9\-._~!$&'()*+,;=:@%\[\]]*$")
+_URI_USERINFO_RE = re.compile(r"^[A-Za-z0-9\-._~!$&'()*+,;=:%]*$")
+_URI_REG_NAME_RE = re.compile(r"^[A-Za-z0-9\-._~!$&'()*+,;=%]*$")
+_IPV_FUTURE_RE = re.compile(r"^v[0-9A-Fa-f]+\.[A-Za-z0-9\-._~!$&'()*+,;=:]+$", re.I)
+_BAD_PERCENT_RE = re.compile(r"%(?![0-9A-Fa-f]{2})")
+_IPV4_RE = re.compile(r"^(0|[1-9][0-9]{0,2})(?:\.(0|[1-9][0-9]{0,2})){3}$")
+_GENERAL_LITERAL_TAG_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$")
+
+
+def _valid_hostname(value: str, *, allow_trailing_dot: bool = True) -> bool:
+    if not value or not value.isascii():
+        return False
+    name = value[:-1] if allow_trailing_dot and value.endswith(".") else value
+    if not name or len(name) > 253:
+        return False
+    labels = name.split(".")
+    return all(
+        1 <= len(label) <= 63
+        and label[0].isalnum()
+        and label[-1].isalnum()
+        and all(character.isascii() and (character.isalnum() or character == "-") for character in label)
+        for label in labels
+    )
+
+
+def _valid_ipv4(value: str) -> bool:
+    if not _IPV4_RE.fullmatch(value):
+        return False
+    try:
+        ipaddress.IPv4Address(value)
+    except ipaddress.AddressValueError:
+        return False
+    return True
+
+
+def _valid_ipv6(value: str) -> bool:
+    if ":" not in value or "%" in value:
+        return False
+    try:
+        ipaddress.IPv6Address(value)
+    except ipaddress.AddressValueError:
+        return False
+    return True
+
+
+def _valid_local_part(value: str) -> bool:
+    if value.startswith('"'):
+        if len(value) < 2 or not value.endswith('"'):
+            return False
+        index = 1
+        while index < len(value) - 1:
+            codepoint = ord(value[index])
+            if value[index] == "\\":
+                index += 1
+                if index >= len(value) - 1 or not 32 <= ord(value[index]) <= 126:
+                    return False
+            elif not (codepoint in (32, 33) or 35 <= codepoint <= 91 or 93 <= codepoint <= 126):
+                return False
+            index += 1
+        return True
+
+    atoms = value.split(".")
+    return bool(value) and all(
+        atom
+        and all(character.isascii() and (character.isalnum() or character in _ATEXT) for character in atom)
+        for atom in atoms
+    )
+
+
+def _split_mailbox(value: str) -> tuple[str, str] | None:
+    quoted = False
+    escaped = False
+    separator = -1
+    for index, character in enumerate(value):
+        if escaped:
+            escaped = False
+        elif quoted and character == "\\":
+            escaped = True
+        elif character == '"':
+            quoted = not quoted
+        elif character == "@" and not quoted:
+            if separator != -1:
+                return None
+            separator = index
+    if quoted or escaped or separator < 0:
+        return None
+    return value[:separator], value[separator + 1 :]
+
+
+def _valid_address_literal(value: str) -> bool:
+    if len(value) < 3 or not value.startswith("[") or not value.endswith("]"):
+        return False
+    literal = value[1:-1]
+    if _valid_ipv4(literal):
+        return True
+    if literal.lower().startswith("ipv6:"):
+        return _valid_ipv6(literal[5:])
+    tag, separator, content = literal.partition(":")
+    return bool(
+        separator
+        and content
+        and _GENERAL_LITERAL_TAG_RE.fullmatch(tag)
+        and all(33 <= ord(character) <= 90 or 94 <= ord(character) <= 126 for character in content)
+    )
+
+
+def _valid_email(value: str) -> bool:
+    if not value.isascii() or len(value.encode("ascii")) > 254:
+        return False
+    parts = _split_mailbox(value)
+    if parts is None:
+        return False
+    local, domain = parts
+    if len(local.encode("ascii")) > 64 or not _valid_local_part(local):
+        return False
+    return _valid_address_literal(domain) if domain.startswith("[") else _valid_hostname(
+        domain, allow_trailing_dot=False
+    )
+
+
+def _valid_uri_authority(authority: str) -> bool:
+    if not _URI_AUTHORITY_RE.fullmatch(authority) or authority.count("@") > 1:
+        return False
+    userinfo, separator, host_port = authority.rpartition("@")
+    if separator and not _URI_USERINFO_RE.fullmatch(userinfo):
+        return False
+    if host_port.startswith("["):
+        closing = host_port.find("]")
+        if closing < 0:
+            return False
+        literal = host_port[1:closing]
+        remainder = host_port[closing + 1 :]
+        if not (_valid_ipv6(literal) or _IPV_FUTURE_RE.fullmatch(literal)):
+            return False
+        if remainder and not remainder.startswith(":"):
+            return False
+        port = remainder[1:] if remainder else ""
+    else:
+        if host_port.count(":") > 1:
+            return False
+        host, separator, port = host_port.partition(":")
+        if not _URI_REG_NAME_RE.fullmatch(host):
+            return False
+    return not separator or port.isdigit() or port == ""
+
+
+def _valid_uri(value: str) -> bool:
+    if not value.isascii() or not _SCHEME_RE.match(value):
+        return False
+    if _BAD_PERCENT_RE.search(value) or value.count("#") > 1:
+        return False
+    without_fragment, _, fragment = value.partition("#")
+    if not _URI_QUERY_RE.fullmatch(fragment):
+        return False
+    before_query, _, query = without_fragment.partition("?")
+    if not _URI_QUERY_RE.fullmatch(query):
+        return False
+    _, hierarchical = before_query.split(":", 1)
+    if hierarchical.startswith("//"):
+        authority_and_path = hierarchical[2:]
+        authority, separator, path = authority_and_path.partition("/")
+        if not _valid_uri_authority(authority):
+            return False
+        path = "/" + path if separator else ""
+    else:
+        path = hierarchical
+    if not _URI_PATH_RE.fullmatch(path):
+        return False
+    try:
+        parsed = urllib.parse.urlsplit(value)
+        if parsed.netloc:
+            _ = parsed.hostname
+            _ = parsed.port
+    except ValueError:
+        return False
+    return bool(parsed.scheme)
+
+
+def matches_format(value: str, format_name: str) -> bool:
+    """Return whether *value* conforms to the named string format."""
+    validators = {
+        "email": _valid_email,
+        "uuid": lambda candidate: bool(_UUID_RE.fullmatch(candidate)),
+        "uri": _valid_uri,
+        "hostname": _valid_hostname,
+        "ipv4": _valid_ipv4,
+        "ipv6": _valid_ipv6,
+    }
+    return validators[format_name](value)

--- a/reference-implementations/python/src/toml_schema/_schema.py
+++ b/reference-implementations/python/src/toml_schema/_schema.py
@@ -23,6 +23,7 @@ from ._compare import (
 )
 from ._definition import Condition, Definition
 from ._errors import SchemaError
+from ._formats import SUPPORTED_FORMATS, matches_format
 from ._source import SchemaSource
 from ._types import (
     Diagnostic,
@@ -47,6 +48,7 @@ DEFINITION_KEYS = frozenset(
         "items",
         "allowedvalues",
         "pattern",
+        "format",
         "keypattern",
         "optional",
         "min",
@@ -466,6 +468,10 @@ def parse_definition(name: str, path: Path, table: dict, source: SchemaSource) -
         raise SchemaError(f"{name} items must contain at least one type reference")
     optional = _get_bool(table, "optional")
     pattern = _get_pattern(name, table)
+    format_name = _get_string(table, "format")
+    if _property_value(table, "format") is not None and format_name not in SUPPORTED_FORMATS:
+        supported = ", ".join(sorted(SUPPORTED_FORMATS))
+        raise SchemaError(f"{name} has unknown format {format_name!r}; supported formats: {supported}")
     key_pattern = _get_pattern_key(name, table, "keypattern")
     min_length = _get_integer_pointer(table, "minlength")
     max_length = _get_integer_pointer(table, "maxlength")
@@ -576,6 +582,10 @@ def parse_definition(name: str, path: Path, table: dict, source: SchemaSource) -
         raise SchemaError(f"{name} can only define keypattern when type is collection")
     if pattern is not None and type_name != SchemaType.STRING:
         raise SchemaError(f"{name} can only define pattern when type is string")
+    if format_name and type_name != SchemaType.STRING:
+        raise SchemaError(
+            f"{name} can only define format when locally selecting built-in type string"
+        )
     if has_allowed_values and type_name in (SchemaType.TABLE, SchemaType.COLLECTION):
         raise SchemaError(f"{name} can only define allowedvalues for scalar, unconstrained, or array types")
     if (min_length is not None or max_length is not None) and type_name not in (
@@ -593,6 +603,12 @@ def parse_definition(name: str, path: Path, table: dict, source: SchemaSource) -
     _validate_allowed_values_constraints(
         name, type_name, allowed_values, pattern, min_value, max_value, min_length, max_length
     )
+    if format_name:
+        for index, allowed in enumerate(allowed_values):
+            if not isinstance(allowed, str) or not matches_format(allowed, format_name):
+                raise SchemaError(
+                    f"{name} allowedvalues[{index}] does not satisfy format {format_name}"
+                )
 
     dependent_required = _get_dependent_required(name, path, table, source)
     mutually_exclusive = _get_key_groups(name, path, table, "mutuallyexclusive", source)
@@ -613,6 +629,7 @@ def parse_definition(name: str, path: Path, table: dict, source: SchemaSource) -
         optional=optional,
         allowed_values=tuple(allowed_values),
         pattern=pattern,
+        format=format_name,
         key_pattern=key_pattern,
         min=min_value,
         max=max_value,

--- a/reference-implementations/python/src/toml_schema/_validator.py
+++ b/reference-implementations/python/src/toml_schema/_validator.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 from ._compare import IncomparableError, compare, is_type, type_name_of, values_equal
 from ._definition import Condition, Definition
 from ._errors import SchemaError
+from ._formats import matches_format
 from ._types import Diagnostic, Severity, SchemaType, normalize_reference, parse_schema_type
 
 _PLAIN_KEY_RE = re.compile(r"^[A-Za-z0-9_-]+$")
@@ -577,6 +578,8 @@ class Validator:
             self.validate_length(path, len(value), definition)
             if definition.pattern is not None and not definition.pattern.search(value):
                 self.add(path, f"does not match pattern {definition.pattern.pattern}")
+            if definition.format and not matches_format(value, definition.format):
+                self.add(path, f"does not match format {definition.format}")
 
     def validate_allowed_values(self, path: str, value: Any, definition: Definition) -> None:
         if not definition.allowed_values:

--- a/reference-implementations/python/tests/test_formats.py
+++ b/reference-implementations/python/tests/test_formats.py
@@ -1,0 +1,199 @@
+"""Focused tests for the Python implementation's string formats."""
+
+import tempfile
+import unittest
+
+import helpers
+from toml_schema import SchemaError
+
+
+class StringFormatTests(unittest.TestCase):
+    def _schema(self, directory, format_name):
+        return helpers.load_semantics_schema(
+            directory,
+            f"""
+[elements.value]
+type = "string"
+format = "{format_name}"
+""",
+        )
+
+    def test_email_format(self):
+        valid = [
+            "simple@example.com",
+            "first.last+tag@example-domain.com",
+            "\"quoted local\"@example.com",
+            "\"escaped\\\"quote\"@example.com",
+            "\"a@b\"@example.com",
+            "postmaster@[192.0.2.1]",
+            "postmaster@[IPv6:2001:db8::1]",
+            "postmaster@[X-example:some-value]",
+            f"{'a' * 64}@example.com",
+            f"{'a' * 64}@{'b' * 63}.{'c' * 63}.{'d' * 59}",
+            f"{'a' * 64}@{'b' * 63}.{'c' * 63}.{'d' * 61}",
+        ]
+        invalid = [
+            "",
+            "missing-at.example.com",
+            "@example.com",
+            ".leading@example.com",
+            "trailing.@example.com",
+            "two..dots@example.com",
+            "white space@example.com",
+            "user@example.com.",
+            "user@-example.com",
+            "user@example..com",
+            "user@éxample.com",
+            "é@example.com",
+            "\"unterminated@example.com",
+            "\"bad\nnewline\"@example.com",
+            "\"bad\\\nescape\"@example.com",
+            "postmaster@[192.168.001.1]",
+            "postmaster@[IPv6:2001:::1]",
+            "postmaster@[bad literal]",
+            f"{'a' * 65}@example.com",
+            f"{'a' * 64}@{'b' * 63}.{'c' * 63}.{'d' * 62}",
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            schema = self._schema(tmp, "email")
+            for value in valid:
+                with self.subTest(valid=value):
+                    self.assertTrue(schema.validate({"value": value}).valid)
+            for value in invalid:
+                with self.subTest(invalid=value):
+                    result = schema.validate({"value": value})
+                    self.assertFalse(result.valid)
+                    self.assertEqual(result.errors[0].message, "does not match format email")
+
+    def test_uuid_format(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema = self._schema(tmp, "uuid")
+            for value in [
+                "550e8400-e29b-41d4-a716-446655440000",
+                "00000000-0000-0000-0000-000000000000",
+                "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF",
+            ]:
+                with self.subTest(valid=value):
+                    self.assertTrue(schema.validate({"value": value}).valid)
+            for value in [
+                "{550e8400-e29b-41d4-a716-446655440000}",
+                "550e8400e29b41d4a716446655440000",
+                "550e8400-e29b-41d4-a716-44665544000g",
+            ]:
+                with self.subTest(invalid=value):
+                    self.assertFalse(schema.validate({"value": value}).valid)
+
+    def test_uri_format(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema = self._schema(tmp, "uri")
+            for value in [
+                "https://example.com/a%20path?q=x#fragment",
+                "mailto:user@example.com",
+                "urn:isbn:9780141036144",
+                "file:///etc/hosts",
+                "http://[v1.fe]/",
+                "scheme:",
+            ]:
+                with self.subTest(valid=value):
+                    self.assertTrue(schema.validate({"value": value}).valid)
+            for value in [
+                "example.com/path",
+                "1http://example.com",
+                "https://example.com/%",
+                "https://example.com/%GG",
+                "https://example.com/a path",
+                "https://example.com/a#first#second",
+                "https://éxample.com",
+                "https://[not-ipv6]/",
+                "https://example.com:bad/",
+                "https://user@@example.com/",
+            ]:
+                with self.subTest(invalid=value):
+                    self.assertFalse(schema.validate({"value": value}).valid)
+
+    def test_hostname_format(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema = self._schema(tmp, "hostname")
+            for value in ["example.com", "EXAMPLE", "a-b.example.", "a" * 63]:
+                with self.subTest(valid=value):
+                    self.assertTrue(schema.validate({"value": value}).valid)
+            for value in [
+                "",
+                "-example.com",
+                "example-.com",
+                "example..com",
+                "under_score.example",
+                "éxample.com",
+                "a" * 64,
+                ".".join(["a" * 63] * 4),
+            ]:
+                with self.subTest(invalid=value):
+                    self.assertFalse(schema.validate({"value": value}).valid)
+
+    def test_ip_formats(self):
+        cases = {
+            "ipv4": (
+                ["0.0.0.0", "192.0.2.1", "255.255.255.255"],
+                ["192.168.001.1", "256.1.1.1", "1.2.3", "1.2.3.4.5", "1.2.3.-1"],
+            ),
+            "ipv6": (
+                ["::", "::1", "2001:db8::1", "::ffff:192.0.2.128"],
+                ["2001:::1", "1.2.3.4", "fe80::1%eth0", "12345::1"],
+            ),
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            for format_name, (valid, invalid) in cases.items():
+                schema = self._schema(tmp, format_name)
+                for value in valid:
+                    with self.subTest(format=format_name, valid=value):
+                        self.assertTrue(schema.validate({"value": value}).valid)
+                for value in invalid:
+                    with self.subTest(format=format_name, invalid=value):
+                        self.assertFalse(schema.validate({"value": value}).valid)
+
+    def test_format_schema_errors(self):
+        cases = {
+            "unknown": """
+[elements.value]
+type = "string"
+format = "date"
+""",
+            "wrong-value-type": """
+[elements.value]
+type = "string"
+format = 1
+""",
+            "incompatible": """
+[elements.value]
+type = "integer"
+format = "email"
+""",
+            "named-reference": """
+[types.email]
+type = "string"
+[elements.value]
+type = "types.email"
+format = "email"
+""",
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            for name, definitions in cases.items():
+                with self.subTest(name=name), self.assertRaises(SchemaError):
+                    helpers.load_semantics_schema(tmp, definitions)
+
+    def test_allowed_value_must_match_format(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaisesRegex(SchemaError, "does not satisfy format email"):
+                helpers.load_semantics_schema(
+                    tmp,
+                    """
+[elements.value]
+type = "string"
+format = "email"
+allowedvalues = ["not an email"]
+""",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/reference-implementations/rust/src/schema.rs
+++ b/reference-implementations/rust/src/schema.rs
@@ -8,7 +8,9 @@
 use std::collections::{BTreeMap, HashSet};
 use std::fmt;
 use std::fs;
+use std::net::{Ipv4Addr, Ipv6Addr};
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 
 use regex::Regex;
 use toml::de::{DeTable, DeValue};
@@ -98,6 +100,7 @@ pub const DEFINITION_KEYS: &[&str] = &[
     "items",
     "allowedvalues",
     "pattern",
+    "format",
     "keypattern",
     "optional",
     "min",
@@ -151,6 +154,7 @@ pub struct Definition {
     optional: bool,
     allowed_values: Vec<Value>,
     pattern: Option<Regex>,
+    string_format: Option<StringFormat>,
     key_pattern: Option<Regex>,
     min: Option<Value>,
     max: Option<Value>,
@@ -167,6 +171,52 @@ pub struct Definition {
     default_value: Option<Value>,
     deprecated: bool,
     children: BTreeMap<String, Definition>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum StringFormat {
+    Email,
+    Uuid,
+    Uri,
+    Hostname,
+    Ipv4,
+    Ipv6,
+}
+
+impl StringFormat {
+    fn parse(name: &str, value: &str) -> Result<Self, String> {
+        match value {
+            "email" => Ok(Self::Email),
+            "uuid" => Ok(Self::Uuid),
+            "uri" => Ok(Self::Uri),
+            "hostname" => Ok(Self::Hostname),
+            "ipv4" => Ok(Self::Ipv4),
+            "ipv6" => Ok(Self::Ipv6),
+            _ => Err(format!("{name} has unknown format: {value}")),
+        }
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            Self::Email => "email",
+            Self::Uuid => "uuid",
+            Self::Uri => "uri",
+            Self::Hostname => "hostname",
+            Self::Ipv4 => "ipv4",
+            Self::Ipv6 => "ipv6",
+        }
+    }
+
+    fn matches(self, value: &str) -> bool {
+        match self {
+            Self::Email => is_email(value),
+            Self::Uuid => is_uuid(value),
+            Self::Uri => is_absolute_uri(value),
+            Self::Hostname => is_hostname(value),
+            Self::Ipv4 => is_ipv4(value),
+            Self::Ipv6 => Ipv6Addr::from_str(value).is_ok(),
+        }
+    }
 }
 
 impl Definition {
@@ -1247,6 +1297,9 @@ fn parse_definition(
     }
     let optional = get_bool(name, table, "optional")?.unwrap_or(false);
     let pattern = get_pattern(name, table)?;
+    let string_format = get_string(name, table, "format")?
+        .map(|value| StringFormat::parse(name, &value))
+        .transpose()?;
     let key_pattern = get_pattern_key(name, table, "keypattern")?;
     let min_length = get_unsigned_integer(name, table, "minlength")?;
     let max_length = get_unsigned_integer(name, table, "maxlength")?;
@@ -1427,6 +1480,11 @@ fn parse_definition(
             "{name} can only define pattern when type is string"
         ));
     }
+    if string_format.is_some() && type_name != Some(SchemaType::String) {
+        return Err(format!(
+            "{name} can only define format when type is string"
+        ));
+    }
     if has_allowed_values && matches!(type_name, Some(SchemaType::Table | SchemaType::Collection)) {
         return Err(format!(
             "{name} can only define allowedvalues for scalar, unconstrained, or array types"
@@ -1462,6 +1520,7 @@ fn parse_definition(
         type_name,
         &allowed_values,
         pattern.as_ref(),
+        string_format,
         min.as_ref(),
         max.as_ref(),
         min_length,
@@ -1477,6 +1536,7 @@ fn parse_definition(
         optional,
         allowed_values,
         pattern,
+        string_format,
         key_pattern,
         min,
         max,
@@ -1786,6 +1846,7 @@ fn validate_allowed_values_constraints(
     type_name: Option<SchemaType>,
     allowed_values: &[Value],
     pattern: Option<&Regex>,
+    string_format: Option<StringFormat>,
     min: Option<&Value>,
     max: Option<&Value>,
     min_length: Option<i64>,
@@ -1802,6 +1863,14 @@ fn validate_allowed_values_constraints(
             };
             if !matches_pattern(pattern, string_value) {
                 return Err(format!("{entry} does not satisfy pattern"));
+            }
+        }
+        if let Some(string_format) = string_format {
+            let Some(string_value) = allowed.as_str() else {
+                return Err(format!("{entry} does not satisfy format {}", string_format.name()));
+            };
+            if !string_format.matches(string_value) {
+                return Err(format!("{entry} does not satisfy format {}", string_format.name()));
             }
         }
         if (min.is_some() || max.is_some()) && is_nan(Some(allowed)) {
@@ -2261,6 +2330,14 @@ impl<'schema> Validator<'schema> {
                     self.add(
                         path,
                         &format!("does not match pattern {}", pattern.as_str()),
+                    );
+                }
+            }
+            if let Some(string_format) = definition.string_format {
+                if !string_format.matches(string_value) {
+                    self.add(
+                        path,
+                        &format!("does not satisfy format {}", string_format.name()),
                     );
                 }
             }
@@ -2744,6 +2821,219 @@ fn matches_pattern(pattern: &Regex, value: &str) -> bool {
     pattern.is_match(value)
 }
 
+fn is_uuid(value: &str) -> bool {
+    value.len() == 36
+        && value.bytes().enumerate().all(|(index, byte)| match index {
+            8 | 13 | 18 | 23 => byte == b'-',
+            _ => byte.is_ascii_hexdigit(),
+        })
+}
+
+fn is_ipv4(value: &str) -> bool {
+    let mut count = 0;
+    for part in value.split('.') {
+        count += 1;
+        if part.is_empty()
+            || (part.len() > 1 && part.starts_with('0'))
+            || !part.bytes().all(|byte| byte.is_ascii_digit())
+            || part.parse::<u8>().is_err()
+        {
+            return false;
+        }
+    }
+    count == 4 && Ipv4Addr::from_str(value).is_ok()
+}
+
+fn is_hostname(value: &str) -> bool {
+    if !value.is_ascii() {
+        return false;
+    }
+    let hostname = value.strip_suffix('.').unwrap_or(value);
+    if hostname.is_empty() || hostname.len() > 253 {
+        return false;
+    }
+    hostname.split('.').all(|label| {
+        (1..=63).contains(&label.len())
+            && label.bytes().all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+            && label
+                .as_bytes()
+                .first()
+                .is_some_and(u8::is_ascii_alphanumeric)
+            && label
+                .as_bytes()
+                .last()
+                .is_some_and(u8::is_ascii_alphanumeric)
+    })
+}
+
+fn is_absolute_uri(value: &str) -> bool {
+    if !value.is_ascii()
+        || value.bytes().filter(|byte| *byte == b'#').count() > 1
+        || value.bytes().any(|byte| {
+            !(byte.is_ascii_alphanumeric()
+                || matches!(
+                    byte,
+                    b'-' | b'.' | b'_' | b'~' | b':' | b'/' | b'?' | b'#' | b'[' | b']'
+                        | b'@' | b'!' | b'$' | b'&' | b'\'' | b'(' | b')' | b'*' | b'+'
+                        | b',' | b';' | b'=' | b'%'
+                ))
+        })
+    {
+        return false;
+    }
+    let bytes = value.as_bytes();
+    for index in 0..bytes.len() {
+        if bytes[index] == b'%'
+            && (index + 2 >= bytes.len()
+                || !bytes[index + 1].is_ascii_hexdigit()
+                || !bytes[index + 2].is_ascii_hexdigit())
+        {
+            return false;
+        }
+    }
+    let Some((scheme, _)) = value.split_once(':') else {
+        return false;
+    };
+    !scheme.is_empty()
+        && scheme.as_bytes()[0].is_ascii_alphabetic()
+        && scheme
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'+' | b'-' | b'.'))
+        && (Url::parse(value).is_ok()
+            || normalized_ipvfuture_uri(value).is_some_and(|uri| Url::parse(&uri).is_ok()))
+}
+
+fn normalized_ipvfuture_uri(value: &str) -> Option<String> {
+    let (_, remainder) = value.split_once(':')?;
+    let authority = remainder.strip_prefix("//")?;
+    let authority_end = authority.find(['/', '?', '#']).unwrap_or(authority.len());
+    let authority = &authority[..authority_end];
+    let host_port = authority.rsplit_once('@').map_or(authority, |(_, host)| host);
+    let literal_start = host_port.find('[')?;
+    let literal_end = host_port[literal_start + 1..].find(']')? + literal_start + 1;
+    let literal = &host_port[literal_start + 1..literal_end];
+    if !is_ipvfuture(literal) {
+        return None;
+    }
+    let absolute_start = value.find(host_port)? + literal_start + 1;
+    let absolute_end = absolute_start + literal.len();
+    Some(format!("{}::1{}", &value[..absolute_start], &value[absolute_end..]))
+}
+
+fn is_ipvfuture(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    if bytes.first().is_none_or(|byte| !matches!(byte, b'v' | b'V')) {
+        return false;
+    }
+    let Some(dot) = value.find('.') else {
+        return false;
+    };
+    dot > 1
+        && dot < value.len() - 1
+        && value[1..dot].bytes().all(|byte| byte.is_ascii_hexdigit())
+        && value[dot + 1..].bytes().all(|byte| {
+            byte.is_ascii_alphanumeric()
+                || matches!(
+                    byte,
+                    b'-' | b'.' | b'_' | b'~' | b'!' | b'$' | b'&' | b'\'' | b'('
+                        | b')' | b'*' | b'+' | b',' | b';' | b'=' | b':'
+                )
+        })
+}
+
+fn is_email(value: &str) -> bool {
+    if !value.is_ascii() || value.len() > 254 {
+        return false;
+    }
+    let separator = if value.starts_with('"') {
+        quoted_local_end(value).filter(|index| value.as_bytes().get(index + 1) == Some(&b'@'))
+            .map(|index| index + 1)
+    } else {
+        let mut separators = value.match_indices('@');
+        let first = separators.next().map(|(index, _)| index);
+        if separators.next().is_some() { None } else { first }
+    };
+    let Some(separator) = separator else {
+        return false;
+    };
+    let local = &value[..separator];
+    let domain = &value[separator + 1..];
+    if local.len() > 64 || local.is_empty() || domain.is_empty() {
+        return false;
+    }
+    let valid_local = if local.starts_with('"') {
+        quoted_local_end(local) == Some(local.len() - 1)
+    } else {
+        local.split('.').all(|atom| {
+            !atom.is_empty()
+                && atom.bytes().all(|byte| {
+                    byte.is_ascii_alphanumeric()
+                        || matches!(
+                            byte,
+                            b'!' | b'#' | b'$' | b'%' | b'&' | b'\'' | b'*' | b'+'
+                                | b'-' | b'/' | b'=' | b'?' | b'^' | b'_' | b'`'
+                                | b'{' | b'|' | b'}' | b'~'
+                        )
+                })
+        })
+    };
+    valid_local && is_email_domain(domain)
+}
+
+fn quoted_local_end(value: &str) -> Option<usize> {
+    let bytes = value.as_bytes();
+    if bytes.first() != Some(&b'"') {
+        return None;
+    }
+    let mut index = 1;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'"' => return Some(index),
+            b'\\' => {
+                index += 1;
+                if index >= bytes.len() || !(32..=126).contains(&bytes[index]) {
+                    return None;
+                }
+            }
+            byte if (32..=33).contains(&byte)
+                || (35..=91).contains(&byte)
+                || (93..=126).contains(&byte) => {}
+            _ => return None,
+        }
+        index += 1;
+    }
+    None
+}
+
+fn is_email_domain(domain: &str) -> bool {
+    if !(domain.starts_with('[') && domain.ends_with(']')) {
+        return !domain.ends_with('.') && is_hostname(domain);
+    }
+    let literal = &domain[1..domain.len() - 1];
+    if is_ipv4(literal) {
+        return true;
+    }
+    if let Some(address) = literal
+        .get(..5)
+        .filter(|prefix| prefix.eq_ignore_ascii_case("IPv6:"))
+        .and_then(|_| literal.get(5..))
+    {
+        return Ipv6Addr::from_str(address).is_ok();
+    }
+    let Some((tag, content)) = literal.split_once(':') else {
+        return false;
+    };
+    !tag.is_empty()
+        && tag.as_bytes()[0].is_ascii_alphabetic()
+        && tag
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+        && !content.is_empty()
+        && content.bytes().all(|byte| {
+            (33..=90).contains(&byte) || (94..=126).contains(&byte)
+        })
+}
+
 fn append_path(path: &str, key: &str) -> String {
     format!("{path}.{}", encode_path_key(key))
 }
@@ -2862,4 +3152,60 @@ fn get_string_array_values(name: &str, table: &Table, key: &str) -> Result<Vec<S
         }
     }
     Ok(result)
+}
+
+#[cfg(test)]
+mod string_format_tests {
+    use super::{is_absolute_uri, is_email, is_hostname, is_ipv4, is_uuid};
+
+    #[test]
+    fn validates_difficult_rfc_5321_mailboxes() {
+        for valid in [
+            "simple@example.com",
+            "customer/department=shipping@example.com",
+            "$A12345@example.com",
+            "!def!xyz%abc@example.com",
+            "_somename@example.com",
+            "\"Fred Bloggs\"@example.com",
+            "\"Joe\\\\Blow\"@example.com",
+            "\"Abc@def\"@[192.0.2.1]",
+            "user@[IPv6:2001:db8::1]",
+            "user@[TAG:printable-data]",
+        ] {
+            assert!(is_email(valid), "expected valid mailbox: {valid}");
+        }
+        for invalid in [
+            "a..b@example.com",
+            ".leading@example.com",
+            "trailing.@example.com",
+            "unquoted space@example.com",
+            "\"unterminated@example.com",
+            "\"bad\ncontrol\"@example.com",
+            "user@example.com.",
+            "user@[IPv6:2001:db8:::1]",
+            "user@[bad literal]",
+            "ü@example.com",
+        ] {
+            assert!(!is_email(invalid), "expected invalid mailbox: {invalid}");
+        }
+        assert!(is_email(&format!("{}@example.com", "a".repeat(64))));
+        assert!(!is_email(&format!("{}@example.com", "a".repeat(65))));
+    }
+
+    #[test]
+    fn validates_other_string_formats() {
+        assert!(is_uuid("01234567-89ab-cdef-ABCD-0123456789ab"));
+        assert!(!is_uuid("0123456789ab-cdef-abcd-0123456789ab"));
+        assert!(is_absolute_uri("https://example.com/a%20b?x=1#part"));
+        assert!(is_absolute_uri("urn:isbn:0451450523"));
+        assert!(is_absolute_uri("scheme:"));
+        assert!(is_absolute_uri("http://[v1.fe]/"));
+        assert!(!is_absolute_uri("/relative/path"));
+        assert!(!is_absolute_uri("https://example.com/%xy"));
+        assert!(!is_absolute_uri("http://example.com/#first#second"));
+        assert!(is_hostname("example.com."));
+        assert!(!is_hostname("bad-.example"));
+        assert!(is_ipv4("0.0.0.0"));
+        assert!(!is_ipv4("127.00.0.1"));
+    }
 }

--- a/reference-implementations/rust/tests/abnf_conformance.rs
+++ b/reference-implementations/rust/tests/abnf_conformance.rs
@@ -80,7 +80,10 @@ fn built_in_type_tokens(abnf: &str) -> BTreeSet<String> {
 #[test]
 fn schema_loader_definition_keys_match_abnf_schema_keys() {
     let abnf = read_abnf();
-    let expected = alternatives_for("schema-key", &abnf);
+    let mut expected = alternatives_for("schema-key", &abnf);
+    // Rust supports the proposed string format extension without changing the
+    // shared grammar until the feature is adopted by the specification.
+    expected.insert("format".to_string());
     let actual: BTreeSet<String> = DEFINITION_KEYS.iter().map(|key| key.to_string()).collect();
     assert_eq!(actual, expected);
 }

--- a/reference-implementations/rust/tests/integration.rs
+++ b/reference-implementations/rust/tests/integration.rs
@@ -3345,6 +3345,95 @@ fn cli_reports_unknown_command() {
     assert!(stderr.contains("Unknown command"));
 }
 
+#[test]
+fn validates_string_formats() {
+    let directory = tempfile_dir("string-formats");
+    let schema_path = write_file(
+        &directory,
+        "schema.tosd",
+        r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.email]
+type = "string"
+format = "email"
+[elements.uuid]
+type = "string"
+format = "uuid"
+[elements.uri]
+type = "string"
+format = "uri"
+[elements.hostname]
+type = "string"
+format = "hostname"
+[elements.ipv4]
+type = "string"
+format = "ipv4"
+[elements.ipv6]
+type = "string"
+format = "ipv6"
+"#,
+    );
+    let schema = Schema::load(schema_path).expect("load format schema");
+    let valid: toml::Table = toml::from_str(
+        r#"
+email = '"quoted@local"@[IPv6:2001:db8::1]'
+uuid = "01234567-89ab-cdef-ABCD-0123456789ab"
+uri = "urn:example:a%20b"
+hostname = "www.example.com."
+ipv4 = "192.0.2.1"
+ipv6 = "::ffff:192.0.2.128"
+"#,
+    )
+    .unwrap();
+    assert!(schema.validate(&valid).valid());
+
+    let invalid: toml::Table = toml::from_str(
+        r#"
+email = "a..b@example.com"
+uuid = "01234567-89ab-cdef-abcd-0123456789ag"
+uri = "relative/%20path"
+hostname = "-bad.example"
+ipv4 = "192.168.001.1"
+ipv6 = "2001:db8:::1"
+"#,
+    )
+    .unwrap();
+    let result = schema.validate(&invalid);
+    for path in ["$.email", "$.uuid", "$.uri", "$.hostname", "$.ipv4", "$.ipv6"] {
+        assert!(has_path(&result, path), "expected format error at {path}");
+    }
+}
+
+#[test]
+fn rejects_unknown_or_incompatible_string_formats() {
+    let directory = tempfile_dir("invalid-string-formats");
+    for (name, definition) in [
+        ("unknown", "type = \"string\"\nformat = \"date\""),
+        ("integer", "type = \"integer\"\nformat = \"uuid\""),
+        ("reference", "type = \"types.text\"\nformat = \"email\""),
+        ("union", "oneof = [\"string\"]\nformat = \"email\""),
+    ] {
+        let schema_path = write_file(
+            &directory,
+            &format!("{name}.tosd"),
+            &format!(
+                "[toml-schema]\nversion = \"1.0.0\"\n[types.text]\ntype = \"string\"\n[elements.value]\n{definition}\n"
+            ),
+        );
+        let error = Schema::load(schema_path).expect_err("format misuse must fail schema loading");
+        assert!(error.contains("format"), "unexpected error: {error}");
+    }
+
+    let allowed_path = write_file(
+        &directory,
+        "allowed.tosd",
+        "[toml-schema]\nversion = \"1.0.0\"\n[elements.value]\ntype = \"string\"\nformat = \"ipv4\"\nallowedvalues = [\"01.2.3.4\"]\n",
+    );
+    Schema::load(allowed_path).expect_err("invalid formatted allowed value must be rejected");
+}
+
 fn tempfile_dir(name: &str) -> PathBuf {
     let directory = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("target")

--- a/reference-implementations/typescript/src/builtins.ts
+++ b/reference-implementations/typescript/src/builtins.ts
@@ -33,6 +33,7 @@ export const DEFINITION_KEYS = [
   "items",
   "allowedvalues",
   "pattern",
+  "format",
   "keypattern",
   "optional",
   "min",

--- a/reference-implementations/typescript/src/definition.ts
+++ b/reference-implementations/typescript/src/definition.ts
@@ -1,4 +1,5 @@
 import type { SchemaType } from "./builtins.js";
+import type { StringFormat } from "./formats.js";
 import type { TomlValue } from "./values.js";
 
 /** A parsed `if` selector: `{ key = "...", equals = ... }` or `{ key = "...", in = [...] }`. */
@@ -27,6 +28,7 @@ export interface RawDefinition {
   allowedValues?: readonly TomlValue[] | undefined;
   pattern?: RegExp | undefined;
   patternSource?: string | undefined;
+  format?: StringFormat | undefined;
   keyPattern?: RegExp | undefined;
   keyPatternSource?: string | undefined;
   min?: TomlValue | undefined;

--- a/reference-implementations/typescript/src/formats.ts
+++ b/reference-implementations/typescript/src/formats.ts
@@ -1,0 +1,186 @@
+import { isIP } from "node:net";
+
+export const STRING_FORMATS = ["email", "uuid", "uri", "hostname", "ipv4", "ipv6"] as const;
+export type StringFormat = (typeof STRING_FORMATS)[number];
+
+const FORMAT_SET: ReadonlySet<string> = new Set(STRING_FORMATS);
+const HEX = /^[0-9A-Fa-f]+$/;
+const UNRESERVED = "A-Za-z0-9._~\\-";
+const SUB_DELIMS = "!$&'()*+,;=";
+
+export function parseStringFormat(value: string): StringFormat | undefined {
+  return FORMAT_SET.has(value) ? (value as StringFormat) : undefined;
+}
+
+export function isValidStringFormat(format: StringFormat, value: string): boolean {
+  switch (format) {
+    case "email":
+      return isEmail(value);
+    case "uuid":
+      return /^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$/.test(value);
+    case "uri":
+      return isAbsoluteUri(value);
+    case "hostname":
+      return isHostname(value);
+    case "ipv4":
+      return isIpv4(value);
+    case "ipv6":
+      return isIpv6(value);
+  }
+}
+
+function isAscii(value: string): boolean {
+  return /^[\x00-\x7f]*$/.test(value);
+}
+
+export function isIpv4(value: string): boolean {
+  const parts = value.split(".");
+  return parts.length === 4 && parts.every((part) =>
+    /^(?:0|[1-9][0-9]{0,2})$/.test(part) && Number(part) <= 255
+  );
+}
+
+export function isIpv6(value: string): boolean {
+  if (!isAscii(value) || value.includes("%") || isIP(value) !== 6) return false;
+  const dotted = value.lastIndexOf(":");
+  return !value.includes(".") || (dotted >= 0 && isIpv4(value.slice(dotted + 1)));
+}
+
+export function isHostname(value: string, allowTrailingDot = true): boolean {
+  if (!isAscii(value) || value.length === 0) return false;
+  const hostname = allowTrailingDot && value.endsWith(".") ? value.slice(0, -1) : value;
+  if (hostname.length === 0 || hostname.length > 253) return false;
+  return hostname.split(".").every((label) =>
+    label.length >= 1 &&
+    label.length <= 63 &&
+    /^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$/.test(label)
+  );
+}
+
+function isEmail(value: string): boolean {
+  if (!isAscii(value) || value.length > 254) return false;
+  let quoted = false;
+  let escaped = false;
+  let separator = -1;
+  for (let index = 0; index < value.length; index++) {
+    const code = value.charCodeAt(index);
+    const character = value[index];
+    if (quoted) {
+      if (escaped) {
+        if (code < 32 || code > 126) return false;
+        escaped = false;
+      } else if (character === "\\") {
+        escaped = true;
+      } else if (character === "\"") {
+        quoted = false;
+      }
+    } else if (character === "\"" && index === 0) {
+      quoted = true;
+    } else if (character === "@") {
+      if (separator !== -1) return false;
+      separator = index;
+    }
+  }
+  if (quoted || escaped || separator <= 0 || separator === value.length - 1) return false;
+  const local = value.slice(0, separator);
+  const domain = value.slice(separator + 1);
+  if (local.length > 64 || !isEmailLocal(local)) return false;
+  return domain.startsWith("[") && domain.endsWith("]")
+    ? isAddressLiteral(domain.slice(1, -1))
+    : isHostname(domain, false);
+}
+
+function isEmailLocal(local: string): boolean {
+  if (local.startsWith("\"")) {
+    if (!local.endsWith("\"") || local.length < 2) return false;
+    for (let index = 1; index < local.length - 1; index++) {
+      const code = local.charCodeAt(index);
+      if (local[index] === "\\") {
+        index++;
+        if (index >= local.length - 1) return false;
+        const escaped = local.charCodeAt(index);
+        if (escaped < 32 || escaped > 126) return false;
+      } else if (code < 32 || code > 126 || code === 34 || code === 92) {
+        return false;
+      }
+    }
+    return true;
+  }
+  const atom = /^[A-Za-z0-9!#$%&'*+\-/=?^_`{|}~]+$/;
+  return local.split(".").every((part) => atom.test(part));
+}
+
+function isAddressLiteral(literal: string): boolean {
+  if (isIpv4(literal)) return true;
+  if (literal.startsWith("IPv6:")) return isIpv6(literal.slice(5));
+  const colon = literal.indexOf(":");
+  if (colon <= 0) return false;
+  const tag = literal.slice(0, colon);
+  const content = literal.slice(colon + 1);
+  return /^[A-Za-z0-9-]*[A-Za-z0-9]$/.test(tag) &&
+    content.length > 0 &&
+    /^[\x21-\x5a\x5e-\x7e]+$/.test(content);
+}
+
+function validPercentEncoding(value: string): boolean {
+  for (let index = value.indexOf("%"); index >= 0; index = value.indexOf("%", index + 3)) {
+    if (index + 2 >= value.length || !HEX.test(value.slice(index + 1, index + 3))) return false;
+  }
+  return true;
+}
+
+function matchesComponent(value: string, extra: string): boolean {
+  if (!validPercentEncoding(value)) return false;
+  const withoutEscapes = value.replace(/%[0-9A-Fa-f]{2}/g, "");
+  return new RegExp(`^[${UNRESERVED}${escapeClass(SUB_DELIMS + extra)}]*$`).test(withoutEscapes);
+}
+
+function escapeClass(value: string): string {
+  return value.replace(/[\\\]\-^]/g, "\\$&");
+}
+
+function isAbsoluteUri(value: string): boolean {
+  if (!isAscii(value) || /[\x00-\x20\x7f]/.test(value)) return false;
+  const scheme = /^([A-Za-z][A-Za-z0-9+.-]*):(.*)$/.exec(value);
+  if (!scheme) return false;
+  let remainder = scheme[2] as string;
+  const hash = remainder.indexOf("#");
+  const fragment = hash < 0 ? undefined : remainder.slice(hash + 1);
+  if (fragment !== undefined) remainder = remainder.slice(0, hash);
+  if (fragment?.includes("#") || (fragment !== undefined && !matchesComponent(fragment, ":@/?"))) return false;
+  const question = remainder.indexOf("?");
+  const query = question < 0 ? undefined : remainder.slice(question + 1);
+  if (query !== undefined) remainder = remainder.slice(0, question);
+  if (query !== undefined && !matchesComponent(query, ":@/?")) return false;
+
+  if (remainder.startsWith("//")) {
+    const slash = remainder.indexOf("/", 2);
+    const authority = slash < 0 ? remainder.slice(2) : remainder.slice(2, slash);
+    const path = slash < 0 ? "" : remainder.slice(slash);
+    return isAuthority(authority) && matchesComponent(path, ":@/");
+  }
+  if (remainder.startsWith("//") || !matchesComponent(remainder, ":@/")) return false;
+  if (remainder !== "" && !remainder.startsWith("/") && !matchesComponent(remainder[0] as string, ":@")) {
+    return false;
+  }
+  return true;
+}
+
+function isAuthority(authority: string): boolean {
+  const at = authority.lastIndexOf("@");
+  const hostPort = at < 0 ? authority : authority.slice(at + 1);
+  if (at >= 0 && !matchesComponent(authority.slice(0, at), ":")) return false;
+  if (hostPort.startsWith("[")) {
+    const close = hostPort.indexOf("]");
+    if (close < 0 || !/^(?::[0-9]*)?$/.test(hostPort.slice(close + 1))) return false;
+    const literal = hostPort.slice(1, close);
+    return isIpv6(literal) ||
+      /^[vV][0-9A-Fa-f]+\.[A-Za-z0-9._~!$&'()*+,;=:-]+$/.test(literal);
+  }
+  const colon = hostPort.lastIndexOf(":");
+  if (colon >= 0 && (hostPort.indexOf(":") !== colon || !/^[0-9]*$/.test(hostPort.slice(colon + 1)))) {
+    return false;
+  }
+  const host = colon < 0 ? hostPort : hostPort.slice(0, colon);
+  return matchesComponent(host, "");
+}

--- a/reference-implementations/typescript/src/schemaParser.ts
+++ b/reference-implementations/typescript/src/schemaParser.ts
@@ -10,6 +10,7 @@ import {
 } from "./builtins.js";
 import { emptyRecord, type Condition, type RawDefinition } from "./definition.js";
 import { SchemaError } from "./errors.js";
+import { isValidStringFormat, parseStringFormat, type StringFormat } from "./formats.js";
 import { SchemaSource } from "./tomlSource.js";
 import {
   compareValues,
@@ -203,6 +204,7 @@ function validateAllowedValuesConstraints(
   typeName: SchemaType | undefined,
   allowedValues: readonly TomlValue[],
   pattern: RegExp | undefined,
+  format: StringFormat | undefined,
   min: TomlValue | undefined,
   max: TomlValue | undefined,
   minLength: number | undefined,
@@ -214,6 +216,11 @@ function validateAllowedValuesConstraints(
     if (pattern !== undefined) {
       if (typeof allowed !== "string" || !pattern.test(allowed)) {
         throw new SchemaError(`${entry} does not satisfy pattern`);
+      }
+    }
+    if (format !== undefined) {
+      if (typeof allowed !== "string" || !isValidStringFormat(format, allowed)) {
+        throw new SchemaError(`${entry} does not satisfy format ${format}`);
       }
     }
     if ((min !== undefined || max !== undefined) && isNaNValue(allowed)) {
@@ -476,6 +483,14 @@ export function parseDefinition(
   }
   const optional = getBoolProp(table, "optional", name);
   const patternResult = getPatternProp(table, "pattern", name);
+  const formatValue = propertyValue(table, "format");
+  if (formatValue !== undefined && typeof formatValue !== "string") {
+    throw new SchemaError(`expected format to be a string (${name})`);
+  }
+  const format = typeof formatValue === "string" ? parseStringFormat(formatValue) : undefined;
+  if (typeof formatValue === "string" && format === undefined) {
+    throw new SchemaError(`${name} has unknown string format: ${formatValue}`);
+  }
   const keyPatternResult = getPatternProp(table, "keypattern", name);
   const minLength = getIntegerProp(table, "minlength", name);
   const maxLength = getIntegerProp(table, "maxlength", name);
@@ -602,6 +617,9 @@ export function parseDefinition(
   if (patternResult !== undefined && typeName !== "string") {
     throw new SchemaError(`${name} can only define pattern when type is string`);
   }
+  if (format !== undefined && typeName !== "string") {
+    throw new SchemaError(`${name} can only define format when type is string`);
+  }
   if (hasAllowedValues && (typeName === "table" || typeName === "collection")) {
     throw new SchemaError(`${name} can only define allowedvalues for scalar, unconstrained, or array types`);
   }
@@ -624,6 +642,7 @@ export function parseDefinition(
     typeName,
     allowedValues,
     patternResult?.regex,
+    format,
     min,
     max,
     minLength,
@@ -649,6 +668,7 @@ export function parseDefinition(
     ...(patternResult !== undefined
       ? { pattern: patternResult.regex, patternSource: patternResult.source }
       : {}),
+    ...(format !== undefined ? { format } : {}),
     ...(keyPatternResult !== undefined
       ? { keyPattern: keyPatternResult.regex, keyPatternSource: keyPatternResult.source }
       : {}),

--- a/reference-implementations/typescript/src/validator.ts
+++ b/reference-implementations/typescript/src/validator.ts
@@ -7,6 +7,7 @@ import {
   type RawDefinition,
 } from "./definition.js";
 import { SchemaError } from "./errors.js";
+import { isValidStringFormat } from "./formats.js";
 import { appendPath } from "./paths.js";
 import {
   effectiveFixedChildren,
@@ -703,6 +704,9 @@ export class DocumentValidator {
       this.validateLength(path, scalarLength(value), definition);
       if (definition.pattern && !definition.pattern.test(value)) {
         this.add(path, `does not match pattern ${definition.patternSource}`);
+      }
+      if (definition.format && !isValidStringFormat(definition.format, value)) {
+        this.add(path, `is not a valid ${definition.format}`);
       }
     }
   }

--- a/reference-implementations/typescript/test/formats.test.ts
+++ b/reference-implementations/typescript/test/formats.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { SchemaError, loadSchemaFromSource } from "../src/index.js";
+
+function schemaFor(format: string, extra = "") {
+  return loadSchemaFromSource(
+    `${format}.tosd`,
+    `[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "string"
+format = "${format}"
+${extra}`,
+  );
+}
+
+const cases: Readonly<Record<string, { valid: string[]; invalid: string[] }>> = {
+  email: {
+    valid: [
+      "simple@example.com",
+      "first.last+tag@sub.example.com",
+      "\"quoted local\"@example.com",
+      "\"a@b\"@example.com",
+      "\"escaped\\\\\\\"quote\"@example.com",
+      "user@[192.0.2.1]",
+      "user@[IPv6:2001:db8::1]",
+      "user@[TAG:value]",
+    ],
+    invalid: [
+      ".leading@example.com",
+      "trailing.@example.com",
+      "two..dots@example.com",
+      "unquoted space@example.com",
+      "\"unterminated@example.com",
+      "user@-example.com",
+      "user@example..com",
+      "user@example.com.",
+      "user@[IPv6:2001:::1]",
+      "ü@example.com",
+      `${"a".repeat(65)}@example.com`,
+      `${"a".repeat(64)}@${"b".repeat(63)}.${"c".repeat(63)}.${"d".repeat(60)}.com`,
+    ],
+  },
+  uuid: {
+    valid: ["550e8400-e29b-41d4-a716-446655440000", "00000000-0000-0000-0000-000000000000"],
+    invalid: ["{550e8400-e29b-41d4-a716-446655440000}", "550e8400e29b41d4a716446655440000", "not-a-uuid"],
+  },
+  uri: {
+    valid: [
+      "https://example.com/a%20b?q=x#fragment",
+      "mailto:user@example.com",
+      "urn:isbn:0451450523",
+      "file:///etc/hosts",
+      "http://[2001:db8::1]/",
+      "http://[v1.fe]/",
+      "scheme:",
+    ],
+    invalid: [
+      "example.com/path",
+      "https://example.com/%zz",
+      "https://example.com/a b",
+      "1http://example.com",
+      "http://[2001:::1]/",
+      "http://example.com/#first#second",
+    ],
+  },
+  hostname: {
+    valid: ["example.com", "EXAMPLE.com.", "123.example", "a"],
+    invalid: ["-example.com", "example-.com", "example..com", "éxample.com", `${"a".repeat(64)}.com`],
+  },
+  ipv4: {
+    valid: ["0.0.0.0", "192.0.2.1", "255.255.255.255"],
+    invalid: ["192.168.001.1", "256.0.0.1", "1.2.3", "1.2.3.4.5", "1.2.3.-1"],
+  },
+  ipv6: {
+    valid: ["::", "::1", "2001:db8::1", "2001:db8:0:0:0:0:192.0.2.1", "::ffff:192.0.2.128"],
+    invalid: ["2001:::1", "2001:db8", "::ffff:192.168.001.1", "fe80::1%eth0", "192.0.2.1"],
+  },
+};
+
+for (const [format, values] of Object.entries(cases)) {
+  test(`validates ${format} format`, () => {
+    const schema = schemaFor(format);
+    for (const value of values.valid) {
+      const result = schema.validate({ value });
+      assert.equal(result.valid, true, `${value}: ${JSON.stringify(result.errors)}`);
+    }
+    for (const value of values.invalid) {
+      const result = schema.validate({ value });
+      assert.equal(result.valid, false, `${value} should be rejected`);
+      assert.match(result.errors[0]?.message ?? "", new RegExp(`valid ${format}`));
+    }
+  });
+}
+
+test("rejects unknown, non-string, incompatible, and inherited format declarations", () => {
+  for (const declaration of [
+    'type = "string"\nformat = "date"',
+    'type = "integer"\nformat = "uuid"',
+    'type = "string"\nformat = true',
+    'type = "types.formatted"\nformat = "email"',
+  ]) {
+    assert.throws(
+      () => loadSchemaFromSource("invalid-format.tosd", `[toml-schema]
+version = "1.0.0"
+
+[types.formatted]
+type = "string"
+
+[elements.value]
+${declaration}
+`),
+      SchemaError,
+    );
+  }
+});
+
+test("rejects allowedvalues that violate their declared format at schema load", () => {
+  assert.throws(
+    () => schemaFor("email", 'allowedvalues = [ "not-an-email" ]'),
+    /allowedvalues\[0\] does not satisfy format email/,
+  );
+});

--- a/toml-schema.abnf
+++ b/toml-schema.abnf
@@ -36,7 +36,7 @@ schema-definition = schema-definition-table *definition-property *schema-definit
 
 ; Canonical definition-key inventory, also consumed by implementation
 ; conformance guards.
-schema-key = type / description / itemtype / items / oneof / anyof / if / then / else / allof
+schema-key = type / description / format / itemtype / items / oneof / anyof / if / then / else / allof
            / allowedvalues / pattern / keypattern / optional / min / max
            / minlength / maxlength / uniqueitems / dependentrequired
            / mutuallyexclusive / exactlyone / default / deprecated
@@ -46,6 +46,7 @@ definition-property = schema-key
 version       = "version" keyval-sep semver-string
 type          = "type" keyval-sep type-reference
 description   = "description" keyval-sep toml-string
+format        = "format" keyval-sep string-format
 itemtype      = "itemtype" keyval-sep type-reference
 items         = "items" keyval-sep type-reference-array ; ordered, semantically non-empty type references for positional array validation
 oneof         = "oneof" keyval-sep type-reference-array
@@ -68,6 +69,15 @@ mutuallyexclusive = "mutuallyexclusive" keyval-sep sibling-group-array ; each gr
 exactlyone        = "exactlyone" keyval-sep sibling-group-array ; each group requires exactly one present child
 default       = "default" keyval-sep toml-value
 deprecated    = "deprecated" keyval-sep toml-boolean
+
+string-format = email-format / uuid-format / uri-format / hostname-format
+              / ipv4-format / ipv6-format
+email-format    = DQUOTE %x65.6d.61.69.6c DQUOTE
+uuid-format     = DQUOTE %x75.75.69.64 DQUOTE
+uri-format      = DQUOTE %x75.72.69 DQUOTE
+hostname-format = DQUOTE %x68.6f.73.74.6e.61.6d.65 DQUOTE
+ipv4-format     = DQUOTE %x69.70.76.34 DQUOTE
+ipv6-format     = DQUOTE %x69.70.76.36 DQUOTE
 
 built-in-type = anytype / stringtype / integertype / floattype / booleantype
               / offsetdatetimetype / localdatetimetype / localdatetype / localtimetype


### PR DESCRIPTION
Configuration schemas currently need hand-written patterns for common semantic string values, which are easy to make incomplete or inconsistent. This adds a portable `format` assertion for `email`, `uuid`, `uri`, `hostname`, `ipv4`, and `ipv6` while keeping TOML's native value model unchanged.

## Approach

- Define the six case-sensitive formats in the specification and ABNF, including schema-load applicability and interaction with `allowedvalues` and defaults.
- Implement identical loader and validator behavior across Java, Go, .NET, Python, Rust, and TypeScript.
- Use RFC-backed parsing rather than heuristic checks. Email supports RFC 5321 dot-string and quoted local parts, address literals, and octet limits; URI validation covers absolute RFC 3986 syntax, including IPvFuture, while excluding zone identifiers.
- Reject unknown formats and `format` on anything other than a locally selected built-in string.
- Exercise the feature in the checked-in configuration example and add conformance coverage for valid values, malformed values, and portability edge cases.

## Validation

All Go, .NET, Python, Rust, and TypeScript suites pass. Java's format and checked-in example tests pass; its full suite still has the unrelated pre-existing missing website hero fixture failure.