### PR TITLE
Apply string formats to industry schemas

### DIFF
--- a/examples/cargo.tosd
+++ b/examples/cargo.tosd
@@ -16,6 +16,16 @@ type = "table"
 [types.stringOrWorkspace]
 oneof = [ "string", "types.workspaceInherited" ]
 
+[types.uri]
+type = "string"
+format = "uri"
+
+[types.documentationOrWorkspace]
+oneof = [ "types.uri", "types.workspaceInherited" ]
+
+[types.homepageOrWorkspace]
+oneof = [ "types.uri", "types.workspaceInherited" ]
+
 [types.stringArrayOrWorkspace]
 oneof = [ "types.stringArray", "types.workspaceInherited" ]
 
@@ -52,7 +62,7 @@ type = "table"
     optional = true
 
     [types.packageBase.documentation]
-    type = "types.stringOrWorkspace"
+    type = "types.documentationOrWorkspace"
     optional = true
 
     [types.packageBase.readme]
@@ -60,7 +70,7 @@ type = "table"
     optional = true
 
     [types.packageBase.homepage]
-    type = "types.stringOrWorkspace"
+    type = "types.homepageOrWorkspace"
     optional = true
 
     [types.packageBase.repository]

--- a/examples/gitlab-runner.tosd
+++ b/examples/gitlab-runner.tosd
@@ -1079,6 +1079,7 @@ itemtype = "any"
 
     [types.runner.url]
     type = "string"
+    format = "uri"
     optional = true
 
     [types.runner.token]
@@ -1154,6 +1155,7 @@ itemtype = "any"
 
     [types.runner.clone_url]
     type = "string"
+    format = "uri"
     optional = true
 
     [types.runner.debug_trace_disabled]

--- a/examples/hugo.tosd
+++ b/examples/hugo.tosd
@@ -10,6 +10,10 @@ itemtype = "string"
 [types.numberValue]
 oneof = [ "integer", "float" ]
 
+[types.uri]
+type = "string"
+format = "uri"
+
 [types.stringOrStringArray]
 oneof = [ "string", "types.stringArray" ]
 
@@ -1004,7 +1008,7 @@ type = "collection"
 itemtype = "any"
 
     [types.language.baseURL]
-    type = "string"
+    type = "types.uri"
     optional = true
 
     [types.language.contentDir]
@@ -1079,7 +1083,7 @@ type = "string"
 optional = true
 
 [elements.baseURL]
-type = "string"
+type = "types.uri"
 optional = true
 
 [elements.build]

--- a/examples/pyproject.tosd
+++ b/examples/pyproject.tosd
@@ -17,6 +17,18 @@ itemtype = "string"
 type = "collection"
 itemtype = "string"
 
+[types.email]
+type = "string"
+format = "email"
+
+[types.uri]
+type = "string"
+format = "uri"
+
+[types.uriMap]
+type = "collection"
+itemtype = "types.uri"
+
 [types.openTable]
 type = "table"
 
@@ -76,7 +88,7 @@ type = "table"
     optional = true
 
     [types.person.email]
-    type = "string"
+    type = "types.email"
     optional = true
 
 [types.people]
@@ -175,7 +187,7 @@ type = "table"
     optional = true
 
     [types.project.urls]
-    type = "types.stringMap"
+    type = "types.uriMap"
     optional = true
 
     [types.project.scripts]

--- a/examples/wrangler.tosd
+++ b/examples/wrangler.tosd
@@ -18,6 +18,25 @@ itemtype = "types.numberValue"
 type = "collection"
 itemtype = "string"
 
+[types.email]
+type = "string"
+format = "email"
+
+[types.emailArray]
+type = "array"
+itemtype = "types.email"
+
+[types.ipv4]
+type = "string"
+format = "ipv4"
+
+[types.ipv6]
+type = "string"
+format = "ipv6"
+
+[types.ipAddress]
+oneof = [ "types.ipv4", "types.ipv6" ]
+
 [types.anyMap]
 type = "collection"
 itemtype = "any"
@@ -252,7 +271,7 @@ type = "table"
     optional = true
 
     [types.dev.ip]
-    type = "string"
+    type = "types.ipAddress"
     optional = true
 
     [types.dev.local_protocol]
@@ -518,12 +537,11 @@ type = "table"
     type = "string"
 
     [types.emailBinding.allowed_destination_addresses]
-    type = "array"
-    itemtype = "string"
+    type = "types.emailArray"
     optional = true
 
     [types.emailBinding.destination_address]
-    type = "string"
+    type = "types.email"
     optional = true
 
 [types.queueProducer]


### PR DESCRIPTION
## Summary

- validate PyProject person emails and absolute project URLs with reusable formatted types
- validate Wrangler email destinations and require `dev.ip` to be either IPv4 or IPv6
- validate Hugo root and per-language `baseURL` values as absolute URIs
- validate GitLab Runner instance and clone URLs as URIs
- validate Cargo `documentation` and `homepage` URLs while preserving workspace inheritance

## Scope decisions

Hugo documents `baseURL` as the absolute published-site URL, so only root and language-specific `baseURL` fields are constrained; menu URLs and URL-pattern fields remain unrestricted.

Cargo documents `documentation` and `homepage` as URLs, so they use purpose-specific URI-or-workspace unions. `repository` remains unchanged because Cargo manifests in practice accept Git SCP-like values such as `git@github.com:owner/repo.git`, which RFC 3986 `uri` validation would reject.

GitLab Runner `listen_address`, host, socket, and host:port fields remain unrestricted.

## Validation

- Java targeted checked-in example, Cargo manifest, and self-schema tests
- Go targeted checked-in example and Cargo manifest tests
- Rust targeted checked-in example and Cargo manifest tests
- .NET targeted checked-in example and Cargo manifest tests