### PR TITLE
Left-align CLI usage docs on the CLI releases page

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -303,8 +303,8 @@ pre {
   margin-top: 28px;
   max-width: 820px;
 }
-.cli-docs {
-  margin-top: 48px;
+.markdown.cli-docs {
+  margin: 48px 0 0;
 }
 .releases-list {
   border-top: 1px solid var(--cp-border);


### PR DESCRIPTION
The "CLI usage" article on `/cli/releases/` looked oddly centered: it sat in the middle of the page while the hero, install panel, and release download list all start at the page's left gutter.

Cause is the shared `.markdown` rule (used by the rendered spec page) which centers its column with `margin: 8px auto 0`. The CLI page embeds that same class inside a full-width layout, so the auto margins pushed the article inward.

Fix is a single scoped override:

```css
.markdown.cli-docs {
  margin: 48px 0 0;
}
```

This keeps the 820px reading width but pins the article to the left edge. Verified in a local browser render: the article's left edge is now 76px, matching the hero heading and the install panel. The spec page is unaffected since the override requires both classes.