### PR TITLE
Restore self-verifying TOML Schema definitions

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -255,13 +255,27 @@ enabled = true
 
 Use `[elements]` for document-specific keys. Use `[types]` for reusable definitions that can be referenced from `[elements]` or from other reusable types. Elements follow the same structure and validation rules as types, except that elements cannot reference other elements. To reuse conditions and structures, define them under `[types]` and reference them from `[elements]`.
 
-The companion [`toml-schema.tosd`](toml-schema.tosd) validates this top-level
-structure. It intentionally leaves individual schema-definition tables open:
-schema property names such as `type` and `itemtype` may also be target child
-keys, and TOML cannot represent both a key-value property and a child table with
-the same path in one self-schema definition. Schema loaders therefore enforce
-the vocabulary, property types, and conditional applicability rules specified
-below.
+The companion [`toml-schema.tosd`](toml-schema.tosd) recursively validates
+schema-definition tables, including the schema document itself. It models
+schema properties as fixed children and ordinary target child definitions as
+dynamic collection entries. The `children` namespace described below resolves
+the remaining TOML key collision when one definition needs both a schema
+property and a target child with the same name.
+
+The self-schema validates property value shapes, selector exclusivity,
+conditional completeness, tuple-versus-homogeneous array structure, nested
+child applicability, string formats, sibling-rule structures, annotations, and
+the selective `children` namespace. Rules that require resolving the schema's
+reference graph remain schema-load semantics: reference existence and cycles,
+effective `allof` compatibility, conditional branch kinds, collection
+`itemtype` inherited through composition, defaults against effective types,
+allowed values against resolved constraints, and sibling-rule operands against
+the effective fixed-child set. Schema loading also preserves source-form
+information that the parsed TOML value model erases, so inline-table properties
+such as `default` and `dependentrequired` can be distinguished from direct child
+tables with those names and the latter can be validated recursively. A
+conforming implementation MUST apply both the self-schema validation and these
+reference-aware and source-aware schema-load checks.
 
 ## Types table - `[types]`
 
@@ -400,47 +414,58 @@ Schema child definitions use TOML tables. When a target TOML key is empty or con
 Target keys may have the same names as TOML Schema properties, such as `type`,
 `itemtype`, `optional`, or `pattern`. A key/value pair directly inside a schema
 definition is a schema property, while a table-header path segment below that
-definition is a target child definition.
+definition is normally a target child definition.
 
 A schema definition with nested child definitions and no explicit selector is
 treated as `type = "table"`. This lets schemas describe target keys that would
-otherwise collide with schema properties.
+otherwise share a name with schema properties when the parent does not also use
+the property.
 
 TOML itself forbids one table from containing both a value and a subtable with
