### PR TITLE
Fix duplicate landing page divider

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -476,7 +476,6 @@ footer {
 .editor-promo {
   align-items: center;
   border-bottom: 1px solid var(--cp-border-strong);
-  border-top: 1px solid var(--cp-border-strong);
   display: grid;
   gap: 48px;
   grid-template-columns: minmax(280px, 0.72fr) minmax(0, 1.28fr);


### PR DESCRIPTION
The validation proof band and the following editor promotion each rendered a boundary, creating two horizontal lines after the proof section. Remove the editor promotion's redundant top border while preserving the proof band's divider and the promotion's bottom boundary.