### PR TITLE
Use string formats in landing page examples

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -243,7 +243,7 @@ type = "table"
 
 [types.server.ip]
 type = "string"
-pattern = "^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$"
+format = "ipv4"
 
 [types.server.role]
 type = "string"</code></pre>
@@ -282,6 +282,7 @@ type = "string"
 
 [types.serverDatabase.host]
 type = "string"
+format = "hostname"
 
 [types.serverDatabase.port]
 type = "integer"


### PR DESCRIPTION
The landing page should demonstrate the standardized string format capability instead of older or unconstrained validation examples.

Replace the hand-written IPv4 regex with `format = "ipv4"` and constrain the database host example with `format = "hostname"`.