### PR TITLE
Complete TOML Schema editor support

### DIFF
--- a/.github/extensions/tosd-editor/client.js
+++ b/.github/extensions/tosd-editor/client.js
@@ -35,6 +35,7 @@ const NUMERIC_TEMPORAL = [
     "local-date",
     "local-time",
 ];
+const STRING_FORMATS = ["", "email", "uuid", "uri", "hostname", "ipv4", "ipv6"];
 const state = {
     path: null,
     model: null,
@@ -60,6 +61,13 @@ function resolvedKinds(ref, seen = new Set()) {
     const props = definition.props || {};
     if (props.type) return resolvedKinds(props.type, nextSeen);
     const alternatives = props.oneof?.length ? props.oneof : props.anyof;
+    if (props.if) {
+        const kinds = new Set();
+        for (const branch of [props.then, props.else]) {
+            for (const kind of resolvedKinds(branch, nextSeen)) kinds.add(kind);
+        }
+        return kinds;
+    }
     if (!alternatives?.length && definition.children?.length) return new Set(["table"]);
     const kinds = new Set();
     for (const alternative of alternatives || []) {
@@ -89,7 +97,8 @@ function el(tag, attrs = {}, ...kids) {
 }
 
 // --- Networking ---------------------------------------------------------
-async function load() {
+async function load({ preserveUndo = false } = {}) {
+    const previous = preserveUndo && state.model ? snapshot() : null;
     const res = await fetch("state");
     const data = await res.json();
     state.path = data.path;
@@ -97,6 +106,10 @@ async function load() {
     state.dirty = false;
     state.selected = (state.model.elements[0] || state.model.types[0]) ?? null;
     resetHistory();
+    if (previous) {
+        history.undo.push(previous);
+        updateHistoryButtons();
+    }
     renderAll();
     schedulePreview();
 }
@@ -112,7 +125,7 @@ async function refreshPreview() {
         const res = await fetch("preview", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(state.model),
+            body: JSON.stringify({ path: state.path, model: state.model }),
         });
         const data = await res.json();
         state.lastIssues = data.issues || [];
@@ -120,7 +133,10 @@ async function refreshPreview() {
         renderIssues();
         updateValidityPill();
     } catch (e) {
+        state.lastIssues = [{ level: "error", path: "preview", message: "Preview unavailable: " + e.message }];
         $("#preview").textContent = "// preview error: " + e.message;
+        renderIssues();
+        updateValidityPill("unavailable");
     }
 }
 
@@ -131,7 +147,7 @@ async function save() {
         const res = await fetch("save", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(state.model),
+            body: JSON.stringify({ path: state.path, model: state.model }),
         });
         const data = await res.json();
         if (data.ok) {
@@ -173,7 +189,7 @@ function snapshot() {
     collect(state.model.types);
     collect(state.model.elements);
     return JSON.stringify(
-        { version: state.model.version, meta: state.model.meta, types: state.model.types, elements: state.model.elements },
+        { path: state.path, version: state.model.version, meta: state.model.meta, types: state.model.types, elements: state.model.elements },
         function replacer(k, v) {
             return schemaNodes.has(this) && transientKeys.has(k) ? undefined : v;
         },
@@ -249,6 +265,7 @@ function resolveSelection(ref) {
 function applySnapshot(str) {
     const ref = selectionRef();
     const d = JSON.parse(str);
+    state.path = d.path ?? state.path;
     state.model.version = d.version;
     state.model.meta = d.meta;
     state.model.types = d.types;
@@ -276,6 +293,25 @@ function redo() {
     updateHistoryButtons();
 }
 
+function replaceModel(model, { path = state.path, saved = false, view = "elements" } = {}) {
+    commitHistory();
+    const previous = snapshot();
+    state.path = path;
+    state.model = model;
+    state.view = view;
+    state.selected = (state.model[view]?.[0] || state.model.elements[0] || state.model.types[0]) ?? null;
+    resetHistory(saved);
+    history.undo.push(previous);
+    state.dirty = !saved;
+    renderAll();
+    schedulePreview();
+    updateHistoryButtons();
+}
+
+function confirmReplacement(action) {
+    return !state.dirty || confirm(`Discard unsaved changes and ${action}? You can undo this replacement afterward.`);
+}
+
 function updateHistoryButtons() {
     const u = $("#undo");
     const r = $("#redo");
@@ -291,11 +327,14 @@ function updateStatus(cls, text) {
     $("#save").disabled = !state.dirty;
 }
 
-function updateValidityPill() {
+function updateValidityPill(mode) {
     const errs = state.lastIssues.filter((i) => i.level === "error").length;
     const warns = state.lastIssues.filter((i) => i.level === "warning").length;
     const pill = $("#validity");
-    if (errs > 0) {
+    if (mode === "unavailable") {
+        pill.className = "pill err";
+        pill.textContent = "preview unavailable";
+    } else if (errs > 0) {
         pill.className = "pill err";
         pill.textContent = `${errs} error${errs > 1 ? "s" : ""}`;
     } else if (warns > 0) {
@@ -326,6 +365,7 @@ function typeBadge(node) {
     if (p.type) return BUILTIN_TYPES.includes(p.type) ? p.type : "→ " + p.type.replace(/^types\./, "");
     if (p.oneof) return "oneof";
     if (p.anyof) return "anyof";
+    if (p.if) return "if/then/else";
     if (node.children && node.children.length) return "table";
     return "?";
 }
@@ -334,6 +374,8 @@ function nodeFlags(node) {
     const p = node.props || {};
     const flags = [];
     if ((p.allof || []).length) flags.push({ text: `allof×${p.allof.length}`, title: "Conjunctive type components" });
+    if (p.format) flags.push({ text: p.format, title: `String format: ${p.format}` });
+    if (p.if) flags.push({ text: `if ${p.if.key || "?"}`, title: "Conditional type selection" });
     if (p.uniqueitems === true) flags.push({ text: "unique", title: "Array items must be unique" });
     if (p.default != null && String(p.default).trim() !== "") flags.push({ text: "default", title: "Has a default annotation" });
     if (p.deprecated === true) flags.push({ text: "deprecated", title: "Deprecated annotation", tone: "warn" });
@@ -341,6 +383,12 @@ function nodeFlags(node) {
     if ((p.mutuallyexclusive || []).length) flags.push({ text: `xor×${p.mutuallyexclusive.length}`, title: "Mutually exclusive groups" });
     if ((p.exactlyone || []).length) flags.push({ text: `one×${p.exactlyone.length}`, title: "Exactly-one groups" });
     return flags;
+}
+
+function canNodeHaveChildren(node) {
+    const p = node.props || {};
+    const implicit = !p.type && !p.oneof && !p.anyof && !p.if;
+    return implicit || p.type === "table" || p.type === "collection";
 }
 
 function typeCategory(node) {
@@ -353,7 +401,7 @@ function typeCategory(node) {
     if (t === "table" || t === "collection") return "table";
     if (t === "array") return "array";
     if (t && !BUILTIN_TYPES.includes(t)) return "ref";
-    if (p.oneof || p.anyof) return "choice";
+    if (p.oneof || p.anyof || p.if) return "choice";
     if (node.children && node.children.length) return "table";
     return "any";
 }
@@ -388,6 +436,7 @@ function compositor(node) {
     if (p.type === "array" || p.type === "collection") return { glyph: "\u21bb", cls: "repeat", title: "Repeating items" };
     if (p.oneof) return { glyph: "\u25c8", cls: "choice", title: "One of \u2014 exactly one alternative" };
     if (p.anyof) return { glyph: "\u25c6", cls: "choice", title: "Any of \u2014 at least one alternative" };
+    if (p.if) return { glyph: "?", cls: "choice", title: "Conditional \u2014 select a branch from a child value" };
     if (p.allof) return { glyph: "\u2227", cls: "choice", title: "All of \u2014 every component applies" };
     return { glyph: "\u2630", cls: "sequence", title: "All child fields (sequence)" };
 }
@@ -402,6 +451,7 @@ function unresolvedRefs(node) {
     for (const r of p.oneof || []) refs.push(r);
     for (const r of p.anyof || []) refs.push(r);
     for (const r of p.allof || []) refs.push(r);
+    if (p.if) refs.push(p.then, p.else);
     return refs.filter((r) => r && !isKnownRef(r));
 }
 
@@ -420,6 +470,7 @@ function renderDiagram() {
         const on = b.dataset.view === view;
         b.classList.toggle("active", on);
         b.setAttribute("aria-selected", on ? "true" : "false");
+        b.setAttribute("tabindex", on ? "0" : "-1");
     });
 
     const roots = state.model[view] || [];
@@ -588,6 +639,17 @@ function diagramBox(node, depth = 1) {
             onclick: (e) => { e.stopPropagation(); jumpToType(jumpReference); },
         }));
     }
+    if (p.if) {
+        for (const [label, reference] of [["T", p.then], ["E", p.else]]) {
+            if (!reference) continue;
+            typeLine.append(el("button", {
+                class: "dg-jump",
+                title: `Jump to ${label === "T" ? "then" : "else"} branch ${reference}`,
+                text: "\u2197" + label,
+                onclick: (e) => { e.stopPropagation(); jumpToType(reference); },
+            }));
+        }
+    }
     box.append(typeLine);
 
     const flags = nodeFlags(node);
@@ -612,7 +674,9 @@ function diagramBox(node, depth = 1) {
     }
 
     const acts = el("div", { class: "dg-actions" });
-    acts.append(el("button", { class: "icon", title: "Add child field", "aria-label": "Add child field to " + node.name, text: "+", onclick: (e) => { e.stopPropagation(); addChild(node); } }));
+    if (canNodeHaveChildren(node)) {
+        acts.append(el("button", { class: "icon", title: "Add child field", "aria-label": "Add child field to " + node.name, text: "+", onclick: (e) => { e.stopPropagation(); addChild(node); } }));
+    }
     acts.append(el("button", { class: "icon", title: "Move up", "aria-label": "Move " + node.name + " up", text: "\u2191", onclick: (e) => { e.stopPropagation(); moveNode(node, -1); } }));
     acts.append(el("button", { class: "icon", title: "Move down", "aria-label": "Move " + node.name + " down", text: "\u2193", onclick: (e) => { e.stopPropagation(); moveNode(node, 1); } }));
     acts.append(el("button", { class: "icon danger", title: "Delete " + node.name, "aria-label": "Delete " + node.name, text: "\u2715", onclick: (e) => { e.stopPropagation(); deleteNode(node); } }));
@@ -810,8 +874,13 @@ function renderEditor() {
     }
 
     const p = (node.props = node.props || {});
-    const implicitTable = !p.type && !p.oneof && !p.anyof && (node.children || []).length > 0;
+    const implicitTable = !p.type && !p.oneof && !p.anyof && !p.if && (node.children || []).length > 0;
     const effectiveLocalType = p.type || (implicitTable ? "table" : "");
+    const definitionMode = p.if ? "conditional"
+        : p.oneof ? "oneof"
+            : p.anyof ? "anyof"
+                : implicitTable ? "implicit"
+                    : "type";
 
     // Header: name + actions
     const nameId = uid("name");
@@ -834,7 +903,7 @@ function renderEditor() {
     box.append(header);
 
     const actions = el("div", { class: "field inline" });
-    actions.append(el("button", { text: "+ Add child", onclick: () => addChild(node) }));
+    if (canNodeHaveChildren(node)) actions.append(el("button", { text: "+ Add child", onclick: () => addChild(node) }));
     actions.append(el("button", { class: "danger", text: "Delete", onclick: () => deleteNode(node) }));
     box.append(actions);
 
@@ -852,11 +921,31 @@ function renderEditor() {
     box.append(textField("description", "Description", p.description || "", (v) => setProp(p, "description", v),
         false, "Human-readable documentation for this schema definition."));
 
-    // Current-node type selector
-    box.append(
-        refField("type", "Type", p.type || "", (v) => setProp(p, "type", v),
-            "A built-in type or reusable type reference. Mutually exclusive with oneof/anyof."),
-    );
+    box.append(selectField("Definition mode", definitionMode, ["type", "oneof", "anyof", "conditional", "implicit"],
+        (mode) => setDefinitionMode(node, mode),
+        "Choose one type, an alternative set, a conditional branch, or an implicit table from child fields.",
+        {
+            type: "Single type",
+            oneof: "Exactly one alternative",
+            anyof: "At least one alternative",
+            conditional: "Conditional table shape",
+            implicit: "Implicit table (from children)",
+        }));
+
+    if (definitionMode === "type") {
+        box.append(
+            refField("type", "Type", p.type || "", (v) => setProp(p, "type", v),
+                "A built-in type or reusable type reference."),
+        );
+    } else if (definitionMode === "oneof") {
+        box.append(listField("oneof", "Alternatives", p.oneof || [], (arr) => setListProp(p, "oneof", arr), true,
+            "Exactly one referenced definition must accept the value."));
+    } else if (definitionMode === "anyof") {
+        box.append(listField("anyof", "Alternatives", p.anyof || [], (arr) => setListProp(p, "anyof", arr), true,
+            "At least one referenced definition must accept the value."));
+    } else if (definitionMode === "conditional") {
+        box.append(conditionalField(p));
+    }
 
     box.append(listField("allof", "allof (must also satisfy)", p.allof || [], (arr) => setListProp(p, "allof", arr), true,
         "Additional compatible type references."));
@@ -877,14 +966,11 @@ function renderEditor() {
             "Validate each dynamically keyed collection value against this type."));
     }
 
-    // Current-node alternatives
-    if (!t || p.oneof || p.anyof) {
-        box.append(listField("oneof", "oneof (exactly one)", p.oneof || [], (arr) => setListProp(p, "oneof", arr), true));
-        box.append(listField("anyof", "anyof (at least one)", p.anyof || [], (arr) => setListProp(p, "anyof", arr), true));
-    }
-
     // String pattern and allowed values for scalar types.
     if (t === "string") {
+        box.append(selectField("Format", p.format || "", STRING_FORMATS, (v) => setProp(p, "format", v),
+            "Optional standardized validation for common string forms.",
+            { "": "No format" }));
         box.append(textField("pattern", "Pattern (regex)", p.pattern || "", (v) => setProp(p, "pattern", v), true,
             "Portable RE2-profile regular expression."));
     }
@@ -919,15 +1005,16 @@ function renderEditor() {
     }
 
     if (["table", "collection"].includes(effectiveLocalType)) {
+        const childNames = (node.children || []).map((child) => child.name);
         box.append(dependentRequiredField("dependentrequired", "dependentrequired", p.dependentrequired || {},
             (value) => setMapProp(p, "dependentrequired", value),
-            "When a trigger child is present, every listed child must also be present."));
+            "When a trigger child is present, every selected child must also be present.", childNames));
         box.append(groupListField("mutuallyexclusive", "mutuallyexclusive", p.mutuallyexclusive || [],
             (groups) => setGroupProp(p, "mutuallyexclusive", groups),
-            "At most one child in each group may be present."));
+            "At most one selected child in each group may be present.", childNames));
         box.append(groupListField("exactlyone", "exactlyone", p.exactlyone || [],
             (groups) => setGroupProp(p, "exactlyone", groups),
-            "Exactly one child in each group must be present."));
+            "Exactly one selected child in each group must be present.", childNames));
     }
 
     box.append(tokenField("default", "Default (raw TOML value)", p.default || "", (v) => setProp(p, "default", v),
@@ -937,43 +1024,61 @@ function renderEditor() {
     // optional (always available)
     box.append(checkboxField("optional", "Optional (may be omitted in the document)", p.optional === true, (v) => setBoolProp(p, "optional", v, true)));
 
-    // Show-all advanced toggle
-    const toggle = el("button", {
-        class: "toggle-all",
-        text: state.showAll ? "Hide advanced properties" : "Show all properties",
-        onclick: () => {
-            state.showAll = !state.showAll;
-            renderEditor();
-        },
-    });
-    box.append(toggle);
-    if (state.showAll) box.append(advancedAll(p));
-
     if (effectiveLocalType === "table") {
         box.append(el("div", { class: "field hint", text: "Table fields are managed as children in the tree. A table with no children is treated as open-ended." }));
     }
 }
 
-function advancedAll(p) {
-    const wrap = el("div");
-    wrap.append(el("div", { class: "section-title", text: "All properties" }));
-    const allProps = ["type", "description", "itemtype", "pattern", "keypattern", "min", "max", "default"];
-    for (const key of allProps) {
-        wrap.append((key === "default")
-            ? tokenField(key, key, p[key] != null ? String(p[key]) : "", (v) => setProp(p, key, v))
-            : textField(key, key, p[key] != null ? String(p[key]) : "", (v) => setProp(p, key, v), true));
+function setDefinitionMode(node, mode) {
+    const p = node.props || (node.props = {});
+    for (const key of ["type", "oneof", "anyof", "if", "then", "else"]) delete p[key];
+    if (mode === "type") p.type = "string";
+    else if (mode === "oneof") p.oneof = ["string"];
+    else if (mode === "anyof") p.anyof = ["string"];
+    else if (mode === "conditional") {
+        p.if = { key: "", equals: '""' };
+        p.then = "";
+        p.else = "";
     }
-    for (const key of ["minlength", "maxlength"]) {
-        wrap.append(numField(key, key, p[key], (v) => setNumProp(p, key, v)));
+    markDirty();
+    renderEditor();
+    renderTree();
+}
+
+function conditionalField(p) {
+    const wrap = el("fieldset", { class: "condition-builder", "data-prop": "if" });
+    wrap.append(el("legend", { text: "Conditional table shape" }));
+    wrap.append(textField("if.key", "Discriminator child", p.if?.key || "", (value) => {
+        p.if = { ...(p.if || { equals: '""' }), key: value };
+        markDirty();
+        renderTree();
+    }, true, "A direct child key of the current table."));
+    const mode = Object.prototype.hasOwnProperty.call(p.if || {}, "in") ? "in" : "equals";
+    wrap.append(selectField("Condition", mode, ["equals", "in"], (value) => {
+        p.if = value === "in"
+            ? { key: p.if?.key || "", in: ['""'] }
+            : { key: p.if?.key || "", equals: '""' };
+        markDirty();
+        renderEditor();
+    }, "Choose whether the child equals one value or belongs to a set.", {
+        equals: "Equals",
+        in: "Is one of",
+    }));
+    if (mode === "equals") {
+        wrap.append(tokenField("if.equals", "Comparison value", p.if?.equals || "", (value) => {
+            p.if = { key: p.if?.key || "", equals: value };
+            markDirty();
+        }, "A TOML value token, such as \"sqlite\" or 3."));
+    } else {
+        wrap.append(listField("if.in", "Comparison values", p.if?.in || [], (values) => {
+            p.if = { key: p.if?.key || "", in: values };
+            markDirty();
+        }, false, "A non-empty set of TOML value tokens."));
     }
-    for (const key of ["items", "oneof", "anyof", "allof", "allowedvalues"]) {
-        wrap.append(listField(key, key, p[key] || [], (arr) => setListProp(p, key, arr), key !== "allowedvalues"));
-    }
-    wrap.append(dependentRequiredField("dependentrequired", "dependentrequired", p.dependentrequired || {}, (value) => setMapProp(p, "dependentrequired", value)));
-    wrap.append(groupListField("mutuallyexclusive", "mutuallyexclusive", p.mutuallyexclusive || [], (groups) => setGroupProp(p, "mutuallyexclusive", groups)));
-    wrap.append(groupListField("exactlyone", "exactlyone", p.exactlyone || [], (groups) => setGroupProp(p, "exactlyone", groups)));
-    wrap.append(checkboxField("uniqueitems", "uniqueitems", p.uniqueitems === true, (v) => setBoolProp(p, "uniqueitems", v)));
-    wrap.append(checkboxField("deprecated", "deprecated", p.deprecated === true, (v) => setBoolProp(p, "deprecated", v)));
+    wrap.append(refField("then", "Then branch", p.then || "", (value) => setProp(p, "then", value),
+        "Named reusable table or collection definition used when the condition matches."));
+    wrap.append(refField("else", "Else branch", p.else || "", (value) => setProp(p, "else", value),
+        "Named reusable table or collection definition used when the condition does not match."));
     return wrap;
 }
 
@@ -1051,7 +1156,7 @@ function markRefValidity(input, msgEl) {
 
 function textField(name, label, value, onchange, mono = false, hint) {
     const id = uid("in");
-    const f = el("div", { class: "field" });
+    const f = el("div", { class: "field", "data-prop": name });
     f.append(labelEl(label, hint, id));
     f.append(el("input", {
         type: "text",
@@ -1066,7 +1171,7 @@ function textField(name, label, value, onchange, mono = false, hint) {
 
 function tokenField(name, label, value, onchange, hint) {
     const id = uid("tok");
-    const f = el("div", { class: "field" });
+    const f = el("div", { class: "field", "data-prop": name });
     f.append(labelEl(label, hint, id));
     f.append(el("textarea", {
         id,
@@ -1080,7 +1185,7 @@ function tokenField(name, label, value, onchange, hint) {
 
 function numField(name, label, value, onchange) {
     const id = uid("num");
-    const f = el("div", { class: "field" });
+    const f = el("div", { class: "field", "data-prop": name });
     f.append(labelEl(label, null, id));
     f.append(el("input", {
         type: "number",
@@ -1092,13 +1197,13 @@ function numField(name, label, value, onchange) {
     return f;
 }
 
-function selectField(label, value, options, onchange, hint) {
+function selectField(label, value, options, onchange, hint, labels = {}) {
     const id = uid("sel");
-    const f = el("div", { class: "field" });
+    const f = el("div", { class: "field", "data-prop": label.toLowerCase().replace(/\s+/g, "-") });
     f.append(labelEl(label, hint, id));
     const sel = el("select", { id, onchange: (e) => onchange(e.target.value) });
     for (const opt of options) {
-        const o = el("option", { value: opt, text: opt === "" ? "(none)" : opt });
+        const o = el("option", { value: opt, text: labels[opt] || (opt === "" ? "(none)" : opt) });
         if (opt === value) o.selected = true;
         sel.append(o);
     }
@@ -1108,7 +1213,7 @@ function selectField(label, value, options, onchange, hint) {
 
 function checkboxField(name, label, checked, onchange) {
     const id = uid("chk");
-    const f = el("div", { class: "field inline" });
+    const f = el("div", { class: "field inline", "data-prop": name });
     const cb = el("input", { type: "checkbox", id, onchange: (e) => onchange(e.target.checked) });
     cb.checked = checked;
     f.append(cb);
@@ -1119,7 +1224,7 @@ function checkboxField(name, label, checked, onchange) {
 function refField(name, label, value, onchange, hint) {
     const id = uid("ref");
     const errId = uid("err");
-    const f = el("div", { class: "field" });
+    const f = el("div", { class: "field", "data-prop": name });
     f.append(labelEl(label, hint, id));
     const msg = el("div", { class: "field-err", id: errId, role: "alert" });
     const input = el("input", {
@@ -1139,7 +1244,7 @@ function refField(name, label, value, onchange, hint) {
 }
 
 function listField(name, label, values, onchange, isRef, hint) {
-    const f = el("div", { class: "field" });
+    const f = el("div", { class: "field", "data-prop": name });
     const groupId = uid("list");
     f.append(labelEl(label, hint, null, groupId));
     const arr = [...values];
@@ -1193,8 +1298,8 @@ function listField(name, label, values, onchange, isRef, hint) {
     return f;
 }
 
-function groupListField(name, label, groups, onchange, hint) {
-    const f = el("div", { class: "field" });
+function groupListField(name, label, groups, onchange, hint, childNames = []) {
+    const f = el("div", { class: "field", "data-prop": name });
     const groupId = uid("groups");
     f.append(labelEl(label, hint, null, groupId));
     const arr = groups.map((group) => [...group]);
@@ -1202,17 +1307,11 @@ function groupListField(name, label, groups, onchange, hint) {
     const rerender = () => {
         container.textContent = "";
         arr.forEach((group, idx) => {
-            const row = el("div", { class: "list-row" });
-            row.append(el("input", {
-                type: "text",
-                class: "mono",
-                value: group.join(", "),
-                placeholder: "child-a, child-b",
-                "aria-label": `${label} group ${idx + 1}`,
-                oninput: (e) => {
-                    arr[idx] = csvNames(e.target.value);
-                    onchange(arr.map((item) => [...item]));
-                },
+            const row = el("div", { class: "list-row relationship-row" });
+            row.append(childMultiSelect(childNames, group, `${label} group ${idx + 1}`, (values) => {
+                arr[idx] = values;
+                onchange(arr.map((item) => [...item]));
+                summary.textContent = relationshipSummary(label, values);
             }));
             row.append(el("button", {
                 class: "icon danger",
@@ -1226,6 +1325,8 @@ function groupListField(name, label, groups, onchange, hint) {
                 },
             }));
             container.append(row);
+            const summary = el("div", { class: "relationship-summary", text: relationshipSummary(label, group) });
+            container.append(summary);
         });
     };
     rerender();
@@ -1243,8 +1344,8 @@ function groupListField(name, label, groups, onchange, hint) {
     return f;
 }
 
-function dependentRequiredField(name, label, mapping, onchange, hint) {
-    const f = el("div", { class: "field" });
+function dependentRequiredField(name, label, mapping, onchange, hint, childNames = []) {
+    const f = el("div", { class: "field", "data-prop": name });
     const groupId = uid("deps");
     f.append(labelEl(label, hint, null, groupId));
     const entries = Object.entries(mapping || {}).map(([trigger, values]) => [trigger, [...values]]);
@@ -1253,28 +1354,26 @@ function dependentRequiredField(name, label, mapping, onchange, hint) {
     const rerender = () => {
         container.textContent = "";
         entries.forEach((entry, idx) => {
-            const row = el("div", { class: "list-row list-row-2" });
-            row.append(el("input", {
-                type: "text",
-                class: "mono",
-                value: entry[0],
-                placeholder: "trigger child",
+            const row = el("div", { class: "list-row list-row-2 relationship-row" });
+            const trigger = el("select", {
                 "aria-label": `${label} trigger ${idx + 1}`,
-                oninput: (e) => {
+                onchange: (e) => {
                     entries[idx][0] = e.target.value;
                     emit();
+                    summary.textContent = dependencySummary(entries[idx]);
                 },
-            }));
-            row.append(el("input", {
-                type: "text",
-                class: "mono",
-                value: entry[1].join(", "),
-                placeholder: "required-a, required-b",
-                "aria-label": `${label} required children ${idx + 1}`,
-                oninput: (e) => {
-                    entries[idx][1] = csvNames(e.target.value);
-                    emit();
-                },
+            });
+            const triggerOptions = [...new Set(["", ...childNames, entry[0]].filter((value, index) => value !== "" || index === 0))];
+            for (const child of triggerOptions) {
+                const option = el("option", { value: child, text: child || "Select trigger child" });
+                option.selected = child === entry[0];
+                trigger.append(option);
+            }
+            row.append(trigger);
+            row.append(childMultiSelect(childNames, entry[1], `${label} required children ${idx + 1}`, (values) => {
+                entries[idx][1] = values;
+                emit();
+                summary.textContent = dependencySummary(entries[idx]);
             }));
             row.append(el("button", {
                 class: "icon danger",
@@ -1288,6 +1387,8 @@ function dependentRequiredField(name, label, mapping, onchange, hint) {
                 },
             }));
             container.append(row);
+            const summary = el("div", { class: "relationship-summary", text: dependencySummary(entry) });
+            container.append(summary);
         });
     };
     rerender();
@@ -1305,11 +1406,30 @@ function dependentRequiredField(name, label, mapping, onchange, hint) {
     return f;
 }
 
-function csvNames(value) {
-    return String(value)
-        .split(",")
-        .map((part) => part.trim())
-        .filter(Boolean);
+function childMultiSelect(childNames, selected, label, onchange) {
+    const select = el("select", { multiple: "", size: "3", "aria-label": label });
+    const options = [...new Set([...childNames, ...selected])];
+    for (const child of options) {
+        const option = el("option", { value: child, text: child });
+        option.selected = selected.includes(child);
+        select.append(option);
+    }
+    select.addEventListener("change", () => {
+        onchange([...select.selectedOptions].map((option) => option.value));
+    });
+    return select;
+}
+
+function relationshipSummary(label, values) {
+    if (!values.length) return "Select at least two child fields.";
+    return label === "exactlyone"
+        ? `Require exactly one of ${values.join(", ")}.`
+        : `Allow at most one of ${values.join(", ")}.`;
+}
+
+function dependencySummary([trigger, required]) {
+    if (!trigger || !required.length) return "Select a trigger and one or more required child fields.";
+    return `When ${trigger} is present, require ${required.join(", ")}.`;
 }
 
 function labelEl(text, hint, forId, id) {
@@ -1407,12 +1527,39 @@ function renderIssues() {
     const box = $("#issues");
     box.textContent = "";
     for (const issue of state.lastIssues) {
-        const row = el("div", { class: "issue " + issue.level, role: "listitem" });
+        const row = el("button", {
+            class: "issue " + issue.level,
+            role: "listitem",
+            title: "Go to this issue",
+            onclick: () => focusIssue(issue),
+        });
         row.append(el("span", { class: "lvl", text: issue.level === "error" ? "ERROR" : "WARN" }));
         row.append(el("span", { text: issue.message }));
         row.append(el("span", { class: "where mono", text: issue.path }));
         box.append(row);
     }
+}
+
+function focusIssue(issue) {
+    const parts = String(issue.path || "").split(".");
+    const view = parts[0];
+    if (!["elements", "types"].includes(view)) return;
+    let path = parts.slice(1);
+    let selected = null;
+    while (path.length && !selected) {
+        selected = resolveSelection({ view, path });
+        if (!selected) path = path.slice(0, -1);
+    }
+    if (!selected) return;
+    state.view = view;
+    state.selected = selected;
+    renderDiagram();
+    renderEditor();
+    const property = /`([^`]+)`/.exec(issue.message)?.[1]?.split(".")[0];
+    const target = property
+        ? document.querySelector(`#editor [data-prop="${CSS.escape(property)}"] input, #editor [data-prop="${CSS.escape(property)}"] select, #editor [data-prop="${CSS.escape(property)}"] textarea`)
+        : document.querySelector("#editor input, #editor select, #editor textarea");
+    target?.focus();
 }
 
 // --- Boot ---------------------------------------------------------------
@@ -1464,8 +1611,8 @@ function boot() {
       <div class="diagram-pane">
         <div class="diagram-bar">
           <div class="view-tabs" role="tablist" aria-label="Schema view">
-            <button class="vtab active" data-view="elements" role="tab" aria-selected="true">Elements</button>
-            <button class="vtab" data-view="types" role="tab" aria-selected="false">Types</button>
+            <button class="vtab active" data-view="elements" role="tab" aria-selected="true" aria-controls="diagram" tabindex="0">Elements</button>
+            <button class="vtab" data-view="types" role="tab" aria-selected="false" aria-controls="diagram" tabindex="-1">Types</button>
           </div>
           <button id="dg-add" class="icon" title="Add a top-level entry to this view">+ Add</button>
           <button id="dg-meta" class="icon" title="Edit [toml-schema] metadata">&#9881; Metadata</button>
@@ -1498,7 +1645,9 @@ function boot() {
     <datalist id="type-refs"></datalist>`;
 
     $("#save").addEventListener("click", save);
-    $("#revert").addEventListener("click", load);
+    $("#revert").addEventListener("click", () => {
+        if (confirmReplacement("reload the file from disk")) load({ preserveUndo: true });
+    });
     $("#new").addEventListener("click", newSchema);
     $("#open").addEventListener("click", openSchema);
     $("#generate").addEventListener("click", openGenerateModal);
@@ -1508,8 +1657,10 @@ function boot() {
     $("#add-type").addEventListener("click", () => { state.view = "types"; addNode(state.model.types, ["types"]); });
     $("#add-element").addEventListener("click", () => { state.view = "elements"; addNode(state.model.elements, ["elements"]); });
 
-    document.querySelectorAll(".vtab").forEach((b) =>
-        b.addEventListener("click", () => { state.view = b.dataset.view; renderDiagram(); }));
+    document.querySelectorAll(".vtab").forEach((b) => {
+        b.addEventListener("click", () => { state.view = b.dataset.view; renderDiagram(); });
+        b.addEventListener("keydown", onViewTabKeydown);
+    });
     $("#dg-add").addEventListener("click", () => addNode(state.model[state.view], [state.view]));
     $("#dg-meta").addEventListener("click", () => { state.selected = "__meta__"; renderEditor(); renderDiagram(); });
     $("#zoom-in").addEventListener("click", () => setZoom((state.zoom || 1) + 0.1));
@@ -1528,6 +1679,18 @@ function boot() {
     setupPanning();
 
     load();
+}
+
+function onViewTabKeydown(event) {
+    if (!["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) return;
+    event.preventDefault();
+    const tabs = [...document.querySelectorAll(".vtab")];
+    const current = tabs.indexOf(event.currentTarget);
+    const next = event.key === "Home" ? 0
+        : event.key === "End" ? tabs.length - 1
+            : (current + (event.key === "ArrowRight" ? 1 : -1) + tabs.length) % tabs.length;
+    tabs[next].click();
+    tabs[next].focus();
 }
 
 function onGlobalKeydown(e) {
@@ -1706,12 +1869,11 @@ function closeModal(overlay) {
 
 // --- New (empty) schema -------------------------------------------------
 function newSchema() {
-    if (state.dirty && !confirm("Discard unsaved changes and start a new schema?")) return;
-    state.model = { version: "1.0.0", meta: null, types: [], elements: [] };
+    if (!confirmReplacement("start a new schema")) return;
+    replaceModel({ version: "1.0.0", meta: null, types: [], elements: [] }, { saved: false });
     state.selected = "__meta__";
-    resetHistory(false);
-    markDirty();
-    renderAll();
+    renderEditor();
+    renderDiagram();
 }
 
 // --- Generate-with-Copilot modal ---------------------------------------
@@ -1734,11 +1896,27 @@ function openGenerateModal() {
 
     const errBox = el("div", { class: "modal-err", role: "alert" });
     dialog.append(errBox);
+    const draftPreview = el("pre", { class: "modal-draft mono", hidden: "", tabindex: "0", "aria-label": "Generated schema preview" });
+    dialog.append(draftPreview);
 
     const actions = el("div", { class: "modal-actions" });
     const cancelBtn = el("button", { text: "Cancel", onclick: () => closeModal(overlay) });
     const genBtn = el("button", { class: "primary", text: "Generate" });
+    let generated = null;
+    ta.addEventListener("input", () => {
+        if (!generated) return;
+        generated = null;
+        draftPreview.hidden = true;
+        genBtn.textContent = "Generate";
+        errBox.textContent = "";
+    });
     genBtn.addEventListener("click", async () => {
+        if (generated) {
+            if (!confirmReplacement("apply the generated schema")) return;
+            replaceModel(generated.model, { saved: false });
+            closeModal(overlay);
+            return;
+        }
         const description = ta.value.trim();
         if (!description) { errBox.className = "modal-err"; errBox.textContent = "Describe the configuration first."; ta.focus(); return; }
         genBtn.disabled = true;
@@ -1759,13 +1937,14 @@ function openGenerateModal() {
                 ta.disabled = false;
                 return;
             }
-            state.model = data.model;
-            state.view = "elements";
-            state.selected = (state.model.elements[0] || state.model.types[0]) ?? null;
-            resetHistory(false);
-            markDirty();
-            renderAll();
-            closeModal(overlay);
+            generated = data;
+            draftPreview.textContent = data.tosd || "";
+            draftPreview.hidden = false;
+            errBox.className = "modal-err";
+            errBox.textContent = "Review the generated schema, then apply it when ready.";
+            genBtn.textContent = "Apply schema";
+            genBtn.disabled = false;
+            ta.disabled = false;
         } catch (e) {
             if (modalRequestCancelled(e, overlay)) return;
             errBox.className = "modal-err";
@@ -1800,6 +1979,7 @@ function openSchema() {
     const doOpen = async (input, openBtn) => {
         const p = input.value.trim();
         if (!p) { errBox.className = "modal-err"; errBox.textContent = "Enter a file path."; input.focus(); return; }
+        if (!confirmReplacement("open another schema")) return;
         errBox.className = "modal-err working";
         errBox.textContent = "Opening\u2026";
         if (openBtn) openBtn.disabled = true;
@@ -1811,13 +1991,7 @@ function openSchema() {
             });
             if (!data) return;
             if (data.error) { errBox.className = "modal-err"; errBox.textContent = data.error; if (openBtn) openBtn.disabled = false; return; }
-            state.path = data.path;
-            state.model = data.model;
-            state.dirty = false;
-            state.selected = (state.model.elements[0] || state.model.types[0]) ?? null;
-            resetHistory();
-            renderAll();
-            schedulePreview();
+            replaceModel(data.model, { path: data.path, saved: true });
             closeModal(overlay);
         } catch (e) {
             if (modalRequestCancelled(e, overlay)) return;
@@ -1871,6 +2045,7 @@ function openInferModal() {
             if (!data) return;
             if (data.error) { errBox.className = "modal-err"; errBox.textContent = data.error; return; }
             ta.value = data.content;
+            clearInferredDraft();
             errBox.className = "modal-err";
             errBox.textContent = "";
         } catch (e) {
@@ -1887,11 +2062,28 @@ function openInferModal() {
 
     const errBox = el("div", { class: "modal-err", role: "alert" });
     dialog.append(errBox);
+    const draftPreview = el("pre", { class: "modal-draft mono", hidden: "", tabindex: "0", "aria-label": "Inferred schema preview" });
+    dialog.append(draftPreview);
 
     const actions = el("div", { class: "modal-actions" });
     actions.append(el("button", { text: "Cancel", onclick: () => closeModal(overlay) }));
     const inferBtn = el("button", { class: "primary", text: "Infer schema" });
+    let inferred = null;
+    const clearInferredDraft = () => {
+        if (!inferred) return;
+        inferred = null;
+        draftPreview.hidden = true;
+        inferBtn.textContent = "Infer schema";
+        errBox.textContent = "";
+    };
+    ta.addEventListener("input", clearInferredDraft);
     inferBtn.addEventListener("click", async () => {
+        if (inferred) {
+            if (!confirmReplacement("apply the inferred schema")) return;
+            replaceModel(inferred.model, { saved: false });
+            closeModal(overlay);
+            return;
+        }
         const toml = ta.value;
         if (!toml.trim()) { errBox.className = "modal-err"; errBox.textContent = "Provide some TOML to infer from."; ta.focus(); return; }
         inferBtn.disabled = true;
@@ -1905,12 +2097,13 @@ function openInferModal() {
             });
             if (!data) return;
             if (data.error) { errBox.className = "modal-err"; errBox.textContent = data.error; inferBtn.disabled = false; return; }
-            state.model = data.model;
-            state.selected = (state.model.elements[0] || state.model.types[0]) ?? null;
-            resetHistory(false);
-            markDirty();
-            renderAll();
-            closeModal(overlay);
+            inferred = data;
+            draftPreview.textContent = data.tosd || "";
+            draftPreview.hidden = false;
+            errBox.className = "modal-err";
+            errBox.textContent = "Review the inferred schema, then apply it when ready.";
+            inferBtn.textContent = "Apply schema";
+            inferBtn.disabled = false;
         } catch (e) {
             if (modalRequestCancelled(e, overlay)) return;
             errBox.className = "modal-err";

--- a/.github/extensions/tosd-editor/extension.mjs
+++ b/.github/extensions/tosd-editor/extension.mjs
@@ -92,7 +92,9 @@ function buildGeneratePrompt(desc) {
         "- Describe the document's top-level structure under [elements]; use nested tables like [elements.<name>.<child>] for sub-tables.",
         '- Put reusable definitions under [types.<name>] and reference them with type = "types.<name>". Use itemtype = "types.<name>" for array and collection members.',
         "- Keep `type`, `oneof`, and `anyof` as mutually exclusive selectors. Use `allof` only as an additive list of compatible type references.",
-        "- Use only TOML Schema property keys: type (string, integer, float, boolean, offset-date-time, local-date-time, local-date, local-time, array, table, collection), optional, min, max, minlength, maxlength, pattern, keypattern, allowedvalues, itemtype, items, oneof, anyof, allof, uniqueitems, dependentrequired, mutuallyexclusive, exactlyone, default, deprecated, description.",
+        "- Use only TOML Schema property keys: type (any, string, integer, float, boolean, offset-date-time, local-date-time, local-date, local-time, array, table, collection), optional, min, max, minlength, maxlength, pattern, format, keypattern, allowedvalues, itemtype, items, oneof, anyof, if, then, else, allof, uniqueitems, dependentrequired, mutuallyexclusive, exactlyone, default, deprecated, description.",
+        '- For standardized strings, use format = "email", "uuid", "uri", "hostname", "ipv4", or "ipv6" when appropriate.',
+        "- For a table shape selected by a direct child value, define reusable table or collection branches under [types], then use if = { key = \"...\", equals = ... } (or in = [ ... ]) together with named then and else references.",
         "- Mark fields that may be omitted with optional = true; everything is required by default.",
     ].join("\n");
 }
@@ -162,6 +164,19 @@ const INDEX_HTML = `<!doctype html>
 
 async function startServer(instanceId, entry) {
     const server = createServer(async (req, res) => {
+        const address = server.address();
+        const port = typeof address === "object" && address ? address.port : 0;
+        const expectedHost = `127.0.0.1:${port}`;
+        if (req.headers.host !== expectedHost) {
+            res.writeHead(403);
+            res.end("forbidden");
+            return;
+        }
+        if (req.method === "POST" && req.headers.origin !== `http://${expectedHost}`) {
+            res.writeHead(403);
+            res.end("forbidden");
+            return;
+        }
         const url = new URL(req.url, "http://127.0.0.1");
         const path = url.pathname;
         try {
@@ -178,7 +193,10 @@ async function startServer(instanceId, entry) {
             }
 
             if (req.method === "POST" && path === "/preview") {
-                const model = JSON.parse(await readBody(req));
+                const body = JSON.parse(await readBody(req));
+                const model = body.model || body;
+                const previewPath = resolvePath(body.path);
+                if (previewPath && entry.approvedPaths.has(previewPath)) entry.path = previewPath;
                 entry.model = model;
                 let toml = "";
                 let error = null;
@@ -200,6 +218,7 @@ async function startServer(instanceId, entry) {
                 try {
                     const text = await readFile(target, "utf8");
                     const model = parseDocument(text);
+                    entry.approvedPaths.add(target);
                     entry.path = target;
                     entry.model = model;
                     return sendJson(res, 200, { ok: true, path: target, model });
@@ -228,7 +247,7 @@ async function startServer(instanceId, entry) {
                         tomlText = await readFile(target, "utf8");
                     }
                     const model = inferModelFromToml(tomlText || "");
-                    return sendJson(res, 200, { model });
+                    return sendJson(res, 200, { model, tosd: serializeDocument(model) });
                 } catch (e) {
                     return sendJson(res, 200, { error: e.message });
                 }
@@ -245,9 +264,14 @@ async function startServer(instanceId, entry) {
             }
 
             if (req.method === "POST" && path === "/save") {
-                const model = JSON.parse(await readBody(req));
+                const body = JSON.parse(await readBody(req));
+                const model = body.model || body;
+                const requestedPath = resolvePath(body.path) || entry.path;
                 entry.model = model;
-                if (!entry.path) return sendJson(res, 200, { ok: false, error: "no file path for this schema" });
+                if (!requestedPath) return sendJson(res, 200, { ok: false, error: "no file path for this schema" });
+                if (!requestedPath.endsWith(".tosd") || !entry.approvedPaths.has(requestedPath)) {
+                    return sendJson(res, 403, { ok: false, error: "Saving is allowed only to a .tosd file opened by this editor." });
+                }
                 try {
                     const errors = validateModel(model).filter((issue) => issue.level === "error");
                     if (errors.length) {
@@ -257,7 +281,8 @@ async function startServer(instanceId, entry) {
                         });
                     }
                     const toml = serializeDocument(model);
-                    await writeFile(entry.path, toml, "utf8");
+                    await writeFile(requestedPath, toml, "utf8");
+                    entry.path = requestedPath;
                     return sendJson(res, 200, { ok: true, path: entry.path });
                 } catch (e) {
                     return sendJson(res, 200, { ok: false, error: e.message });
@@ -387,7 +412,7 @@ const canvas = createCanvas({
             const inputPath = ctx.input && ctx.input.path;
             const filePath = resolvePath(inputPath) || (await findDefaultTosd());
             const model = await loadModelForPath(filePath);
-            entry = { server: null, url: null, path: filePath, model };
+            entry = { server: null, url: null, path: filePath, model, approvedPaths: new Set([filePath]) };
             instances.set(ctx.instanceId, entry);
             await startServer(ctx.instanceId, entry);
             session.log(`tosd-editor: editing ${filePath}`, { level: "info", ephemeral: true });

--- a/.github/extensions/tosd-editor/model.mjs
+++ b/.github/extensions/tosd-editor/model.mjs
@@ -11,11 +11,12 @@
 // node = { name, props: { <prop>: <editorValue> }, children: [ node, ... ] }
 //
 // Editor value encoding per property:
-//   type/itemtype/description/pattern/keypattern : plain string
+//   type/itemtype/description/format/pattern/keypattern/then/else : plain string
 //   optional/uniqueitems/deprecated              : boolean
 //   minlength/maxlength                          : number
 //   items/oneof/anyof/allof                      : string[]
 //   allowedvalues                                : string[]  (TOML value tokens)
+//   if                                           : { key, equals } | { key, in[] }
 //   dependentrequired                            : { trigger: string[] }
 //   mutuallyexclusive/exactlyone                 : string[][]
 //   min/max/default                              : string    (TOML value token)
@@ -29,14 +30,19 @@ import {
     isPlainTable,
     tableCollisions,
 } from "./toml.mjs";
+import { isIP } from "node:net";
 
 export const PROP_ORDER = [
     "type",
     "description",
+    "format",
     "itemtype",
     "items",
     "oneof",
     "anyof",
+    "if",
+    "then",
+    "else",
     "allof",
     "allowedvalues",
     "pattern",
@@ -54,7 +60,7 @@ export const PROP_ORDER = [
     "optional",
 ];
 
-const STRING_PROPS = new Set(["type", "description", "itemtype", "pattern", "keypattern"]);
+const STRING_PROPS = new Set(["type", "description", "format", "itemtype", "pattern", "keypattern", "then", "else"]);
 const INT_PROPS = new Set(["minlength", "maxlength"]);
 const BOOL_PROPS = new Set(["optional", "uniqueitems", "deprecated"]);
 const REFLIST_PROPS = new Set(["items", "oneof", "anyof", "allof"]);
@@ -62,6 +68,7 @@ const GROUPLIST_PROPS = new Set(["mutuallyexclusive", "exactlyone"]);
 const MAPLIST_PROPS = new Set(["dependentrequired"]);
 const VALUELIST_PROPS = new Set(["allowedvalues"]);
 const VALUE_PROPS = new Set(["min", "max", "default"]);
+const CONDITIONAL_PROPS = new Set(["if"]);
 
 const ALL_PROPS = new Set(PROP_ORDER);
 
@@ -140,7 +147,23 @@ function tableToNode(name, table, path) {
     const node = { name, props: {}, children: [] };
     for (const [key, value] of Object.entries(table)) {
         if (isPlainTable(value)) {
-            node.children.push(tableToNode(key, value, `${path}.${key}`));
+            const escapedChildren = key === "children"
+                && !["type", "oneof", "anyof", "if"].some((selector) =>
+                    Object.prototype.hasOwnProperty.call(value, selector)
+                    && !isPlainTable(value[selector]));
+            if (escapedChildren) {
+                for (const [childName, childValue] of Object.entries(value)) {
+                    if (!ALL_PROPS.has(childName) && childName !== "children") {
+                        throw new TomlError(`${path}.children may escape only schema-property child names; found ${childName}.`);
+                    }
+                    if (!isPlainTable(childValue)) {
+                        throw new TomlError(`${path}.children.${childName} must be a schema definition table.`);
+                    }
+                    node.children.push(tableToNode(childName, childValue, `${path}.children.${childName}`));
+                }
+            } else {
+                node.children.push(tableToNode(key, value, `${path}.${key}`));
+            }
         } else if (ALL_PROPS.has(key)) {
             node.props[key] = decodeProp(key, value, path);
         } else {
@@ -195,8 +218,28 @@ function decodeProp(key, value, path) {
         if (!Array.isArray(value)) throw new TomlError(`${path}.${key} must be an array.`);
         return value.map(formatValue);
     }
+    if (CONDITIONAL_PROPS.has(key)) return decodeConditional(value, path);
     if (VALUE_PROPS.has(key)) return formatValue(value);
     return formatValue(value);
+}
+
+function decodeConditional(value, path) {
+    const inner = value && value.__inline ? value.value : value;
+    if (!isPlainTable(inner)) throw new TomlError(`${path}.if must be an inline table.`);
+    const keys = Object.keys(inner);
+    if (keys.some((key) => !["key", "equals", "in"].includes(key))) {
+        throw new TomlError(`${path}.if may contain only key and exactly one of equals or in.`);
+    }
+    if (typeof inner.key !== "string") throw new TomlError(`${path}.if.key must be a string.`);
+    const hasEquals = Object.prototype.hasOwnProperty.call(inner, "equals");
+    const hasIn = Object.prototype.hasOwnProperty.call(inner, "in");
+    if (hasEquals === hasIn) throw new TomlError(`${path}.if must define exactly one of equals or in.`);
+    if (hasIn && (!Array.isArray(inner.in) || inner.in.length === 0)) {
+        throw new TomlError(`${path}.if.in must be a non-empty array.`);
+    }
+    return hasEquals
+        ? { key: inner.key, equals: formatValue(inner.equals) }
+        : { key: inner.key, in: inner.in.map(formatValue) };
 }
 
 function decodeGroupList(value) {
@@ -264,7 +307,10 @@ function emitNode(node, parentPath, depth, lines) {
 
     for (const child of node.children || []) {
         lines.push("");
-        emitNode(child, path, depth + 1, lines);
+        const childParent = ALL_PROPS.has(child.name) || child.name === "children"
+            ? [...path, "children"]
+            : path;
+        emitNode(child, childParent, depth + 1, lines);
     }
 }
 
@@ -287,8 +333,23 @@ function encodeProp(key, raw) {
             .filter((v) => v !== undefined);
         return arr;
     }
+    if (CONDITIONAL_PROPS.has(key)) return encodeConditional(raw);
     if (VALUE_PROPS.has(key)) return parseTokenForEmit(raw);
     return parseTokenForEmit(raw);
+}
+
+function encodeConditional(raw) {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+    const key = String(raw.key ?? "");
+    if (Object.prototype.hasOwnProperty.call(raw, "equals")) {
+        const equals = parseTokenForEmit(raw.equals);
+        if (equals === undefined) return undefined;
+        return { __inline: true, value: { key, equals } };
+    }
+    const values = (Array.isArray(raw.in) ? raw.in : [])
+        .map((token) => parseTokenForEmit(token))
+        .filter((value) => value !== undefined);
+    return values.length ? { __inline: true, value: { key, in: values } } : undefined;
 }
 
 function encodeBoolean(raw) {
@@ -408,6 +469,10 @@ const SIMPLE_TYPES = new Set([
     "local-date",
     "local-time",
 ]);
+const STRING_FORMATS = new Set(["email", "uuid", "uri", "hostname", "ipv4", "ipv6"]);
+const URI_HEX = /^[0-9A-Fa-f]+$/;
+const URI_UNRESERVED = "A-Za-z0-9._~\\-";
+const URI_SUB_DELIMS = "!$&'()*+,;=";
 
 const SEMVER_RE =
     /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
@@ -465,6 +530,166 @@ function patternIssue(pattern) {
         return { level: "warning", message: "uses syntax outside the portable RE2 profile" };
     }
     return null;
+}
+
+function isAscii(value) {
+    return /^[\x00-\x7f]*$/.test(value);
+}
+
+function isIpv4(value) {
+    const parts = value.split(".");
+    return parts.length === 4 && parts.every((part) =>
+        /^(?:0|[1-9][0-9]{0,2})$/.test(part) && Number(part) <= 255);
+}
+
+function isIpv6(value) {
+    if (!isAscii(value) || value.includes("%") || isIP(value) !== 6) return false;
+    const dotted = value.lastIndexOf(":");
+    return !value.includes(".") || (dotted >= 0 && isIpv4(value.slice(dotted + 1)));
+}
+
+function isHostname(value, allowTrailingDot = true) {
+    if (!isAscii(value) || value.length === 0) return false;
+    const hostname = allowTrailingDot && value.endsWith(".") ? value.slice(0, -1) : value;
+    if (hostname.length === 0 || hostname.length > 253) return false;
+    return hostname.split(".").every((label) =>
+        label.length >= 1
+        && label.length <= 63
+        && /^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$/.test(label));
+}
+
+function isEmailLocal(local) {
+    if (local.startsWith("\"")) {
+        if (!local.endsWith("\"") || local.length < 2) return false;
+        for (let index = 1; index < local.length - 1; index += 1) {
+            const code = local.charCodeAt(index);
+            if (local[index] === "\\") {
+                index += 1;
+                if (index >= local.length - 1) return false;
+                const escaped = local.charCodeAt(index);
+                if (escaped < 32 || escaped > 126) return false;
+            } else if (code < 32 || code > 126 || code === 34 || code === 92) {
+                return false;
+            }
+        }
+        return true;
+    }
+    const atom = /^[A-Za-z0-9!#$%&'*+\-/=?^_`{|}~]+$/;
+    return local.split(".").every((part) => atom.test(part));
+}
+
+function isAddressLiteral(literal) {
+    if (isIpv4(literal)) return true;
+    if (literal.startsWith("IPv6:")) return isIpv6(literal.slice(5));
+    const colon = literal.indexOf(":");
+    if (colon <= 0) return false;
+    const tag = literal.slice(0, colon);
+    const content = literal.slice(colon + 1);
+    return /^[A-Za-z0-9-]*[A-Za-z0-9]$/.test(tag)
+        && content.length > 0
+        && /^[\x21-\x5a\x5e-\x7e]+$/.test(content);
+}
+
+function isEmail(value) {
+    if (!isAscii(value) || value.length > 254) return false;
+    let quoted = false;
+    let escaped = false;
+    let separator = -1;
+    for (let index = 0; index < value.length; index += 1) {
+        const code = value.charCodeAt(index);
+        const character = value[index];
+        if (quoted) {
+            if (escaped) {
+                if (code < 32 || code > 126) return false;
+                escaped = false;
+            } else if (character === "\\") {
+                escaped = true;
+            } else if (character === "\"") {
+                quoted = false;
+            }
+        } else if (character === "\"" && index === 0) {
+            quoted = true;
+        } else if (character === "@") {
+            if (separator !== -1) return false;
+            separator = index;
+        }
+    }
+    if (quoted || escaped || separator <= 0 || separator === value.length - 1) return false;
+    const local = value.slice(0, separator);
+    const domain = value.slice(separator + 1);
+    if (local.length > 64 || !isEmailLocal(local)) return false;
+    return domain.startsWith("[") && domain.endsWith("]")
+        ? isAddressLiteral(domain.slice(1, -1))
+        : isHostname(domain, false);
+}
+
+function validPercentEncoding(value) {
+    for (let index = value.indexOf("%"); index >= 0; index = value.indexOf("%", index + 3)) {
+        if (index + 2 >= value.length || !URI_HEX.test(value.slice(index + 1, index + 3))) return false;
+    }
+    return true;
+}
+
+function escapeClass(value) {
+    return value.replace(/[\\\]\-^]/g, "\\$&");
+}
+
+function matchesUriComponent(value, extra) {
+    if (!validPercentEncoding(value)) return false;
+    const withoutEscapes = value.replace(/%[0-9A-Fa-f]{2}/g, "");
+    return new RegExp(`^[${URI_UNRESERVED}${escapeClass(URI_SUB_DELIMS + extra)}]*$`).test(withoutEscapes);
+}
+
+function isAuthority(authority) {
+    const at = authority.lastIndexOf("@");
+    const hostPort = at < 0 ? authority : authority.slice(at + 1);
+    if (at >= 0 && !matchesUriComponent(authority.slice(0, at), ":")) return false;
+    if (hostPort.startsWith("[")) {
+        const close = hostPort.indexOf("]");
+        if (close < 0 || !/^(?::[0-9]*)?$/.test(hostPort.slice(close + 1))) return false;
+        const literal = hostPort.slice(1, close);
+        return isIpv6(literal)
+            || /^[vV][0-9A-Fa-f]+\.[A-Za-z0-9._~!$&'()*+,;=:-]+$/.test(literal);
+    }
+    const colon = hostPort.lastIndexOf(":");
+    if (colon >= 0 && (hostPort.indexOf(":") !== colon || !/^[0-9]*$/.test(hostPort.slice(colon + 1)))) {
+        return false;
+    }
+    const host = colon < 0 ? hostPort : hostPort.slice(0, colon);
+    return matchesUriComponent(host, "");
+}
+
+function isAbsoluteUri(value) {
+    if (!isAscii(value) || /[\x00-\x20\x7f]/.test(value)) return false;
+    const scheme = /^([A-Za-z][A-Za-z0-9+.-]*):(.*)$/.exec(value);
+    if (!scheme) return false;
+    let remainder = scheme[2];
+    const hash = remainder.indexOf("#");
+    const fragment = hash < 0 ? undefined : remainder.slice(hash + 1);
+    if (fragment !== undefined) remainder = remainder.slice(0, hash);
+    if (fragment?.includes("#") || (fragment !== undefined && !matchesUriComponent(fragment, ":@/?"))) return false;
+    const question = remainder.indexOf("?");
+    const query = question < 0 ? undefined : remainder.slice(question + 1);
+    if (query !== undefined) remainder = remainder.slice(0, question);
+    if (query !== undefined && !matchesUriComponent(query, ":@/?")) return false;
+    if (remainder.startsWith("//")) {
+        const slash = remainder.indexOf("/", 2);
+        const authority = slash < 0 ? remainder.slice(2) : remainder.slice(2, slash);
+        const path = slash < 0 ? "" : remainder.slice(slash);
+        return isAuthority(authority) && matchesUriComponent(path, ":@/");
+    }
+    if (remainder.startsWith("//") || !matchesUriComponent(remainder, ":@/")) return false;
+    return remainder === "" || remainder.startsWith("/") || matchesUriComponent(remainder[0], ":@");
+}
+
+function isValidStringFormat(format, value) {
+    if (format === "email") return isEmail(value);
+    if (format === "uuid") return /^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$/.test(value);
+    if (format === "uri") return isAbsoluteUri(value);
+    if (format === "hostname") return isHostname(value);
+    if (format === "ipv4") return isIpv4(value);
+    if (format === "ipv6") return isIpv6(value);
+    return false;
 }
 
 function numericValue(details) {
@@ -612,6 +837,10 @@ function alternativeRefs(props) {
     return Array.isArray(props?.anyof) ? props.anyof : [];
 }
 
+function conditionalRefs(props) {
+    return props?.if ? [props.then, props.else].filter(Boolean) : [];
+}
+
 // Mirrors the loader rule that a definition with children but no selector is a table.
 function builtinTypeOf(node) {
     const props = node.props || {};
@@ -744,6 +973,7 @@ function createDefaultChecker(typesByName) {
     const collectFixedChildren = (node, visiting) => {
         const result = new Set((node.children || []).map((child) => child.name));
         const props = node.props || {};
+        if (props.if && typeof props.if.key === "string") result.add(props.if.key);
         const merge = (ref) => {
             const scope = new Set(visiting);
             for (const name of collectFixedChildren(resolve(ref, scope), scope)) result.add(name);
@@ -751,6 +981,7 @@ function createDefaultChecker(typesByName) {
         const reference = namedTypeRef(props);
         if (reference) merge(reference);
         for (const alternative of alternativeRefs(props)) merge(alternative);
+        for (const branch of conditionalRefs(props)) merge(branch);
         for (const component of props.allof || []) merge(component);
         return result;
     };
@@ -768,6 +999,17 @@ function createDefaultChecker(typesByName) {
             for (const alternative of alternatives) {
                 const scope = new Set(visiting);
                 const candidate = effectiveKind(resolve(alternative, scope), scope);
+                if (kind === null) kind = candidate;
+                else if (kind !== candidate) return "any";
+            }
+            return kind === null ? "any" : kind;
+        }
+        const branches = conditionalRefs(props);
+        if (branches.length > 0) {
+            let kind = null;
+            for (const branch of branches) {
+                const scope = new Set(visiting);
+                const candidate = effectiveKind(resolve(branch, scope), scope);
                 if (kind === null) kind = candidate;
                 else if (kind !== candidate) return "any";
             }
@@ -802,6 +1044,20 @@ function createDefaultChecker(typesByName) {
     };
 
     const add = (errors, path, message) => errors.push({ path, message });
+
+    const conditionMatches = (value, condition) => {
+        if (!isTableValue(value) || !condition || typeof condition.key !== "string") return false;
+        if (!tableHasKey(value, condition.key)) return false;
+        const actual = tableGetKey(value, condition.key);
+        if (Object.prototype.hasOwnProperty.call(condition, "equals")) {
+            const expected = parseTokenForValidation(condition.equals);
+            return expected.ok && valuesEqual(actual, expected.value);
+        }
+        return (Array.isArray(condition.in) ? condition.in : []).some((token) => {
+            const expected = parseTokenForValidation(token);
+            return expected.ok && valuesEqual(actual, expected.value);
+        });
+    };
 
     // Keys allowed at this node by contributors other than the one being validated.
     const siblingChildren = (node, externalChildren, excludePrimary, excludedComponent, visiting) => {
@@ -851,6 +1107,7 @@ function createDefaultChecker(typesByName) {
         const props = node.props || {};
         const reference = namedTypeRef(props);
         const alternatives = alternativeRefs(props);
+        const branches = conditionalRefs(props);
         if (reference) {
             const scope = new Set(visiting);
             const target = resolve(reference, scope);
@@ -863,6 +1120,20 @@ function createDefaultChecker(typesByName) {
                 siblingChildren(node, externalChildren, true, null, visiting), errors);
             if (isTableValue(value)) validatePresenceRules(path, value, node, errors);
             if (Array.isArray(value) && props.uniqueitems === true) validateUniqueItems(path, value, errors);
+        } else if (branches.length > 0) {
+            const selected = conditionMatches(value, props.if) ? props.then : props.else;
+            const scope = new Set(visiting);
+            const target = resolve(selected, scope);
+            const sharedChildren = siblingChildren(node, externalChildren, true, null, visiting);
+            if (typeof props.if?.key === "string") sharedChildren.add(props.if.key);
+            validateContributor(path, value, target, sharedChildren, scope, errors);
+            if (effectiveKind(target, new Set(scope)) === "table" && isTableValue(value)) {
+                const closure = new Set(collectFixedChildren(target, new Set(scope)));
+                for (const name of sharedChildren) closure.add(name);
+                for (const key of tableKeys(value)) {
+                    if (!closure.has(key)) add(errors, `${path}.${key}`, "unexpected key");
+                }
+            }
         } else {
             const type = builtinTypeOf(node);
             if (!isValueOfType(value, type)) {
@@ -1028,6 +1299,9 @@ function createDefaultChecker(typesByName) {
             if (pattern && !pattern.test(value)) {
                 add(errors, path, `does not match pattern ${props.pattern}`);
             }
+            if (props.format && !isValidStringFormat(props.format, value)) {
+                add(errors, path, `is not a valid ${props.format}`);
+            }
         }
     };
 
@@ -1185,6 +1459,13 @@ export function validateModel(model) {
             }
             return kinds;
         }
+        if (props.if) {
+            const kinds = new Set();
+            for (const branch of [props.then, props.else]) {
+                for (const kind of resolvedKinds(branch, seen)) kinds.add(kind);
+            }
+            return kinds;
+        }
         if (node.children?.length) return new Set(["table"]);
         return new Set();
     };
@@ -1203,12 +1484,27 @@ export function validateModel(model) {
     const fixedChildrenForNode = (node, seen = new Set()) => {
         const fixed = new Set((node.children || []).map((child) => child.name));
         const props = node.props || {};
+        if (props.if && typeof props.if.key === "string") fixed.add(props.if.key);
         if (props.type && isNamedRef(props.type)) {
             const name = normalizeRef(props.type);
             if (!seen.has(name) && typesByName.has(name)) {
                 for (const childName of fixedChildrenForNode(typesByName.get(name), new Set(seen).add(name))) {
                     fixed.add(childName);
                 }
+            }
+        }
+        for (const ref of [...(props.oneof || []), ...(props.anyof || [])]) {
+            const name = normalizeRef(ref);
+            if (!name || BUILTIN_TYPES.includes(name) || seen.has(name) || !typesByName.has(name)) continue;
+            for (const childName of fixedChildrenForNode(typesByName.get(name), new Set(seen).add(name))) {
+                fixed.add(childName);
+            }
+        }
+        for (const ref of props.if ? [props.then, props.else] : []) {
+            const name = normalizeRef(ref);
+            if (!name || BUILTIN_TYPES.includes(name) || seen.has(name) || !typesByName.has(name)) continue;
+            for (const childName of fixedChildrenForNode(typesByName.get(name), new Set(seen).add(name))) {
+                fixed.add(childName);
             }
         }
         for (const ref of props.allof || []) {
@@ -1227,6 +1523,7 @@ export function validateModel(model) {
         const references = [];
         if (props.type && isNamedRef(props.type)) references.push(props.type);
         references.push(...(props.oneof || []), ...(props.anyof || []), ...(props.allof || []));
+        if (props.if) references.push(props.then, props.else);
         for (const ref of references) {
             const name = normalizeRef(ref);
             if (!name || BUILTIN_TYPES.includes(name) || seen.has(name) || !typesByName.has(name)) continue;
@@ -1342,14 +1639,18 @@ export function validateModel(model) {
         const fixedChildren = fixedChildrenForNode(node);
         let compiledPattern = null;
 
-        const exclusivity = ["type", "oneof", "anyof"].filter((key) => Object.prototype.hasOwnProperty.call(p, key));
+        const exclusivity = ["type", "oneof", "anyof", "if"].filter((key) => Object.prototype.hasOwnProperty.call(p, key));
+        const conditionalParts = ["if", "then", "else"].filter((key) => Object.prototype.hasOwnProperty.call(p, key));
+        if (conditionalParts.length > 0 && conditionalParts.length < 3) {
+            issues.push({ level: "error", path: label, message: "A conditional selector must define `if`, `then`, and `else` together." });
+        }
         for (const key of ["type", "itemtype"]) {
             if (Object.prototype.hasOwnProperty.call(p, key) && !String(p[key]).trim()) {
                 issues.push({ level: "error", path: label, message: `\`${key}\` must not be blank.` });
             }
         }
         if (exclusivity.length > 1) {
-            issues.push({ level: "error", path: label, message: "`type`, `oneof`, and `anyof` are mutually exclusive." });
+            issues.push({ level: "error", path: label, message: "`type`, `oneof`, `anyof`, and `if` are mutually exclusive." });
         }
         if (exclusivity.length === 0 && (!node.children || node.children.length === 0)) {
             issues.push({ level: "error", path: label, message: "A definition must select a type or contain child definitions." });
@@ -1368,6 +1669,58 @@ export function validateModel(model) {
                 if (!allowed.has(key)) {
                     issues.push({ level: "error", path: label, message: `A union cannot define \`${key}\`.` });
                 }
+            }
+        }
+
+        const isConditionalSelector = Object.prototype.hasOwnProperty.call(p, "if");
+        if (isConditionalSelector) {
+            const allowed = new Set(["if", "then", "else", "allof", "description", "optional", "default", "deprecated"]);
+            for (const key of Object.keys(p)) {
+                if (!allowed.has(key)) {
+                    issues.push({ level: "error", path: label, message: `A conditional selector cannot define \`${key}\`.` });
+                }
+            }
+            if ((node.children || []).length > 0) {
+                issues.push({ level: "error", path: label, message: "A conditional selector cannot define child definitions." });
+            }
+            if (!isNonArrayObject(p.if)) {
+                issues.push({ level: "error", path: label, message: "`if` must be an inline-table condition." });
+            } else {
+                const conditionKeys = Object.keys(p.if);
+                if (conditionKeys.some((key) => !["key", "equals", "in"].includes(key))) {
+                    issues.push({ level: "error", path: label, message: "`if` may contain only `key` and exactly one of `equals` or `in`." });
+                }
+                if (typeof p.if.key !== "string") {
+                    issues.push({ level: "error", path: label, message: "`if.key` must be a string." });
+                }
+                const hasEquals = Object.prototype.hasOwnProperty.call(p.if, "equals");
+                const hasIn = Object.prototype.hasOwnProperty.call(p.if, "in");
+                if (hasEquals === hasIn) {
+                    issues.push({ level: "error", path: label, message: "`if` must define exactly one of `equals` or `in`." });
+                } else if (hasEquals) {
+                    pushTokenIssue(label, "if.equals", p.if.equals);
+                } else if (!Array.isArray(p.if.in) || p.if.in.length === 0) {
+                    issues.push({ level: "error", path: label, message: "`if.in` must be a non-empty array of TOML values." });
+                } else {
+                    p.if.in.forEach((token) => pushTokenIssue(label, "if.in", token));
+                }
+            }
+            for (const key of ["then", "else"]) {
+                if (!String(p[key] || "").trim()) {
+                    issues.push({ level: "error", path: label, message: `\`${key}\` must be a non-blank named reusable type reference.` });
+                } else {
+                    validateRef(label, key, p[key], { disallowAny: true, disallowCollection: true });
+                    if (bareBuiltin(p[key])) {
+                        issues.push({ level: "error", path: label, message: `\`${key}\` must reference a named reusable type.` });
+                    }
+                }
+            }
+            const thenKinds = resolvedKinds(p.then);
+            const elseKinds = resolvedKinds(p.else);
+            const thenKind = thenKinds.size === 1 ? [...thenKinds][0] : null;
+            const elseKind = elseKinds.size === 1 ? [...elseKinds][0] : null;
+            if (!thenKind || !elseKind || thenKind !== elseKind || !["table", "collection"].includes(thenKind)) {
+                issues.push({ level: "error", path: label, message: "Conditional branches must resolve to the same table or collection kind." });
             }
         }
 
@@ -1462,6 +1815,14 @@ export function validateModel(model) {
             if (issue?.level !== "error") compiledPattern = new RegExp(p.pattern, "u");
         }
 
+        if (Object.prototype.hasOwnProperty.call(p, "format")) {
+            if (p.type !== "string") {
+                issues.push({ level: "error", path: label, message: "`format` requires the built-in type `string`." });
+            } else if (!STRING_FORMATS.has(p.format)) {
+                issues.push({ level: "error", path: label, message: `Unknown string format: \`${p.format}\`.` });
+            }
+        }
+
         if (Object.prototype.hasOwnProperty.call(p, "keypattern") && p.type !== "collection") {
             issues.push({ level: "error", path: label, message: "`keypattern` requires the built-in type `collection`." });
         } else if (p.keypattern) {
@@ -1541,6 +1902,9 @@ export function validateModel(model) {
                 if (compiledPattern && details.kind === "string" && !compiledPattern.test(details.value)) {
                     issues.push({ level: "error", path: label, message: `\`allowedvalues\` entry ${token} does not satisfy \`pattern\`.` });
                 }
+                if (p.format && details.kind === "string" && !isValidStringFormat(p.format, details.value)) {
+                    issues.push({ level: "error", path: label, message: `\`allowedvalues\` entry ${token} does not satisfy \`format\` ${p.format}.` });
+                }
                 if (p.type === "string" && details.kind === "string") {
                     const length = [...details.value].length;
                     if (p.minlength != null && length < p.minlength) {
@@ -1598,7 +1962,12 @@ export function validateModel(model) {
         const nextVisiting = new Set(visiting).add(name);
         const props = typesByName.get(name).props || {};
         if (props.type) visitSelector(props.type, nextVisiting);
-        for (const ref of [...(props.oneof || []), ...(props.anyof || []), ...(props.allof || [])]) {
+        for (const ref of [
+            ...(props.oneof || []),
+            ...(props.anyof || []),
+            ...(props.if ? [props.then, props.else] : []),
+            ...(props.allof || []),
+        ]) {
             visitSelector(ref, nextVisiting);
         }
         visited.add(name);

--- a/.github/extensions/tosd-editor/model.test.mjs
+++ b/.github/extensions/tosd-editor/model.test.mjs
@@ -49,6 +49,10 @@ type = "string"
     assert.equal(parsed.types[0].children[0].name, "type");
     assert.equal(parsed.types[0].children[0].props.type, "string");
     assert.deepEqual(parseDocument(serializeDocument(parsed)), parsed);
+    assert.throws(
+        () => parseDocument('[toml-schema]\nversion = "1.0.0"\n[elements.parent]\ntype = "table"\n[elements.parent.children.arbitrary]\ntype = "string"\n'),
+        /may escape only schema-property child names/,
+    );
 });
 
 test("large TOML integers round-trip without precision loss", () => {
@@ -303,6 +307,97 @@ test("portable patterns use Unicode scalar-value semantics", () => {
         allowedvalues: ['"😀"'],
     })]);
     assert.deepEqual(errors(value), []);
+});
+
+test("string formats round-trip and validate allowed values and defaults", () => {
+    const source = `
+[toml-schema]
+version = "1.0.0"
+
+[elements.endpoint]
+type = "string"
+format = "uri"
+allowedvalues = [ "https://example.com/a%20b" ]
+default = "https://example.com/a%20b"
+`;
+    const parsed = parseDocument(source);
+    assert.equal(parsed.elements[0].props.format, "uri");
+    assert.deepEqual(errors(parsed), []);
+    assert.deepEqual(parseDocument(serializeDocument(parsed)), parsed);
+
+    for (const invalid of [
+        model([definition("x", { type: "integer", format: "uuid" })]),
+        model([definition("x", { type: "string", format: "date" })]),
+        model([definition("x", { type: "string", format: "email", allowedvalues: ['"not-an-email"'] })]),
+        model([definition("x", { type: "string", format: "ipv4", default: '"192.168.001.1"' })]),
+    ]) {
+        assert.ok(errors(invalid).length > 0);
+    }
+});
+
+test("conditional selectors round-trip and validate the selected default branch", () => {
+    const source = `
+[toml-schema]
+version = "1.0.0"
+
+[types.sqlite]
+type = "table"
+[types.sqlite.engine]
+type = "string"
+[types.sqlite.path]
+type = "string"
+
+[types.server]
+type = "table"
+[types.server.engine]
+type = "string"
+[types.server.host]
+type = "string"
+
+[elements.database]
+if = { key = "engine", equals = "sqlite" }
+then = "types.sqlite"
+else = "types.server"
+default = { engine = "sqlite", path = "data.db" }
+`;
+    const parsed = parseDocument(source);
+    assert.deepEqual(parsed.elements[0].props.if, { key: "engine", equals: "'sqlite'" });
+    assert.deepEqual(errors(parsed), []);
+    assert.deepEqual(parseDocument(serializeDocument(parsed)), parsed);
+
+    parsed.elements[0].props.default = '{ engine = "sqlite", host = "wrong-branch" }';
+    assert.ok(errors(parsed).some((issue) => issue.message.includes("`default`")));
+});
+
+test("conditional selector shape, branches, kinds, and cycles are validated", () => {
+    const tableBranch = definition("tableBranch", { type: "table" }, [
+        definition("engine", { type: "string" }),
+    ]);
+    const collectionBranch = definition("collectionBranch", { type: "collection", itemtype: "string" });
+
+    const malformed = [
+        model([definition("x", { if: { key: "engine", equals: '"x"' }, then: "types.a" })], [
+            definition("a", { type: "table" }),
+        ]),
+        model([definition("x", { if: { key: "engine", equals: '"x"', in: ['"x"'] }, then: "types.a", else: "types.a" })], [
+            definition("a", { type: "table" }),
+        ]),
+        model([definition("x", { if: { key: "engine", equals: '"x"' }, then: "table", else: "table" })]),
+        model([definition("x", { if: { key: "engine", equals: '"x"' }, then: "types.tableBranch", else: "types.collectionBranch" })], [
+            tableBranch,
+            collectionBranch,
+        ]),
+        model([], [
+            definition("first", { if: { key: "engine", equals: '"x"' }, then: "types.second", else: "types.fallback" }),
+            definition("second", { type: "types.first" }),
+            definition("fallback", { type: "table" }),
+        ]),
+        model([definition("x", { if: { key: "engine", equals: '"x"' }, then: "types.mixed", else: "types.tableBranch" })], [
+            definition("mixed", { oneof: ["table", "string"] }),
+            tableBranch,
+        ]),
+    ];
+    malformed.forEach((value, index) => assert.ok(errors(value).length > 0, `conditional malformed case ${index}`));
 });
 
 test("declared defaults are rejected when they violate the effective definition", () => {

--- a/.github/extensions/tosd-editor/styles.css
+++ b/.github/extensions/tosd-editor/styles.css
@@ -620,7 +620,8 @@ button.danger:hover {
     transition: opacity 0.1s ease;
 }
 
-.dg-box:hover .dg-actions {
+.dg-box:hover .dg-actions,
+.dg-box:focus-within .dg-actions {
     opacity: 1;
 }
 
@@ -905,7 +906,8 @@ button.danger:hover {
 }
 
 .node-row:hover .row-actions,
-.node-row.selected .row-actions {
+.node-row.selected .row-actions,
+.node-row:focus-within .row-actions {
     opacity: 1;
 }
 
@@ -1042,6 +1044,47 @@ button.danger:hover {
     box-shadow: 0 0 0 3px var(--tosd-accent-soft);
 }
 
+.list-row select {
+    flex: 1;
+    min-width: 0;
+    padding: 6px 9px;
+    border: 1px solid var(--tosd-border);
+    border-radius: var(--tosd-radius-sm);
+    background: var(--tosd-bg);
+    color: inherit;
+    font: inherit;
+}
+
+.relationship-row {
+    align-items: flex-start;
+}
+
+.relationship-row select[multiple] {
+    min-height: 72px;
+}
+
+.relationship-summary {
+    margin: -2px 0 10px;
+    color: var(--tosd-muted);
+    font-size: 11px;
+    overflow-wrap: anywhere;
+}
+
+.condition-builder {
+    margin: 0 0 16px;
+    padding: 14px;
+    border: 1px solid var(--tosd-border);
+    border-radius: var(--tosd-radius);
+    background: var(--tosd-subtle);
+}
+
+.condition-builder legend {
+    padding: 0 6px;
+    color: var(--cat-choice);
+    font-size: 12px;
+    font-weight: 600;
+}
+
 .section-title {
     font-size: 11px;
     text-transform: uppercase;
@@ -1128,6 +1171,17 @@ pre.preview {
     padding: 6px 14px;
     font-size: 12px;
     align-items: baseline;
+    width: 100%;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    color: inherit;
+    text-align: left;
+}
+
+.issue:hover,
+.issue:focus-visible {
+    background: var(--tosd-subtle);
 }
 
 .issue + .issue {
@@ -1157,6 +1211,8 @@ pre.preview {
 .issue .where {
     color: var(--tosd-muted);
     font-family: var(--font-mono, monospace);
+    margin-left: auto;
+    overflow-wrap: anywhere;
 }
 
 .tabs {
@@ -1272,6 +1328,19 @@ pre.preview {
     outline: none;
     border-color: var(--tosd-accent);
     box-shadow: 0 0 0 3px var(--tosd-accent-soft);
+}
+
+.modal-draft {
+    max-height: 280px;
+    margin: 12px 0 0;
+    padding: 12px;
+    overflow: auto;
+    border: 1px solid var(--tosd-border);
+    border-radius: var(--tosd-radius-sm);
+    background: var(--tosd-subtle);
+    white-space: pre;
+    font-size: 11px;
+    line-height: 1.5;
 }
 
 .modal-err {
@@ -1483,6 +1552,67 @@ button:disabled {
 
 .legend-label {
     color: var(--text-color-default);
+}
+
+@media (max-width: 900px) {
+    .workspace {
+        grid-template-columns: 1fr;
+        grid-template-rows: minmax(300px, 48%) minmax(0, 1fr);
+    }
+
+    .diagram-pane {
+        border-right: 0;
+        border-bottom: 1px solid var(--tosd-border);
+    }
+
+    .side {
+        grid-template-columns: 1fr 1fr;
+        grid-template-rows: minmax(0, 1fr);
+    }
+
+    .side-panel:first-child {
+        border-bottom: 0;
+        border-right: 1px solid var(--tosd-border);
+    }
+}
+
+@media (max-width: 620px) {
+    .toolbar {
+        padding-inline: 10px;
+    }
+
+    .workspace {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .diagram-pane {
+        min-height: 42vh;
+    }
+
+    .side {
+        display: flex;
+        flex-direction: column;
+        min-height: 58vh;
+    }
+
+    .side-panel {
+        min-height: 280px;
+    }
+
+    .side-panel:first-child {
+        border-right: 0;
+        border-bottom: 1px solid var(--tosd-border);
+    }
+
+    .row-2,
+    .list-row-2 {
+        grid-template-columns: 1fr;
+    }
+
+    .diagram-bar {
+        overflow-x: auto;
+    }
 }
 
 /* Reduced motion --------------------------------------------------------- */


### PR DESCRIPTION
The visual editor could not load or preserve valid schemas that use string `format` constraints or conditional `if`/`then`/`else` definitions. This completes the editor's specification coverage and makes advanced schema workflows safer and easier to understand.

## What changed

- Parse, serialize, validate, and round-trip all supported string formats and conditional selectors, including defaults, allowed values, branch compatibility, cycles, escaped child names, and effective table closure.
- Add explicit definition modes, structured conditional controls, format selection, branch navigation, child relationship selectors, and actionable validation issues.
- Make replacement workflows reviewable and recoverable with generated/inferred previews, unsaved-change guards, path-aware undo, and safer save endpoint authorization.
- Improve keyboard behavior, focus visibility, responsive layouts, graph summaries, and preview failure reporting.
- Expand focused model coverage while retaining semantic round-trips for every checked-in `.tosd` schema.