-the same key. Therefore, a definition cannot simultaneously use a schema
-property and define a target child with that property's name. For example, an
-implicit table can define `[elements.plugin.type]`, but the parent cannot also
-declare a `type = ...` property. Likewise, a definition cannot have both a
-`default = ...` annotation and a child table named `default`. Authors can
-sometimes avoid a collision by factoring structure through a reusable type or
-by choosing the implicit-table form. If the colliding schema property is still
-required on the same definition, TOML Schema 1.0 cannot express both meanings
-there. Quoting the child key does not remove this TOML data model restriction.
+the same key. When a definition must simultaneously use a schema property and
+define a target child with that property's name, place the child definition
+under the reserved `children` table. The segment immediately following
+`children` is the target key; `children` is not part of the target document
+path.
+
+The `children` table is a selective escape hatch, not a general alternative
+child syntax. Every direct entry below it MUST be named either `children` or one
+of the schema properties listed under [Supported Properties](#supported-properties).
+Schema loaders MUST reject non-conflicting names there. Ordinary, quoted,
+dotted, and empty child keys continue to use direct TOML table paths.
+
+A table named `children` that declares `type`, `oneof`, `anyof`, or the
+`if`/`then`/`else` selector is an ordinary target child definition rather than
+the escape namespace. This preserves the direct form for a target child
+literally named `children`. A selectorless table child with that name is written
+through the escape namespace as `[elements.parent.children.children]`.
 
 Example TOML document:
 
 ```toml
-"" = "blank"
-
-[site]
-"google.com" = true
-
 [plugin]
 type = "npm"
+name = "example"
 ```
 
 Schema:
 
 ```toml
-[elements.""]
+[elements.plugin]
+type = "table"
+
+[elements.plugin.children.type]
 type = "string"
+allowedvalues = [ "npm", "local" ]
 
-[elements.site."google.com"]
-type = "boolean"
-
-[elements.plugin.type]
+[elements.plugin.name]
 type = "string"
 ```
+
+Here `elements.plugin.type = "table"` selects the parent type, while
+`[elements.plugin.children.type]` describes the target key `plugin.type`.
+Without the `children` segment, TOML would require `type` to be both a string
+and a table at the same path.
 
 ### Scalar and Unconstrained Built-in Types
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -440,6 +440,47 @@ the escape namespace. This preserves the direct form for a target child
 literally named `children`. A selectorless table child with that name is written
 through the escape namespace as `[elements.parent.children.children]`.
 
+For example, this schema defines a scalar target key named `children` directly:
+
+```toml
+[elements.parent]
+type = "table"
+
+[elements.parent.children]
+type = "string"
+```
+
+It validates:
+
+```toml
+[parent]
+children = "value"
+```
+
+The `type` selector makes `[elements.parent.children]` an ordinary child
+definition. To define a selectorless target table named `children`, repeat the
+name through the escape namespace:
+
+```toml
+[elements.parent]
+type = "table"
+
+[elements.parent.children.children]
+
+[elements.parent.children.children.name]
+type = "string"
+```
+
+It validates:
+
+```toml
+[parent.children]
+name = "value"
+```
+
+The first `children` segment is the escape namespace. The second is the literal
+target key, and the selectorless definition is inferred as `type = "table"`.
+
 Example TOML document:
 
 ```toml

--- a/reference-implementations/dotnet/TomlSchema.Tests/TomlSchemaTests.cs
+++ b/reference-implementations/dotnet/TomlSchema.Tests/TomlSchemaTests.cs
@@ -10,7 +10,7 @@ public class TomlSchemaTests : TestBase
         var schema = TomlSchema.Load(Fixture("config.tosd"));
         var result = schema.Validate(Fixture("config.toml"));
 
-        Assert.True(result.IsValid, $"Validation failed: {string.Join(", ", result.Errors.Select(e => e.Message))}");
+        Assert.True(result.IsValid, $"Validation failed: {string.Join(", ", result.Errors.Select(e => $"{e.Path}: {e.Message}"))}");
     }
 
     [Fact]
@@ -19,7 +19,7 @@ public class TomlSchemaTests : TestBase
         var selfSchema = TomlSchema.Load(Fixture("toml-schema.tosd"));
         var result = selfSchema.Validate(Fixture("config.tosd"));
 
-        Assert.True(result.IsValid, $"Validation failed: {string.Join(", ", result.Errors.Select(e => e.Message))}");
+        Assert.True(result.IsValid, $"Validation failed: {string.Join(", ", result.Errors.Select(e => $"{e.Path}: {e.Message}"))}");
     }
 
     [Fact]
@@ -115,6 +115,73 @@ public class TomlSchemaTests : TestBase
         // Invalid schema should fail on load
         var ex = Assert.ThrowsAny<Exception>(() => TomlSchema.Load(invalidSchema));
         Assert.NotNull(ex);
+    }
+
+    [Fact]
+    public void SupportsSelectiveChildrenEscapeAndLiteralChildren()
+    {
+        var schemaPath = Write("children-escape.tosd", """
+            [toml-schema]
+            version = "1.0.0"
+
+            [elements.plugin]
+            type = "table"
+
+            [elements.plugin.children.type]
+            type = "string"
+
+            [elements.plugin.children.children]
+            type = "boolean"
+            """);
+        var documentPath = Write("children-escape.toml", """
+            [plugin]
+            type = "npm"
+            children = true
+            """);
+
+        var schema = TomlSchema.Load(schemaPath);
+        var result = schema.Validate(documentPath);
+
+        Assert.True(result.IsValid, $"Validation failed: {string.Join(", ", result.Errors.Select(e => e.Message))}");
+
+        var literalSchemaPath = Write("literal-children.tosd", """
+            [toml-schema]
+            version = "1.0.0"
+
+            [elements.plugin]
+            type = "table"
+
+            [elements.plugin.children]
+            type = "string"
+            """);
+        var literalDocumentPath = Write("literal-children.toml", """
+            [plugin]
+            children = "ordinary child"
+            """);
+
+        var literalSchema = TomlSchema.Load(literalSchemaPath);
+        var literalResult = literalSchema.Validate(literalDocumentPath);
+
+        Assert.True(literalResult.IsValid,
+            $"Validation failed: {string.Join(", ", literalResult.Errors.Select(e => e.Message))}");
+    }
+
+    [Theory]
+    [InlineData("[elements.plugin.children]")]
+    [InlineData("[elements.plugin.children.name]\ntype = \"string\"")]
+    public void RejectsInvalidChildrenEscapeNamespaces(string body)
+    {
+        var schemaPath = Write($"invalid-children-{Guid.NewGuid():N}.tosd", $$"""
+            [toml-schema]
+            version = "1.0.0"
+
+            [elements.plugin]
+            type = "table"
+
+            {{body}}
+            """);
+
+        Assert.ThrowsAny<Exception>(() => TomlSchema.Load(schemaPath));
     }
 
     [Fact]

--- a/reference-implementations/dotnet/TomlSchema/SchemaLoader.cs
+++ b/reference-implementations/dotnet/TomlSchema/SchemaLoader.cs
@@ -145,9 +145,11 @@ public class SchemaLoader
             }
         }
 
-        var hasOneOf = table.ContainsKey("oneof");
-        var hasAnyOf = table.ContainsKey("anyof");
-        var hasConditional = table.ContainsKey("if");
+        var hasOneOf = table.TryGetValue("oneof", out var oneOfSelector) && oneOfSelector is not TomlTable;
+        var hasAnyOf = table.TryGetValue("anyof", out var anyOfSelector) && anyOfSelector is not TomlTable;
+        var hasConditional = table.TryGetValue("if", out var conditionalSelector)
+            && conditionalSelector is TomlTable conditionalTable
+            && IsConditionalProperty(conditionalTable);
 
         var format = GetString(table, "format");
         if (format != null)
@@ -181,13 +183,43 @@ public class SchemaLoader
         }
 
         var children = new Dictionary<string, SchemaDefinition>();
+        var hasEscapeNamespace = table.TryGetValue("children", out var escapedValue)
+            && escapedValue is TomlTable escapedChildren
+            && !HasSelectorMarker(escapedChildren);
+        if (hasEscapeNamespace)
+        {
+            var escapeTable = (TomlTable)escapedValue!;
+            if (escapeTable.Count == 0)
+                throw new InvalidOperationException($"{location} children escape namespace must not be empty");
+
+            foreach (var (key, value) in escapeTable)
+            {
+                if (!DefinitionKeys.Contains(key) && key != "children")
+                    throw new InvalidOperationException(
+                        $"{location} children escape namespace contains non-conflicting child: {key}");
+                if (value is not TomlTable childTable)
+                    throw new InvalidOperationException(
+                        $"{location}.children.{key} must be a child definition table");
+
+                children[key] = ParseDefinition($"{location}.{key}", childTable);
+            }
+        }
+
         foreach (var (key, value) in table)
         {
-            if (DefinitionKeys.Contains(key))
+            if (key == "children" && hasEscapeNamespace)
+                continue;
+            if (DefinitionKeys.Contains(key)
+                && (value is not TomlTable definitionTable
+                    || IsTableValuedProperty(key, definitionTable)))
                 continue;
 
             if (value is TomlTable childTable)
+            {
+                if (children.ContainsKey(key))
+                    throw new InvalidOperationException($"{location} defines child {key} more than once");
                 children[key] = ParseDefinition($"{location}.{key}", childTable);
+            }
         }
 
         var oneOf = table.TryGetValue("oneof", out var oneOfValue) && oneOfValue is TomlArray oneOfArray
@@ -272,7 +304,9 @@ public class SchemaLoader
 
     private SchemaCondition? ParseCondition(string location, TomlTable table)
     {
-        if (!table.TryGetValue("if", out var ifValue) || ifValue is not TomlTable ifTable)
+        if (!table.TryGetValue("if", out var ifValue)
+            || ifValue is not TomlTable ifTable
+            || !IsConditionalProperty(ifTable))
             return null;
 
         var key = GetString(ifTable, "key");
@@ -306,6 +340,25 @@ public class SchemaLoader
     {
         return table.TryGetValue(key, out var value) && value is TomlTable;
     }
+
+    private static bool HasSelectorMarker(TomlTable table) =>
+        table.TryGetValue("type", out var type) && type is not TomlTable
+        || table.TryGetValue("oneof", out var oneOf) && oneOf is not TomlTable
+        || table.TryGetValue("anyof", out var anyOf) && anyOf is not TomlTable
+        || table.TryGetValue("if", out var condition) && condition is TomlTable conditionTable
+            && IsConditionalProperty(conditionTable);
+
+    private static bool IsConditionalProperty(TomlTable table) =>
+        table.ContainsKey("key")
+        && (table.ContainsKey("equals") || table.ContainsKey("in"));
+
+    private static bool IsTableValuedProperty(string key, TomlTable table) =>
+        key switch
+        {
+            "if" => IsConditionalProperty(table),
+            "default" or "dependentrequired" => !HasSelectorMarker(table),
+            _ => false
+        };
 
     private static List<List<string>> ParseNameGroups(TomlArray values) =>
         values.All(value => value is string)

--- a/reference-implementations/dotnet/TomlSchema/SchemaValidator.cs
+++ b/reference-implementations/dotnet/TomlSchema/SchemaValidator.cs
@@ -326,15 +326,27 @@ internal class SchemaValidator
 
     private void ValidateCollection(TomlTable table, SchemaDefinition schema, string path)
     {
-        // Collections allow any string keys matching keypattern
         var keyPattern = schema.KeyPattern;
         var valueSchema = !string.IsNullOrEmpty(schema.ItemType)
             ? ResolveItemType(schema.ItemType)
                 ?? throw new InvalidOperationException($"Undefined item type: {schema.ItemType}")
             : null;
 
+        foreach (var (key, childSchema) in schema.Children)
+        {
+            if (table.TryGetValue(key, out var childValue))
+                ValidateElement(key, childValue, childSchema, path);
+            else if (!childSchema.Optional)
+                _errors.Add(new ValidationError(AppendPath(path, key), "required value is missing", "required"));
+        }
+
+        ValidatePresenceRules(table, schema, path);
+
         foreach (var (key, value) in table)
         {
+            if (schema.Children.ContainsKey(key))
+                continue;
+
             var keyPath = AppendPath(path, key);
 
             // Validate key pattern

--- a/reference-implementations/go/schema.go
+++ b/reference-implementations/go/schema.go
@@ -937,7 +937,35 @@ func parseDefinition(name string, path []string, table map[string]any, source *s
 		return Definition{}, fmt.Errorf("%s cannot define more than one of type, oneof, anyof, and if", name)
 	}
 	children := map[string]Definition{}
+	escapedChildren, childrenIsTable := asMap(table["children"])
+	escapedPath := appendSourcePath(path, "children")
+	hasEscapedChildren := childrenIsTable &&
+		!source.isProperty(table, path, "children") &&
+		!hasDefinitionMarker(escapedChildren, escapedPath, source)
+	if hasEscapedChildren {
+		if len(escapedChildren) == 0 {
+			return Definition{}, fmt.Errorf("%s.children must contain at least one escaped child", name)
+		}
+		for key, value := range escapedChildren {
+			if !definitionKeys[key] && key != "children" {
+				return Definition{}, fmt.Errorf(
+					"%s.children may only contain schema-key conflicts, found: %s", name, key)
+			}
+			childTable, ok := asMap(value)
+			if !ok {
+				return Definition{}, fmt.Errorf("%s.children.%s must be a table", name, key)
+			}
+			child, err := parseDefinition(name+"."+key, appendSourcePath(escapedPath, key), childTable, source)
+			if err != nil {
+				return Definition{}, err
+			}
+			children[key] = child
+		}
+	}
 	for key, value := range table {
+		if key == "children" && hasEscapedChildren {
+			continue
+		}
 		if definitionKeys[key] && source.isProperty(table, path, key) {
 			continue
 		}
@@ -2458,6 +2486,15 @@ func propertyValue(table map[string]any, key string) any {
 		return nil
 	}
 	return value
+}
+
+func hasDefinitionMarker(table map[string]any, path []string, source *schemaSource) bool {
+	for _, key := range []string{"type", "oneof", "anyof", "if"} {
+		if source.isProperty(table, path, key) {
+			return true
+		}
+	}
+	return false
 }
 
 func getString(table map[string]any, key string) (string, error) {

--- a/reference-implementations/go/schema_test.go
+++ b/reference-implementations/go/schema_test.go
@@ -21,6 +21,65 @@ func TestValidatesCheckedInExample(t *testing.T) {
 	}
 }
 
+func TestSupportsChildrenEscapeHatchForSchemaKeyConflicts(t *testing.T) {
+	dir := t.TempDir()
+	schemaPath := write(t, dir, "escaped-children.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[elements.plugin]
+type = "table"
+
+[elements.plugin.children.type]
+type = "string"
+
+[elements.plugin.children.optional]
+type = "boolean"
+
+[elements.plugin.name]
+type = "string"
+`)
+	documentPath := write(t, dir, "escaped-children.toml", `
+[plugin]
+type = "npm"
+optional = true
+name = "example"
+`)
+	invalidEscape := write(t, dir, "invalid-escaped-child.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[elements.plugin]
+type = "table"
+
+[elements.plugin.children.name]
+type = "string"
+`)
+	emptyEscape := write(t, dir, "empty-escaped-children.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[elements.plugin]
+type = "table"
+
+[elements.plugin.children]
+`)
+
+	schema, err := LoadSchema(schemaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result := schema.ValidateFile(documentPath); !result.Valid() {
+		t.Fatalf("expected escaped schema-key children to validate, got %#v", result.Errors)
+	}
+	if _, err := LoadSchema(invalidEscape); err == nil {
+		t.Fatal("expected children escape hatch to reject a non-conflicting name")
+	}
+	if _, err := LoadSchema(emptyEscape); err == nil {
+		t.Fatal("expected children escape hatch to reject an empty namespace")
+	}
+}
+
 func TestLoadsCheckedInExamples(t *testing.T) {
 	for _, name := range []string{
 		"cargo.tosd",
@@ -35,6 +94,119 @@ func TestLoadsCheckedInExamples(t *testing.T) {
 				t.Fatal(err)
 			}
 		})
