### PR TITLE
Fix duplicate validation report divider

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -871,7 +871,6 @@ footer {
   margin-top: 0;
 }
 .result-groups {
-  border-top: 1px solid var(--cp-border);
   margin-top: 32px;
 }
 .result-group {


### PR DESCRIPTION
The validation report showed two horizontal separators between its jump index and result groups. Remove the result list's redundant top border so the index's existing bottom border provides a single divider.