+	}
+}
+
+func TestSelfSchemaValidatesSchemaDocuments(t *testing.T) {
+	dir := t.TempDir()
+	invalidPropertyType := write(t, dir, "invalid-property-type.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[elements.name]
+type = "string"
+optional = "yes"
+`)
+	unknownProperty := write(t, dir, "unknown-property.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[elements.name]
+type = "string"
+optonal = true
+`)
+	invalidEscape := write(t, dir, "invalid-escape.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[elements.parent]
+type = "table"
+
+[elements.parent.children.name]
+type = "string"
+`)
+	literalChildren := write(t, dir, "literal-children.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[elements.parent]
+type = "table"
+
+[elements.parent.children]
+type = "array"
+itemtype = "string"
+`)
+	invalidSemantics := []string{
+		write(t, dir, "incomplete-conditional.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+if = { key = "kind", equals = "a" }
+then = "types.branch"
+`),
+		write(t, dir, "competing-selectors.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "string"
+oneof = [ "string" ]
+`),
+		write(t, dir, "inapplicable-property.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "integer"
+pattern = "^[0-9]+$"
+`),
+		write(t, dir, "tuple-conflict.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "array"
+items = [ "string" ]
+minlength = 1
+`),
+		write(t, dir, "scalar-child.tosd", `
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "string"
+
+[elements.value.child]
+type = "string"
+`),
+	}
+	schemaSchema, err := LoadSchema(fixture("toml-schema.tosd"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, schemaPath := range []string{
+		fixture("toml-schema.tosd"),
+		fixture("config.tosd"),
+		filepath.Join(fixture("examples"), "database-conditional.tosd"),
+	} {
+		if result := schemaSchema.ValidateFile(schemaPath); !result.Valid() {
+			t.Fatalf("expected self-schema to accept %s, got %#v", schemaPath, result.Errors)
+		}
+		if result := schemaSchema.ValidateFile(literalChildren); !result.Valid() {
+			t.Fatalf("expected self-schema to accept a literal children definition, got %#v", result.Errors)
+		}
+	}
+	for _, schemaPath := range []string{invalidPropertyType, unknownProperty, invalidEscape} {
+		if result := schemaSchema.ValidateFile(schemaPath); result.Valid() {
+			t.Fatalf("expected self-schema to reject %s", schemaPath)
+		}
+	}
+	for _, schemaPath := range invalidSemantics {
+		if result := schemaSchema.ValidateFile(schemaPath); result.Valid() {
+			t.Fatalf("expected self-schema to reject semantic violation in %s", schemaPath)
+		}
 	}
 }
 

--- a/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
@@ -197,8 +197,31 @@ final class SchemaLoader {
         }
 
         Map<String, SchemaDefinition> children = new LinkedHashMap<>();
+        TomlTable escapedChildren = table.getTable("children");
+        boolean hasEscapedChildren = escapedChildren != null
+                && !isProperty(table, "children")
+                && !hasDefinitionMarker(escapedChildren);
+        if (hasEscapedChildren) {
+            if (escapedChildren.keySet().isEmpty()) {
+                throw new SchemaException(name + ".children must contain at least one escaped child");
+            }
+            for (String key : escapedChildren.keySet()) {
+                if (!DEFINITION_KEYS.contains(key) && !key.equals("children")) {
+                    throw new SchemaException(
+                            name + ".children may only contain schema-key conflicts, found: " + key);
+                }
+                Object value = escapedChildren.get(List.of(key));
+                if (!(value instanceof TomlTable childTable)) {
+                    throw new SchemaException(name + ".children." + key + " must be a table");
+                }
+                children.put(key, parseDefinition(name + "." + key, childTable));
+            }
+        }
         for (String key : table.keySet()) {
             Object value = table.get(List.of(key));
+            if (key.equals("children") && hasEscapedChildren) {
+                continue;
+            }
             if (DEFINITION_KEYS.contains(key)
                     && isProperty(table, key)) {
                 continue;
@@ -900,6 +923,13 @@ final class SchemaLoader {
             valueStart++;
         }
         return valueStart < line.length() && line.charAt(valueStart) == '{';
+    }
+
+    private boolean hasDefinitionMarker(TomlTable table) {
+        return isProperty(table, "type")
+                || isProperty(table, "oneof")
+                || isProperty(table, "anyof")
+                || isProperty(table, "if");
     }
 
     private void validateDefinitionSemantics(

--- a/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
+++ b/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
@@ -29,6 +29,57 @@ class TomlSchemaTest {
     }
 
     @Test
+    void supportsChildrenEscapeHatchForSchemaKeyConflicts() throws IOException {
+        Path schemaPath = write("escaped-children.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.plugin]
+                type = "table"
+
+                [elements.plugin.children.type]
+                type = "string"
+
+                [elements.plugin.children.optional]
+                type = "boolean"
+
+                [elements.plugin.name]
+                type = "string"
+                """);
+        Path documentPath = write("escaped-children.toml", """
+                [plugin]
+                type = "npm"
+                optional = true
+                name = "example"
+                """);
+        Path invalidEscape = write("invalid-escaped-child.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.plugin]
+                type = "table"
+
+                [elements.plugin.children.name]
+                type = "string"
+                """);
+        Path emptyEscape = write("empty-escaped-children.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.plugin]
+                type = "table"
+
+                [elements.plugin.children]
+                """);
+
+        ValidationResult result = TomlSchema.load(schemaPath).validate(documentPath);
+
+        assertTrue(result.isValid(), () -> result.errors().toString());
+        assertThrows(SchemaException.class, () -> TomlSchema.load(invalidEscape));
+        assertThrows(SchemaException.class, () -> TomlSchema.load(emptyEscape));
+    }
+
+    @Test
     void loadsCheckedInExamples() {
         for (String schema : List.of(
                 "examples/cargo.tosd",
@@ -90,11 +141,101 @@ class TomlSchemaTest {
 
                 [elements]
                 """);
+        Path invalidPropertyType = write("invalid-property-type.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.name]
+                type = "string"
+                optional = "yes"
+                """);
+        Path unknownProperty = write("unknown-property.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.name]
+                type = "string"
+                optonal = true
+                """);
+        Path invalidEscape = write("invalid-escape.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.parent]
+                type = "table"
+
+                [elements.parent.children.name]
+                type = "string"
+                """);
+        Path literalChildren = write("literal-children.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+
+                [elements.parent]
+                type = "table"
+
+                [elements.parent.children]
+                type = "array"
+                itemtype = "string"
+                """);
+        List<Path> invalidSemantics = List.of(
+                write("incomplete-conditional.tosd", """
+                        [toml-schema]
+                        version = "1.0.0"
+
+                        [elements.value]
+                        if = { key = "kind", equals = "a" }
+                        then = "types.branch"
+                        """),
+                write("competing-selectors.tosd", """
+                        [toml-schema]
+                        version = "1.0.0"
+
+                        [elements.value]
+                        type = "string"
+                        oneof = [ "string" ]
+                        """),
+                write("inapplicable-property.tosd", """
+                        [toml-schema]
+                        version = "1.0.0"
+
+                        [elements.value]
+                        type = "integer"
+                        pattern = "^[0-9]+$"
+                        """),
+                write("tuple-conflict.tosd", """
+                        [toml-schema]
+                        version = "1.0.0"
+
+                        [elements.value]
+                        type = "array"
+                        items = [ "string" ]
+                        minlength = 1
+                        """),
+                write("scalar-child.tosd", """
+                        [toml-schema]
+                        version = "1.0.0"
+
+                        [elements.value]
+                        type = "string"
+
+                        [elements.value.child]
+                        type = "string"
+                        """)
+        );
 
         assertTrue(schemaSchema.validate(fixture("config.tosd")).isValid());
         assertTrue(schemaSchema.validate(fixture("toml-schema.tosd")).isValid());
         assertTrue(schemaSchema.validate(emptyElementsSchema).isValid());
+        assertFalse(schemaSchema.validate(invalidPropertyType).isValid());
+        assertFalse(schemaSchema.validate(unknownProperty).isValid());
+        assertFalse(schemaSchema.validate(invalidEscape).isValid());
+        assertTrue(schemaSchema.validate(literalChildren).isValid());
+        for (Path invalidSemantic : invalidSemantics) {
+            assertFalse(schemaSchema.validate(invalidSemantic).isValid(), invalidSemantic.toString());
+        }
         for (String schema : List.of(
+                "examples/database-conditional.tosd",
                 "examples/cargo.tosd",
                 "examples/gitlab-runner.tosd",
                 "examples/hugo.tosd",

--- a/reference-implementations/python/src/toml_schema/_schema.py
+++ b/reference-implementations/python/src/toml_schema/_schema.py
@@ -442,6 +442,13 @@ def parse_definitions(
     return definitions
 
 
+def _is_selector_bearing_child(table: dict, path: Path, source: SchemaSource) -> bool:
+    return any(
+        source.is_property(table, path, key)
+        for key in ("type", "oneof", "anyof", "if")
+    )
+
+
 def parse_definition(name: str, path: Path, table: dict, source: SchemaSource) -> Definition:
     type_selector = _get_string(table, "type")
     if _property_value(table, "type") is not None and type_selector == "":
@@ -529,7 +536,28 @@ def parse_definition(name: str, path: Path, table: dict, source: SchemaSource) -
         raise SchemaError(f"{name} cannot define more than one of type, oneof, anyof, and if")
 
     children: Dict[str, Definition] = {}
+    escaped_children = table.get("children")
+    has_escape_namespace = (
+        isinstance(escaped_children, dict)
+        and not _is_selector_bearing_child(escaped_children, path + ("children",), source)
+    )
+    if has_escape_namespace:
+        if not escaped_children:
+            raise SchemaError(f"{name} children escape namespace must not be empty")
+        for key, value in escaped_children.items():
+            if key not in DEFINITION_KEYS and key != "children":
+                raise SchemaError(
+                    f"{name} children escape namespace contains non-conflicting child: {key}"
+                )
+            if not isinstance(value, dict):
+                raise SchemaError(f"{name}.children.{key} must be a child definition table")
+            children[key] = parse_definition(
+                f"{name}.{key}", path + ("children", key), value, source
+            )
+
     for key, value in table.items():
+        if key == "children" and has_escape_namespace:
+            continue
         if key in DEFINITION_KEYS and source.is_property(table, path, key):
             continue
         if isinstance(value, dict):

--- a/reference-implementations/python/tests/test_examples.py
+++ b/reference-implementations/python/tests/test_examples.py
@@ -171,5 +171,98 @@ description = 42
                 load_schema(invalid_schema)
 
 
+class ChildrenEscapeTests(unittest.TestCase):
+    def test_selective_children_escape_and_literal_children(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            schema_path = helpers.write_file(
+                tmp,
+                "children-escape.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+
+[elements.plugin]
+type = "table"
+
+[elements.plugin.children.type]
+type = "string"
+
+[elements.plugin.children.children]
+type = "boolean"
+""",
+            )
+            document_path = helpers.write_file(
+                tmp,
+                "children-escape.toml",
+                """
+[plugin]
+type = "npm"
+children = true
+""",
+            )
+            schema = load_schema(schema_path)
+            result = schema.validate_file(document_path)
+            self.assertTrue(result.valid, msg=result.errors)
+
+            literal_schema_path = helpers.write_file(
+                tmp,
+                "literal-children.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+
+[elements.plugin]
+type = "table"
+
+[elements.plugin.children]
+type = "string"
+""",
+            )
+            literal_document_path = helpers.write_file(
+                tmp,
+                "literal-children.toml",
+                """
+[plugin]
+children = "ordinary child"
+""",
+            )
+            literal_schema = load_schema(literal_schema_path)
+            literal_result = literal_schema.validate_file(literal_document_path)
+            self.assertTrue(literal_result.valid, msg=literal_result.errors)
+
+    def test_rejects_invalid_children_escape_namespaces(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            for name, body in (
+                ("empty", "[elements.plugin.children]"),
+                (
+                    "non-conflicting",
+                    """
+[elements.plugin.children.name]
+type = "string"
+""",
+                ),
+            ):
+                with self.subTest(name=name):
+                    schema_path = helpers.write_file(
+                        tmp,
+                        f"{name}.tosd",
+                        f"""
+[toml-schema]
+version = "1.0.0"
+
+[elements.plugin]
+type = "table"
+
+{body}
+""",
+                    )
+                    with self.assertRaises(SchemaError):
+                        load_schema(schema_path)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/reference-implementations/rust/src/schema.rs
+++ b/reference-implementations/rust/src/schema.rs
@@ -1375,7 +1375,45 @@ fn parse_definition(
         ));
     }
     let mut children: BTreeMap<String, Definition> = BTreeMap::new();
+    let escaped_path = context.child_path("children");
+    let escaped_context = context.child(&escaped_path);
+    let has_escaped_children = table
+        .get("children")
+        .and_then(Value::as_table)
+        .is_some_and(|escaped_children| {
+            !context.is_property(table, "children")
+                && !has_definition_marker(escaped_children, escaped_context)
+        });
+    if let Some(escaped_children) = table.get("children").and_then(Value::as_table) {
+        if has_escaped_children {
+            if escaped_children.is_empty() {
+                return Err(format!(
+                    "{name}.children must contain at least one escaped child"
+                ));
+            }
+            for (key, value) in escaped_children {
+                if !is_definition_key(key) && key != "children" {
+                    return Err(format!(
+                        "{name}.children may only contain schema-key conflicts, found: {key}"
+                    ));
+                }
+                let child_table = value
+                    .as_table()
+                    .ok_or_else(|| format!("{name}.children.{key} must be a table"))?;
+                let child_path = escaped_context.child_path(key);
+                let child = parse_definition(
+                    &format!("{name}.{key}"),
+                    child_table,
+                    escaped_context.child(&child_path),
+                )?;
+                children.insert(key.clone(), child);
+            }
+        }
+    }
     for (key, value) in table.iter() {
+        if key == "children" && has_escaped_children {
+            continue;
+        }
         if is_definition_key(key) && context.is_property(table, key) {
             continue;
         }
@@ -3090,6 +3128,12 @@ fn property_value<'a>(table: &'a Table, key: &str) -> Option<&'a Value> {
         Some(Value::Table(_)) => None,
         value => value,
     }
+}
+
+fn has_definition_marker(table: &Table, context: SyntaxContext<'_>) -> bool {
+    ["type", "oneof", "anyof", "if"]
+        .iter()
+        .any(|key| context.is_property(table, key))
 }
 
 fn get_string(name: &str, table: &Table, key: &str) -> Result<Option<String>, String> {

--- a/reference-implementations/rust/tests/integration.rs
+++ b/reference-implementations/rust/tests/integration.rs
@@ -85,6 +85,84 @@ fn validates_checked_in_example() {
 }
 
 #[test]
+fn supports_children_escape_hatch_for_schema_key_conflicts() {
+    let directory = tempfile_dir("escaped-children");
+    let schema_path = write_file(
+        &directory,
+        "escaped-children.tosd",
+        r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.plugin]
+type = "table"
+
+[elements.plugin.children.type]
+type = "string"
+
+[elements.plugin.children.optional]
+type = "boolean"
+
+[elements.plugin.name]
+type = "string"
+"#,
+    );
+    let document_path = write_file(
+        &directory,
+        "escaped-children.toml",
+        r#"
+[plugin]
+type = "npm"
+optional = true
+name = "example"
+"#,
+    );
+    let invalid_escape = write_file(
+        &directory,
+        "invalid-escaped-child.tosd",
+        r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.plugin]
+type = "table"
+
+[elements.plugin.children.name]
+type = "string"
+"#,
+    );
+    let empty_escape = write_file(
+        &directory,
+        "empty-escaped-children.tosd",
+        r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.plugin]
+type = "table"
+
+[elements.plugin.children]
+"#,
+    );
+
+    let schema = Schema::load(schema_path).expect("load escaped-children schema");
+    let result = schema.validate_file(document_path);
+    assert!(
+        result.valid(),
+        "expected escaped schema-key children to validate: {:?}",
+        result.errors
+    );
+    assert!(
+        Schema::load(invalid_escape).is_err(),
+        "children escape hatch must reject a non-conflicting name"
+    );
+    assert!(
+        Schema::load(empty_escape).is_err(),
+        "children escape hatch must reject an empty namespace"
+    );
+}
+
+#[test]
 fn loads_checked_in_examples() {
     for name in [
         "cargo.tosd",
@@ -274,6 +352,150 @@ fn validates_self_schema_against_itself() {
     assert!(
         result.valid(),
         "expected valid document, got {:#?}",
+        result.errors
+    );
+
+    let directory = tempfile_dir("invalid-self-schema-documents");
+    let invalid_property_type = write_file(
+        &directory,
+        "invalid-property-type.tosd",
+        r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.name]
+type = "string"
+optional = "yes"
+"#,
+    );
+    let unknown_property = write_file(
+        &directory,
+        "unknown-property.tosd",
+        r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.name]
+type = "string"
+optonal = true
+"#,
+    );
+    let invalid_escape = write_file(
+        &directory,
+        "invalid-escape.tosd",
+        r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.parent]
+type = "table"
+
+[elements.parent.children.name]
+type = "string"
+"#,
+    );
+    let literal_children = write_file(
+        &directory,
+        "literal-children.tosd",
+        r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.parent]
+type = "table"
+
+[elements.parent.children]
+type = "array"
+itemtype = "string"
+"#,
+    );
+    let invalid_semantics = [
+        (
+            "incomplete-conditional.tosd",
+            r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+if = { key = "kind", equals = "a" }
+then = "types.branch"
+"#,
+        ),
+        (
+            "competing-selectors.tosd",
+            r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "string"
+oneof = [ "string" ]
+"#,
+        ),
+        (
+            "inapplicable-property.tosd",
+            r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "integer"
+pattern = "^[0-9]+$"
+"#,
+        ),
+        (
+            "tuple-conflict.tosd",
+            r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "array"
+items = [ "string" ]
+minlength = 1
+"#,
+        ),
+        (
+            "scalar-child.tosd",
+            r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "string"
+
+[elements.value.child]
+type = "string"
+"#,
+        ),
+    ];
+    for schema_path in [invalid_property_type, unknown_property, invalid_escape] {
+        let result = schema.validate_file(&schema_path);
+        assert!(
+            !result.valid(),
+            "expected self-schema to reject {}",
+            schema_path.display()
+        );
+    }
+    let result = schema.validate_file(&literal_children);
+    assert!(
+        result.valid(),
+        "expected self-schema to accept a literal children definition: {:?}",
+        result.errors
+    );
+    for (name, content) in invalid_semantics {
+        let schema_path = write_file(&directory, name, content);
+        let result = schema.validate_file(&schema_path);
+        assert!(
+            !result.valid(),
+            "expected self-schema to reject semantic violation in {}",
+            schema_path.display()
+        );
+    }
+    let result = schema.validate_file(fixture("examples/database-conditional.tosd"));
+    assert!(
+        result.valid(),
+        "expected self-schema to accept conditional example: {:?}",
         result.errors
     );
 }

--- a/reference-implementations/typescript/src/schemaParser.ts
+++ b/reference-implementations/typescript/src/schemaParser.ts
@@ -445,6 +445,14 @@ export function parseDefinitions(
   return definitions;
 }
 
+function isSelectorBearingChild(
+  table: TomlTable,
+  path: readonly string[],
+  source: SchemaSource,
+): boolean {
+  return ["type", "oneof", "anyof", "if"].some((key) => source.isProperty(table, path, key));
+}
+
 export function parseDefinition(
   name: string,
   path: readonly string[],
@@ -546,7 +554,37 @@ export function parseDefinition(
   }
 
   const children = emptyRecord<RawDefinition>();
+  const escapedChildren = table["children"];
+  const hasEscapeNamespace =
+    isTomlTable(escapedChildren) &&
+    !isSelectorBearingChild(escapedChildren, [...path, "children"], source);
+  if (hasEscapeNamespace) {
+    const entries = Object.entries(escapedChildren);
+    if (entries.length === 0) {
+      throw new SchemaError(`${name} children escape namespace must not be empty`);
+    }
+    for (const [key, value] of entries) {
+      if (!(DEFINITION_KEYS as readonly string[]).includes(key) && key !== "children") {
+        throw new SchemaError(
+          `${name} children escape namespace contains non-conflicting child: ${key}`,
+        );
+      }
+      if (!isTomlTable(value)) {
+        throw new SchemaError(`${name}.children.${key} must be a child definition table`);
+      }
+      children[key] = parseDefinition(
+        `${name}.${key}`,
+        [...path, "children", key],
+        value,
+        source,
+      );
+    }
+  }
+
   for (const [key, value] of Object.entries(table)) {
+    if (key === "children" && hasEscapeNamespace) {
+      continue;
+    }
     if ((DEFINITION_KEYS as readonly string[]).includes(key) && source.isProperty(table, path, key)) {
       continue;
     }

--- a/reference-implementations/typescript/test/checked-in.test.ts
+++ b/reference-implementations/typescript/test/checked-in.test.ts
@@ -61,3 +61,86 @@ test("loadDocument returns a plain parsed table usable with Schema.validate", as
   const result = schema.validate(document);
   assert.equal(result.valid, true, JSON.stringify(result.errors));
 });
+
+test("selective children escape and literal children child", async () => {
+  const { mkdtemp, writeFile } = await import("node:fs/promises");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+  const dir = await mkdtemp(join(tmpdir(), "toml-schema-children-"));
+  const schemaPath = join(dir, "children-escape.tosd");
+  const documentPath = join(dir, "children-escape.toml");
+  await writeFile(
+    schemaPath,
+    `[toml-schema]
+version = "1.0.0"
+
+[elements.plugin]
+type = "table"
+
+[elements.plugin.children.type]
+type = "string"
+
+[elements.plugin.children.children]
+type = "boolean"
+`,
+  );
+  await writeFile(
+    documentPath,
+    `[plugin]
+type = "npm"
+children = true
+`,
+  );
+  const schema = await loadSchema(schemaPath);
+  const result = await schema.validateFile(documentPath);
+  assert.equal(result.valid, true, JSON.stringify(result.errors));
+
+  const literalSchemaPath = join(dir, "literal-children.tosd");
+  const literalDocumentPath = join(dir, "literal-children.toml");
+  await writeFile(
+    literalSchemaPath,
+    `[toml-schema]
+version = "1.0.0"
+
+[elements.plugin]
+type = "table"
+
+[elements.plugin.children]
+type = "string"
+`,
+  );
+  await writeFile(
+    literalDocumentPath,
+    `[plugin]
+children = "ordinary child"
+`,
+  );
+  const literalSchema = await loadSchema(literalSchemaPath);
+  const literalResult = await literalSchema.validateFile(literalDocumentPath);
+  assert.equal(literalResult.valid, true, JSON.stringify(literalResult.errors));
+});
+
+test("rejects invalid children escape namespaces", async () => {
+  const { mkdtemp, writeFile } = await import("node:fs/promises");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+  const dir = await mkdtemp(join(tmpdir(), "toml-schema-children-invalid-"));
+  for (const [name, body] of [
+    ["empty", "[elements.plugin.children]"],
+    ["non-conflicting", "[elements.plugin.children.name]\ntype = \"string\""],
+  ] as const) {
+    const schemaPath = join(dir, `${name}.tosd`);
+    await writeFile(
+      schemaPath,
+      `[toml-schema]
+version = "1.0.0"
+
+[elements.plugin]
+type = "table"
+
+${body}
+`,
+    );
+    await assert.rejects(() => loadSchema(schemaPath));
+  }
+});

--- a/toml-schema.abnf
+++ b/toml-schema.abnf
@@ -32,7 +32,18 @@ metadata-table    = toml-table-header-toml-schema-meta *metadata-member
 metadata-member   = toml-keyval / metadata-subtable
 metadata-subtable = toml-table-header-toml-schema-meta-descendant *metadata-member
 
-schema-definition = schema-definition-table *definition-property *schema-definition
+schema-definition = schema-definition-table
+                    *(definition-property / direct-child-definition / escaped-children-table)
+direct-child-definition = schema-definition
+; A direct child uses its target key as the next table-path segment.
+; If that name is also present as a definition-property on the same definition,
+; TOML cannot represent both values and the child instead uses the reserved
+; escaped-children-table namespace.
+escaped-children-table = schema-children-table 1*escaped-child-definition
+escaped-child-definition = schema-definition
+; Each escaped child name MUST be "children" or a schema-key. Non-conflicting
+; child names MUST use direct-child-definition instead. At most one
+; escaped-children-table is allowed per definition.
 
 ; Canonical definition-key inventory, also consumed by implementation
 ; conformance guards.
@@ -114,6 +125,7 @@ toml-table-header-elements         = <TOML 1.0 table header for [elements]>
 toml-table-header-toml-schema-meta = <TOML 1.0 table header under [toml-schema.meta]>
 toml-table-header-toml-schema-meta-descendant = <TOML 1.0 table header below [toml-schema.meta]>
 schema-definition-table            = <TOML 1.0 table header under [types] or [elements]; a key/value schema property and a child table of the same name cannot coexist>
+schema-children-table              = <TOML 1.0 table header named children directly below a schema definition>
 toml-keyval                        = <TOML 1.0 key/value pair>
 toml-key                           = <TOML 1.0 key>
 toml-value                         = <TOML 1.0 value>

--- a/toml-schema.tosd
+++ b/toml-schema.tosd
@@ -2,38 +2,593 @@
 [toml-schema]
 version = "1.0.0"
 
-# Types
-[types]
+# Reusable schema-language definitions
+[types.typeReference]
+type = "string"
+minlength = 1
 
-    # This is intentionally an open structural definition. Schema property
-    # names can also be document child keys, so modeling fixed properties here
-    # would collide with this definition's own type and itemtype keys. Schema
-    # loaders enforce property types, composition, sibling rules, annotations,
-    # and conditional applicability.
-    [types.schemaDef]
-    type = "table"
+[types.typeReferences]
+type = "array"
+itemtype = "types.typeReference"
+minlength = 1
+uniqueitems = true
 
-# Elements
-[elements]
+[types.nonEmptyValues]
+type = "array"
+itemtype = "any"
+minlength = 1
 
-    [elements.toml-schema]
-    type = "table"
+[types.nameList]
+type = "array"
+itemtype = "string"
+minlength = 1
+uniqueitems = true
 
-        [elements.toml-schema.version]
-        type = "string"
-        pattern = '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-((?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$'
+[types.nameGroup]
+type = "array"
+itemtype = "string"
+minlength = 2
+uniqueitems = true
 
-        [elements.toml-schema.meta]
-        type = "table"
-        optional = true
+[types.nameGroups]
+type = "array"
+itemtype = "types.nameGroup"
+minlength = 1
 
-    [elements.types]
-    type = "collection"
-    itemtype = "types.schemaDef"
-    minlength = 0
+[types.nonNegativeInteger]
+type = "integer"
+min = 0
+
+[types.dependentRequired]
+type = "collection"
+itemtype = "types.nameList"
+minlength = 1
+
+[types.conditionalEquals]
+type = "table"
+
+    [types.conditionalEquals.key]
+    type = "string"
+
+    [types.conditionalEquals.equals]
+    type = "any"
+
+[types.conditionalIn]
+type = "table"
+
+    [types.conditionalIn.key]
+    type = "string"
+
+    [types.conditionalIn.in]
+    type = "types.nonEmptyValues"
+
+[types.conditional]
+oneof = [ "types.conditionalEquals", "types.conditionalIn" ]
+
+[types.stringFormat]
+type = "string"
+allowedvalues = [ "email", "uuid", "uri", "hostname", "ipv4", "ipv6" ]
+
+[types.neverA]
+type = "any"
+
+[types.neverB]
+type = "any"
+
+[types.never]
+oneof = [ "types.neverA", "types.neverB" ]
+
+# Scalar definitions are closed: dynamic table entries validate against `never`.
+[types.stringDefinition]
+type = "collection"
+itemtype = "types.never"
+
+    [types.stringDefinition.children.type]
+    type = "string"
+    allowedvalues = [ "string" ]
+
+    [types.stringDefinition.description]
+    type = "string"
     optional = true
 
-    [elements.elements]
-    type = "collection"
-    itemtype = "types.schemaDef"
-    minlength = 0
+    [types.stringDefinition.format]
+    type = "types.stringFormat"
+    optional = true
+
+    [types.stringDefinition.pattern]
+    type = "string"
+    optional = true
+
+    [types.stringDefinition.allowedvalues]
+    type = "types.nonEmptyValues"
+    optional = true
+
+    [types.stringDefinition.minlength]
+    type = "types.nonNegativeInteger"
+    optional = true
+
+    [types.stringDefinition.maxlength]
+    type = "types.nonNegativeInteger"
+    optional = true
+
+    [types.stringDefinition.optional]
+    type = "boolean"
+    optional = true
+
+    [types.stringDefinition.default]
+    type = "any"
+    optional = true
+
+    [types.stringDefinition.deprecated]
+    type = "boolean"
+    optional = true
+
+    [types.stringDefinition.allof]
+    type = "types.typeReferences"
+    optional = true
+
+[types.comparableDefinition]
+type = "collection"
+itemtype = "types.never"
+
+    [types.comparableDefinition.children.type]
+    type = "string"
+    allowedvalues = [ "integer", "float", "offset-date-time", "local-date-time", "local-date", "local-time" ]
+
+    [types.comparableDefinition.description]
+    type = "string"
+    optional = true
+
+    [types.comparableDefinition.allowedvalues]
+    type = "types.nonEmptyValues"
+    optional = true
+
+    [types.comparableDefinition.min]
+    oneof = [ "integer", "float", "offset-date-time", "local-date-time", "local-date", "local-time" ]
+    optional = true
+
+    [types.comparableDefinition.max]
+    oneof = [ "integer", "float", "offset-date-time", "local-date-time", "local-date", "local-time" ]
+    optional = true
+
+    [types.comparableDefinition.optional]
+    type = "boolean"
+    optional = true
+
+    [types.comparableDefinition.default]
+    type = "any"
+    optional = true
+
+    [types.comparableDefinition.deprecated]
+    type = "boolean"
+    optional = true
+
+    [types.comparableDefinition.allof]
+    type = "types.typeReferences"
+    optional = true
+
+[types.simpleScalarDefinition]
+type = "collection"
+itemtype = "types.never"
+
+    [types.simpleScalarDefinition.children.type]
+    type = "string"
+    allowedvalues = [ "any", "boolean" ]
+
+    [types.simpleScalarDefinition.description]
+    type = "string"
+    optional = true
+
+    [types.simpleScalarDefinition.allowedvalues]
+    type = "types.nonEmptyValues"
+    optional = true
+
+    [types.simpleScalarDefinition.optional]
+    type = "boolean"
+    optional = true
+
+    [types.simpleScalarDefinition.default]
+    type = "any"
+    optional = true
+
+    [types.simpleScalarDefinition.deprecated]
+    type = "boolean"
+    optional = true
+
+    [types.simpleScalarDefinition.allof]
+    type = "types.typeReferences"
+    optional = true
+
+[types.arrayDefinition]
+type = "collection"
+itemtype = "types.never"
+
+    [types.arrayDefinition.children.type]
+    type = "string"
+    allowedvalues = [ "array" ]
+
+    [types.arrayDefinition.children.itemtype]
+    type = "types.typeReference"
+    optional = true
+
+    [types.arrayDefinition.description]
+    type = "string"
+    optional = true
+
+    [types.arrayDefinition.allowedvalues]
+    type = "types.nonEmptyValues"
+    optional = true
+
+    [types.arrayDefinition.min]
+    oneof = [ "integer", "float", "offset-date-time", "local-date-time", "local-date", "local-time" ]
+    optional = true
+
+    [types.arrayDefinition.max]
+    oneof = [ "integer", "float", "offset-date-time", "local-date-time", "local-date", "local-time" ]
+    optional = true
+
+    [types.arrayDefinition.minlength]
+    type = "types.nonNegativeInteger"
+    optional = true
+
+    [types.arrayDefinition.maxlength]
+    type = "types.nonNegativeInteger"
+    optional = true
+
+    [types.arrayDefinition.uniqueitems]
+    type = "boolean"
+    optional = true
+
+    [types.arrayDefinition.optional]
+    type = "boolean"
+    optional = true
+
+    [types.arrayDefinition.default]
+    type = "any"
+    optional = true
+
+    [types.arrayDefinition.deprecated]
+    type = "boolean"
+    optional = true
+
+    [types.arrayDefinition.allof]
+    type = "types.typeReferences"
+    optional = true
+
+[types.tupleDefinition]
+type = "collection"
+itemtype = "types.never"
+
+    [types.tupleDefinition.children.type]
+    type = "string"
+    allowedvalues = [ "array" ]
+
+    [types.tupleDefinition.items]
+    type = "types.typeReferences"
+
+    [types.tupleDefinition.description]
+    type = "string"
+    optional = true
+
+    [types.tupleDefinition.uniqueitems]
+    type = "boolean"
+    optional = true
+
+    [types.tupleDefinition.optional]
+    type = "boolean"
+    optional = true
+
+    [types.tupleDefinition.default]
+    type = "any"
+    optional = true
+
+    [types.tupleDefinition.deprecated]
+    type = "boolean"
+    optional = true
+
+    [types.tupleDefinition.allof]
+    type = "types.typeReferences"
+    optional = true
+
+[types.tableDefinition]
+type = "collection"
+itemtype = "types.schemaDef"
+
+    [types.tableDefinition.children.type]
+    type = "string"
+    allowedvalues = [ "table" ]
+
+    [types.tableDefinition.children.description]
+    oneof = [ "string", "types.schemaDef" ]
+    optional = true
+
+    [types.tableDefinition.children.optional]
+    oneof = [ "boolean", "types.schemaDef" ]
+    optional = true
+
+    [types.tableDefinition.children.default]
+    type = "any"
+    optional = true
+
+    [types.tableDefinition.children.deprecated]
+    oneof = [ "boolean", "types.schemaDef" ]
+    optional = true
+
+    [types.tableDefinition.children.allof]
+    oneof = [ "types.typeReferences", "types.schemaDef" ]
+    optional = true
+
+    [types.tableDefinition.children.dependentrequired]
+    oneof = [ "types.dependentRequired", "types.schemaDef" ]
+    optional = true
+
+    [types.tableDefinition.children.mutuallyexclusive]
+    oneof = [ "types.nameGroups", "types.schemaDef" ]
+    optional = true
+
+    [types.tableDefinition.children.exactlyone]
+    oneof = [ "types.nameGroups", "types.schemaDef" ]
+    optional = true
+
+    [types.tableDefinition.children.children]
+    anyof = [ "types.escapedChildren", "types.literalChildren" ]
+    optional = true
+
+[types.collectionDefinition]
+type = "collection"
+itemtype = "types.schemaDef"
+
+    [types.collectionDefinition.children.type]
+    type = "string"
+    allowedvalues = [ "collection" ]
+
+    [types.collectionDefinition.children.itemtype]
+    oneof = [ "types.typeReference", "types.schemaDef" ]
+    optional = true
+
+    [types.collectionDefinition.children.description]
+    oneof = [ "string", "types.schemaDef" ]
+    optional = true
+
+    [types.collectionDefinition.children.keypattern]
+    oneof = [ "string", "types.schemaDef" ]
+    optional = true
+
+    [types.collectionDefinition.children.minlength]
+    oneof = [ "types.nonNegativeInteger", "types.schemaDef" ]
+    optional = true
+
+    [types.collectionDefinition.children.maxlength]
+    oneof = [ "types.nonNegativeInteger", "types.schemaDef" ]
+    optional = true
+
+    [types.collectionDefinition.children.optional]
+    oneof = [ "boolean", "types.schemaDef" ]
+    optional = true
+
+    [types.collectionDefinition.children.default]
+    type = "any"
+    optional = true
+
+    [types.collectionDefinition.children.deprecated]
+    oneof = [ "boolean", "types.schemaDef" ]
+    optional = true
+
+    [types.collectionDefinition.children.allof]
+    oneof = [ "types.typeReferences", "types.schemaDef" ]
+    optional = true
+
+    [types.collectionDefinition.children.dependentrequired]
+    oneof = [ "types.dependentRequired", "types.schemaDef" ]
+    optional = true
+
+    [types.collectionDefinition.children.mutuallyexclusive]
+    oneof = [ "types.nameGroups", "types.schemaDef" ]
+    optional = true
+
+    [types.collectionDefinition.children.exactlyone]
+    oneof = [ "types.nameGroups", "types.schemaDef" ]
+    optional = true
+
+    [types.collectionDefinition.children.children]
+    anyof = [ "types.escapedChildren", "types.literalChildren" ]
+    optional = true
+
+[types.namedReferenceDefinition]
+type = "collection"
+itemtype = "types.never"
+
+    [types.namedReferenceDefinition.children.type]
+    type = "types.typeReference"
+
+    [types.namedReferenceDefinition.description]
+    type = "string"
+    optional = true
+
+    [types.namedReferenceDefinition.optional]
+    type = "boolean"
+    optional = true
+
+    [types.namedReferenceDefinition.default]
+    type = "any"
+    optional = true
+
+    [types.namedReferenceDefinition.deprecated]
+    type = "boolean"
+    optional = true
+
+    [types.namedReferenceDefinition.allof]
+    type = "types.typeReferences"
+    optional = true
+
+[types.unionDefinition]
+type = "collection"
+itemtype = "types.never"
+exactlyone = [ [ "oneof", "anyof" ] ]
+
+    [types.unionDefinition.oneof]
+    type = "types.typeReferences"
+    optional = true
+
+    [types.unionDefinition.anyof]
+    type = "types.typeReferences"
+    optional = true
+
+    [types.unionDefinition.description]
+    type = "string"
+    optional = true
+
+    [types.unionDefinition.optional]
+    type = "boolean"
+    optional = true
+
+    [types.unionDefinition.default]
+    type = "any"
+    optional = true
+
+    [types.unionDefinition.deprecated]
+    type = "boolean"
+    optional = true
+
+    [types.unionDefinition.allof]
+    type = "types.typeReferences"
+    optional = true
+
+[types.conditionalDefinition]
+type = "collection"
+itemtype = "types.never"
+
+    [types.conditionalDefinition.children.if]
+    type = "types.conditional"
+
+    [types.conditionalDefinition.then]
+    type = "types.typeReference"
+
+    [types.conditionalDefinition.else]
+    type = "types.typeReference"
+
+    [types.conditionalDefinition.description]
+    type = "string"
+    optional = true
+
+    [types.conditionalDefinition.optional]
+    type = "boolean"
+    optional = true
+
+    [types.conditionalDefinition.default]
+    type = "any"
+    optional = true
+
+    [types.conditionalDefinition.deprecated]
+    type = "boolean"
+    optional = true
+
+    [types.conditionalDefinition.allof]
+    type = "types.typeReferences"
+    optional = true
+
+[types.implicitTableDefinition]
+type = "collection"
+itemtype = "types.schemaDef"
+
+    [types.implicitTableDefinition.children.type]
+    type = "types.schemaDef"
+    optional = true
+
+    [types.implicitTableDefinition.children.oneof]
+    type = "types.schemaDef"
+    optional = true
+
+    [types.implicitTableDefinition.children.anyof]
+    type = "types.schemaDef"
+    optional = true
+
+    [types.implicitTableDefinition.children.if]
+    type = "types.schemaDef"
+    optional = true
+
+    [types.implicitTableDefinition.children.description]
+    oneof = [ "string", "types.schemaDef" ]
+    optional = true
+
+    [types.implicitTableDefinition.children.optional]
+    oneof = [ "boolean", "types.schemaDef" ]
+    optional = true
+
+    [types.implicitTableDefinition.children.default]
+    type = "any"
+    optional = true
+
+    [types.implicitTableDefinition.children.deprecated]
+    oneof = [ "boolean", "types.schemaDef" ]
+    optional = true
+
+    [types.implicitTableDefinition.children.allof]
+    oneof = [ "types.typeReferences", "types.schemaDef" ]
+    optional = true
+
+    [types.implicitTableDefinition.children.dependentrequired]
+    oneof = [ "types.dependentRequired", "types.schemaDef" ]
+    optional = true
+
+    [types.implicitTableDefinition.children.mutuallyexclusive]
+    oneof = [ "types.nameGroups", "types.schemaDef" ]
+    optional = true
+
+    [types.implicitTableDefinition.children.exactlyone]
+    oneof = [ "types.nameGroups", "types.schemaDef" ]
+    optional = true
+
+    [types.implicitTableDefinition.children.children]
+    anyof = [ "types.escapedChildren", "types.literalChildren" ]
+    optional = true
+
+[types.schemaDef]
+anyof = [
+    "types.stringDefinition",
+    "types.comparableDefinition",
+    "types.simpleScalarDefinition",
+    "types.arrayDefinition",
+    "types.tupleDefinition",
+    "types.tableDefinition",
+    "types.collectionDefinition",
+    "types.namedReferenceDefinition",
+    "types.unionDefinition",
+    "types.conditionalDefinition",
+    "types.implicitTableDefinition",
+]
+
+[types.escapedChildren]
+type = "collection"
+itemtype = "types.schemaDef"
+keypattern = '^(type|description|format|itemtype|items|oneof|anyof|if|then|else|allof|allowedvalues|pattern|keypattern|optional|min|max|minlength|maxlength|uniqueitems|dependentrequired|mutuallyexclusive|exactlyone|default|deprecated|children)$'
+minlength = 1
+
+[types.literalChildren]
+type = "collection"
+itemtype = "types.schemaDef"
+allof = [ "types.schemaDef" ]
+exactlyone = [ [ "type", "oneof", "anyof", "if" ] ]
+
+# Schema document structure
+[elements.toml-schema]
+type = "table"
+
+    [elements.toml-schema.version]
+    type = "string"
+    pattern = '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-((?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$'
+
+    [elements.toml-schema.meta]
+    type = "table"
+    optional = true
+
+[elements.types]
+type = "collection"
+itemtype = "types.schemaDef"
+minlength = 0
+optional = true
+
+[elements.elements]
+type = "collection"
+itemtype = "types.schemaDef"
+minlength = 0


### PR DESCRIPTION
The self-schema had become an open placeholder that only checked top-level structure, leaving schema vocabulary and most new capabilities unverifiable through `toml-schema.tosd`. This restores the invariant that schema documents, including the self-schema, are structurally and semantically checked by the schema language itself wherever the TOML value model permits.

## Approach

- Restore `children` as a selective escape hatch only for target keys that conflict with schema keywords.
- Implement identical escape parsing and ambiguity handling in Java, Go, and Rust.
- Replace the open `schemaDef` placeholder with recursive variants for scalar, array, tuple, table, collection, named-reference, union, conditional, and implicit-table definitions.
- Validate selector exclusivity, conditional completeness, property applicability, formats, sibling-rule structures, tuple constraints, annotations, and recursive children.
- Keep reference-graph and source-form checks in schema loaders where they require resolved types or distinctions erased by parsed TOML values.
- Add cross-implementation conformance coverage for valid and invalid self-schema documents.

## Notable tradeoff

`children` remains selective rather than becoming mandatory for every nested definition. Ordinary child paths retain the concise existing syntax; only schema-key collisions use the reserved namespace.