### PR TITLE
Phase 3: make the spec cohesive, and close two language gaps

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1891,15 +1891,17 @@ equality between integers and floats does not make their TOML kinds
 interchangeable for this schema-load check. A malformed enumeration MUST be
 rejected at schema-load time.
 
-For a definition that is neither an `array` nor a `collection`, when
-`allowedvalues` is combined with `pattern`, `format`,
-`min`, `max`, `minlength`, or `maxlength` on the same definition, every entry in
-`allowedvalues` MUST satisfy every applicable constraint. A schema containing an
-entry that violates one of those constraints is malformed, and schema loaders
-MUST reject it at schema-load time. This is a consistency check on the
-enumeration itself; it describes nothing about how a document value is
-validated. For offset date-times, this boundary check uses instant
-ordering even though subsequent `allowedvalues` membership uses parsed-value
+For every definition, when `allowedvalues` is combined on the same definition
+with a constraint that applies to the same values the enumeration describes,
+every entry in `allowedvalues` MUST satisfy that constraint, and schema loaders
+MUST reject a violating entry at schema-load time. The constraints in scope are
+`pattern`, `format`, `min`, and `max` for every definition, plus `minlength` and
+`maxlength` for a definition that is neither an `array` nor a `collection`. On an
+`array` or a `collection`, `minlength` and `maxlength` bound the container itself
+rather than its members, so they are not part of this per-entry check. This is a
+consistency check on the enumeration itself; it describes nothing about how a
+document value is validated. For offset date-times, this boundary check uses
+instant ordering even though subsequent `allowedvalues` membership uses parsed-value
 equality; equivalent instants with different retained local fields or offsets
 therefore compare equal for a boundary but remain distinct enumeration values.
 
@@ -2291,10 +2293,11 @@ rules used for numeric and temporal items are defined under
 [Minimum Value / Maximum Value](#minimum-value--maximum-value---min-and-max).
 
 When `allowedvalues` is present on an array, every array item MUST be a member
-of that enumeration. The enumeration does not have to be sorted. If `min` or
-`max` is also present, every enumerated value MUST satisfy the applicable
-inclusive boundary, and a schema loader MUST reject an enumerated value that
-violates one; an enumerated value need not equal either boundary.
+of that enumeration. The enumeration does not have to be sorted.
+[Allowed Values](#allowed-values---allowedvalues) is authoritative for the
+schema-load consistency check between `allowedvalues` and a sibling per-member
+constraint such as `min` or `max`, including the requirement that a loader
+reject an enumerated value violating an applicable inclusive boundary.
 
 When the array declares `itemtype`, every enumerated value MUST have a TOML
 kind permitted by the effective item type, as

--- a/SPEC.md
+++ b/SPEC.md
@@ -100,7 +100,9 @@ the other.
 - **Type reference** / **reference**. A string that names a built-in type or a
   named reusable definition, accepted by `type`, `itemtype`, `items`, `oneof`,
   `anyof`, `allof`, `then`, and `else`. The optional `types.` prefix is stripped
-  once before lookup. The resolution and edge-classification rules for references
+  once before lookup. Which reference each of those positions accepts is stated
+  under [Type Reference Restrictions](#type-reference-restrictions), and the
+  resolution and edge-classification rules for references
   are defined under [Reference Resolution](#reference-resolution) and
   [The Reference Graph](#the-reference-graph).
 
@@ -279,6 +281,7 @@ and the preferred term is the one to use in new text.
   - [Schema Versioning](#schema-versioning)
 - [Elements table - `[elements]`](#elements-table---elements)
 - [Types table - `[types]`](#types-table---types)
+  - [Type Reference Restrictions](#type-reference-restrictions)
   - [Schema Definition Properties](#schema-definition-properties)
     - [Local and Effective Checks](#local-and-effective-checks)
   - [Quoted and Special Keys](#quoted-and-special-keys)
@@ -626,6 +629,10 @@ Type references are strings accepted by `type`, `itemtype`, `items`, `oneof`,
 - a built-in type name such as `"string"`, `"boolean"`, or `"integer"`;
 - a named reusable definition from `[types]`, written either as `"types.<typename>"` or `"<typename>"`.
 
+Which references each of those positions accepts, and which recursion each
+permits, is stated once under
+[Type Reference Restrictions](#type-reference-restrictions).
+
 Each reusable type is a direct child of `[types]`, and its name is the exact
 decoded TOML key of that child. A dot in a type name is an ordinary character
 when the key is quoted, so `[types."network.endpoint"]` defines the reusable
@@ -640,21 +647,6 @@ unambiguous, a reusable type name MUST NOT begin with the literal characters
 `[types]` definition names. The reserved names are `any`, `string`, `integer`,
 `float`, `boolean`, `offset-date-time`, `local-date-time`, `local-date`,
 `local-time`, `array`, `table`, and `collection`.
-
-Two built-in names have context-specific restrictions:
-
-- `collection` is valid for `type` only when the effective definition obtains
-  an `itemtype` locally or from a compatible `allof` component. It MUST NOT be
-  used as a bare reference in `itemtype`, `items`, `oneof`, `anyof`, `allof`,
-  `then`, or `else`, because those locations cannot supply the collection's dynamic-value
-  rule. Schema loaders MUST reject such references at schema-load time.
-- `any` is valid for `type`, `itemtype`, and `items`, but it MUST NOT appear
-  directly in `oneof`, `anyof`, `allof`, `then`, or `else`. Schema loaders MUST
-  reject a direct `any` component at schema-load time.
-
-These restrictions apply to bare built-in references, not to named reusable
-definitions. A named definition that declares a complete collection or selects
-`type = "any"` remains a valid reference.
 
 `type`, `oneof`, `anyof`, and the `if`/`then`/`else` triple are alternative
 ways to select the type of the current schema node. A definition MUST declare
@@ -682,24 +674,6 @@ built-in `table` or `collection` type, or when the node omits a selector and is
 therefore an implicit table. Schema loaders MUST reject child definitions attached to
 a scalar, `array`, named type reference, `oneof`, `anyof`, or conditional node rather than
 silently ignoring them.
-
-Every named reference used by `type`, `itemtype`, `items`, `oneof`, `anyof`,
-`allof`, `then`, or `else`
-MUST resolve to a definition in `[types]`. Schema loaders MUST reject unresolved
-references at schema-load time, including references in definitions that are
-optional or not exercised by the document being validated. The ordered algorithm
-that turns a reference string into a built-in type or a reusable definition is
-defined under [Reference Resolution](#reference-resolution), which is
-authoritative for how the restrictions above are applied.
-
-Type-selection and composition references MUST be acyclic. A cycle composed of
-named `type` aliases, `oneof` alternatives, `anyof` alternatives, conditional
-branches, or `allof` components cannot resolve to a concrete definition and
-schema loaders MUST reject it at schema-load time. Structural recursion through
-table or collection children, array `itemtype`, or tuple `items` remains valid
-because each recursive step consumes a nested document value.
-[Cycle Legality](#cycle-legality) states this classification in terms of the
-reference graph and is authoritative for deciding which cycles are legal.
 
 ```toml
 [types]
@@ -733,6 +707,64 @@ default = <toml-value>
 deprecated = true|false
 ```
 
+### Type Reference Restrictions
+
+This section is the single authority for which references each reference
+position accepts. Every other mention of these restrictions in this
+specification points here rather than restating them.
+
+| Position | Bare built-in name | Named `[types]` reference | Reference to a pure mixin | Reference edge |
+| --- | --- | --- | --- | --- |
+| `type` | Any built-in. `collection` only when the effective definition obtains an `itemtype` locally or from a compatible `allof` component | Yes | Yes | Non-consuming |
+| `itemtype` | Any built-in except `collection` | Yes | Yes | Consuming |
+| `items` | Any built-in except `collection` | Yes | Yes | Consuming |
+| `oneof`, `anyof` | Any built-in except `any` and `collection` | Yes | Yes | Non-consuming |
+| `allof` | Any built-in except `any` and `collection` | Yes | Yes | Non-consuming |
+| `then`, `else` | None; a bare built-in reference is invalid in either | Yes, and both branches MUST resolve to the same effective kind, which MUST be `table` or `collection` | Yes, subject to that same kind requirement | Non-consuming |
+
+The two restricted built-ins are restricted for one reason each:
+
+- `collection` is valid for `type` only when the effective definition obtains
+  an `itemtype` locally or from a compatible `allof` component. It MUST NOT be
+  used as a bare reference in `itemtype`, `items`, `oneof`, `anyof`, `allof`,
+  `then`, or `else`, because those locations cannot supply the collection's dynamic-value
+  rule. Schema loaders MUST reject such references at schema-load time.
+- `any` is valid for `type`, `itemtype`, and `items`, but it MUST NOT appear
+  directly in `oneof`, `anyof`, `allof`, `then`, or `else`. Schema loaders MUST
+  reject a direct `any` component at schema-load time.
+
+These restrictions apply to bare built-in references, not to named reusable
+definitions. A named definition that declares a complete collection or selects
+`type = "any"` remains a valid reference. A
+[pure mixin](#composition-supplying-the-local-skeleton) is an ordinary named
+definition once its components determine its effective type, so it may be
+referenced wherever any other named definition may be, subject to the same kind
+requirement the position imposes on a named reference. What a definition may
+declare *beside* a named reference is stated under
+[Type Reference](#type-reference).
+
+Every named reference used by `type`, `itemtype`, `items`, `oneof`, `anyof`,
+`allof`, `then`, or `else`
+MUST resolve to a definition in `[types]`. Schema loaders MUST reject unresolved
+references at schema-load time, including references in definitions that are
+optional or not exercised by the document being validated. The ordered algorithm
+that turns a reference string into a built-in type or a reusable definition is
+defined under [Reference Resolution](#reference-resolution), which is
+authoritative for how the restrictions above are applied. An element MUST NOT
+reference another element, as
+[Elements table](#elements-table---elements) requires.
+
+Type-selection and composition references MUST be acyclic. A cycle composed of
+named `type` aliases, `oneof` alternatives, `anyof` alternatives, conditional
+branches, or `allof` components — the positions the table above marks
+**non-consuming** — cannot resolve to a concrete definition and
+schema loaders MUST reject it at schema-load time. Structural recursion through
+table or collection children, array `itemtype`, or tuple `items` — the
+**consuming** positions — remains valid
+because each recursive step consumes a nested document value.
+[Cycle Legality](#cycle-legality) states this classification in terms of the
+reference graph and is authoritative for deciding which cycles are legal.
+
 ### Schema Definition Properties
 
 The following matrix summarizes where definition properties apply. The
@@ -740,8 +772,8 @@ detailed sections below remain authoritative.
 
 | Property | Applicable definition |
 | --- | --- |
-| `type` | Selects one built-in or named type; mutually exclusive with other selectors |
-| `oneof`, `anyof` | Select the current node from one or more alternatives; mutually exclusive with other selectors |
+| `type` | Selects one built-in or named type; at most one selector per definition, per [Types table](#types-table---types) |
+| `oneof`, `anyof` | Select the current node from one or more alternatives; at most one selector per definition, per [Types table](#types-table---types) |
 | `if`, `then`, `else` | Exhaustively select one of two named table-like definitions from a direct child's parsed value |
 | `allof` | Conjunctively applies one or more compatible type references in addition to the local definition; alone, it also supplies an omitted selector, per [Composition Supplying the Local Skeleton](#composition-supplying-the-local-skeleton) |
 | `description`, `optional`, `default`, `deprecated` | Any definition, including a named reference or alternative selector |
@@ -874,8 +906,9 @@ Target keys may have the same names as TOML Schema properties, such as `type`,
 definition is a schema property, while a table-header path segment below that
 definition is normally a target child definition.
 
-A schema definition with nested child definitions and no explicit selector is
-treated as `type = "table"`. This lets schemas describe target keys that would
+A schema definition with nested child definitions and no explicit selector is an
+implicit table, as [Types table](#types-table---types) defines. This lets
+schemas describe target keys that would
 otherwise share a name with schema properties when the parent does not also use
 the property.
 
@@ -1101,7 +1134,9 @@ The formats use the following portable rules:
 `string`, and, as a [per-member constraint](#per-member-value-constraints), on a
 non-tuple `array` or `collection` whose effective member type is the built-in
 `string`. It cannot be attached to another built-in type, an alternative
-selector, or a named type reference. A schema loader MUST reject an unsupported
+selector, or a named type reference, as
+[Schema Definition Properties](#schema-definition-properties) requires. A schema
+loader MUST reject an unsupported
 format name or incompatible use at schema-load time rather than ignoring it.
 
 When `format` is combined with `allowedvalues`, every allowed string MUST
@@ -1125,22 +1160,23 @@ format = "uuid"
 
 ### Minimum Value / Maximum Value - `min` and `max`
 
-These properties define inclusive value ranges. They may only be used for:
+These properties define inclusive value ranges. The **comparable kinds** are:
 
  - `float`
  - `integer`
  - date and/or time types: `offset-date-time`, `local-date-time`, `local-date`, and `local-time`
- - `array` or `collection`, when `itemtype` resolves to `integer`, `float`, or one of the temporal types above
 
-For an `array` or a `collection`, `min` and `max` are
+`min` and `max` may be declared only on a definition whose type resolves to
+exactly one comparable kind, and on an `array` or a `collection` whose members
+do, as the next paragraph describes.
+
+On an `array` or a `collection`, `min` and `max` are
 [per-member constraints](#per-member-value-constraints) and apply to each item
-or each dynamic entry. `itemtype` MUST resolve to one
-comparable built-in kind: `integer`, `float`, `offset-date-time`,
-`local-date-time`, `local-date`, or `local-time`. Named references and aliases
-are resolved before this rule is checked, and all alternatives of a referenced
-`oneof` or `anyof` definition MUST resolve to that same kind.
-Schema loaders MUST reject container range constraints when the member schema can resolve to
-different kinds or to a non-comparable kind. The interaction between array range
+or each dynamic entry. That section is authoritative for the per-member reading,
+for how the member type is resolved through `itemtype` and through the
+alternatives of a referenced `oneof` or `anyof`, and for the schema-load
+rejection of a member type that is indeterminate or of the wrong kind. The
+interaction between array range
 boundaries and `allowedvalues` is defined under
 [Observations on Conditions to Arrays](#observations-on-conditions-to-arrays).
 
@@ -1188,7 +1224,8 @@ Both `minlength` and `maxlength` MUST be integers `>= 0`. When both are present,
 
 `minlength` and `maxlength` are valid only on definitions whose selected type is
 the built-in `string`, `array`, or `collection`. They cannot be attached to
-another built-in type, an alternative selector, or a named type reference.
+another built-in type, an alternative selector, or a named type reference, as
+[Schema Definition Properties](#schema-definition-properties) requires.
 Schema loaders MUST reject an incompatible length constraint at schema-load time rather
 than silently ignoring it.
 
@@ -1216,7 +1253,8 @@ Table headers and inline tables produce the same value kind and are validated
 identically.
 
 If a schema definition has nested child definitions but does not declare a
-selector, schema loaders MUST treat it as if it declared `type = "table"`.
+selector, it is an implicit table, as
+[Types table](#types-table---types) defines.
 
 The **fixed children** of a table, for the purpose of the rules below, are its
 own nested child definitions together with the children contributed by every
@@ -1288,14 +1326,13 @@ colors=[ "red", "yellow", "green" ]
 ##### Observations on Conditions to Arrays
 
 The `min` and `max` conditions set an inclusive range for every array item.
-Their applicability rule, including how a named `itemtype` and its alternatives
-are resolved, and the ordering rules used for numeric and temporal items, are
-defined under
+[Per-Member Value Constraints](#per-member-value-constraints) is authoritative
+for that per-item reading, for the shared subset `min`, `max`, `allowedvalues`,
+`pattern`, and `format`, for how a named `itemtype` and its alternatives are
+resolved, and for the equivalence of an inline constraint to the same constraint
+written on the `itemtype` definition. The comparable kinds and the ordering
+rules used for numeric and temporal items are defined under
 [Minimum Value / Maximum Value](#minimum-value--maximum-value---min-and-max).
-`min`, `max`, `allowedvalues`, `pattern`, and `format` all apply per item here,
-and [Per-Member Value Constraints](#per-member-value-constraints) is
-authoritative for that shared subset and for its equivalence to the same
-constraint written on the `itemtype` definition.
 
 When `allowedvalues` is present on an array, every array item MUST be a member
 of that enumeration. The enumeration does not have to be sorted. If `min` or
@@ -1304,9 +1341,9 @@ inclusive boundary, and a schema loader MUST reject an enumerated value that
 violates one; an enumerated value need not equal either boundary.
 
 When the array declares `itemtype`, every enumerated value MUST have a TOML
-kind permitted by the effective item type. Named references, aliases, and
-`oneof` or `anyof` alternatives are resolved before this check. An `itemtype`
-that permits `any` permits enumeration entries of any TOML kind. This
+kind permitted by the effective item type, as
+[Per-Member Value Constraints](#per-member-value-constraints) requires. An
+`itemtype` that permits `any` permits enumeration entries of any TOML kind. This
 schema-load check verifies the permitted TOML kind; constraints inside a named
 item definition still apply normally when a document array is validated.
 
@@ -1323,7 +1360,9 @@ permits non-array and array items to be mixed in the outer array.
 
 ##### Array Item Schemas and Arrays of Tables
 
-`itemtype` accepts the same built-in or named references as `type`. Use a
+`itemtype` accepts the references
+[Type Reference Restrictions](#type-reference-restrictions) permits at that
+position. Use a
 built-in reference such as `itemtype = "string"` for a homogeneous scalar
 array, or a reusable schema definition when members require constraints or
 structure. A reusable table definition is required for TOML arrays of tables
@@ -1459,8 +1498,9 @@ contributed by a compatible `allof` component; this is the collection instance
 of the general principle stated under
 [Composition Supplying the Local Skeleton](#composition-supplying-the-local-skeleton),
 not a rule peculiar to collections. Each dynamic child must be given
-a unique key in the TOML document. `itemtype` may reference a built-in type or a
-named reusable definition. A schema loader MUST reject an effective collection
+a unique key in the TOML document. `itemtype` accepts the references
+[Type Reference Restrictions](#type-reference-restrictions) permits at that
+position. A schema loader MUST reject an effective collection
 when neither its local definition nor any referenced or composed definition
 contributes an `itemtype`. This is a schema-load check, so it reads only the
 contributions that are determinate at schema-load time; which components make
@@ -1470,7 +1510,9 @@ checks that read the effective rather than the local view, as
 [Local and Effective Checks](#local-and-effective-checks) enumerates.
 
 The built-in `collection` cannot itself be used as `itemtype` or as an entry in
-`items`, `oneof`, `anyof`, or `allof`: those bare references provide no place to declare
+`items`, `oneof`, `anyof`, or `allof`, as
+[Type Reference Restrictions](#type-reference-restrictions) states: those bare
+references provide no place to declare
 the nested collection's required `itemtype`. Define a reusable collection with
 its own `itemtype` and reference that named definition instead.
 
@@ -1686,10 +1728,8 @@ occupied, not because container members are otherwise privileged.
 A type reference applies a built-in type or inherits the rules of a named reusable type. Both `[types]` definitions and `[elements]` definitions may use type references. The `type` property selects the current node's type; built-in and named references use the same syntax.
 
 When `type` selects a named reusable definition, the reference inherits that
-definition's validation rules as-is. This inheritance includes `optional`: the
-referencing slot is optional when either the use site or the referenced
-definition declares `optional = true`. A use-site `optional = false` cannot
-make an optional referenced definition required. In version 1.0, the
+definition's validation rules as-is. This inheritance includes `optional`, as
+[Optionality](#optionality---optional) defines. In version 1.0, the
 referencing definition MAY additionally declare only `allof`, `description`,
 `optional`, `default`, and `deprecated`; it MUST NOT declare any other sibling
 property or child definition. `allof` adds conjunctive components rather than
@@ -1891,9 +1931,8 @@ same kind as the local definition. Structured components must all be `table` or
 all be `collection`; a `table` and a `collection` are not interchangeable for
 composition because they have different unknown-key semantics. A component
 whose alternatives resolve to different kinds is likewise indeterminate and
-MUST be rejected. The bare built-ins `any` and `collection` MUST NOT appear
-directly in `allof`; a complete named definition may resolve to either where it
-is otherwise compatible.
+MUST be rejected. Which references `allof` accepts at all is stated under
+[Type Reference Restrictions](#type-reference-restrictions).
 
 `allof` MUST NOT list the same component twice. Duplication is judged on
 resolved identity, after the optional `types.` prefix has been removed, exactly
@@ -1949,10 +1988,8 @@ MUST satisfy every contributed `keypattern`. A collection's required
 dynamic-entry constraint may therefore be supplied entirely by one or more
 `allof` components; it need not repeat a local `itemtype`.
 
-`optional` on the local definition determines whether the composed node may be
-absent. An `optional` value inside an `allof` component does not make the
-composed node optional; it only has meaning when that component is referenced
-normally with `type`.
+Whether a composed node may be absent is governed by `optional` on the local
+definition, as [Optionality](#optionality---optional) defines.
 
 #### Determinate Fixed-Child Set
 
@@ -2265,15 +2302,14 @@ Use `oneof` or `anyof` when a value may validate against alternative type refere
 - `oneof`: exactly one referenced type must validate.
 - `anyof`: at least one referenced type must validate.
 
-These properties can be used anywhere a schema definition can appear, including an `[elements]` field, a reusable `[types]` definition, and a type referenced through `itemtype` for array or collection items. Alternatives may reference built-in type names directly or named definitions when a branch needs constraints.
-
-The bare built-in names `any` and `collection` MUST NOT appear directly in
-`oneof` or `anyof`. Use a named reusable definition when an alternative needs a
-fully defined collection or an intentionally unconstrained named branch.
+These properties can be used anywhere a schema definition can appear, including an `[elements]` field, a reusable `[types]` definition, and a type referenced through `itemtype` for array or collection items. Which references an alternative may name is stated under
+[Type Reference Restrictions](#type-reference-restrictions); use a named
+reusable definition when an alternative needs a fully defined collection, an
+intentionally unconstrained named branch, or any other constraint.
 
 `type`, `oneof`, `anyof`, and the conditional triple all select the current
-node's type and are mutually exclusive. A schema loader MUST reject a
-definition containing more than one selector.
+node's type, and a definition declares at most one of them, as
+[Types table](#types-table---types) requires.
 
 The array assigned to `oneof` or `anyof` MUST contain at least one type
 reference. A union definition MAY additionally declare only `description`,
@@ -2474,23 +2510,25 @@ the matched branch declares are known keys of that node, while keys declared
 only by the branch that was not selected are not.
 
 `then` and `else` MUST each be a string naming a reusable definition in
-`[types]`; bare built-in references are invalid. Both definitions MUST resolve
-to the same effective kind, and that kind MUST be `table` or `collection`.
+`[types]`, and both definitions MUST resolve
+to the same effective kind, which MUST be `table` or `collection`, as
+[Type Reference Restrictions](#type-reference-restrictions) states.
 Schema loaders MUST reject unresolved branches, different branch kinds,
 branches that do not resolve to a table-like kind, and cycles through
 conditional branches.
 
-The conditional triple is mutually exclusive with `type`, `oneof`, and
-`anyof`. A conditional definition MAY additionally declare only `allof`,
+The conditional triple is one of the four selectors a definition declares at
+most one of, as [Types table](#types-table---types) requires. A conditional
+definition MAY additionally declare only `allof`,
 `description`, `optional`, `default`, and `deprecated`; it MUST NOT contain
 kind-specific validation properties or nested child definitions. An `allof`
 component MUST be compatible with the common branch kind and is applied
 conjunctively with whichever branch is selected.
 
-Optionality belongs to the conditional definition. An `optional` annotation
-inside a branch does not make the conditional slot optional, because no branch
-is selected when the slot is absent. A default on the conditional definition
-MUST validate against the branch selected by that default at schema-load time.
+Optionality belongs to the conditional definition, as
+[Optionality](#optionality---optional) defines. A default on the conditional
+definition MUST validate against the branch selected by that default at
+schema-load time.
 
 Example with a multi-value condition:
 
@@ -2721,7 +2759,7 @@ was selected. The general precedence is:
 `deprecated` is an exception to point 2 and does not follow the general
 precedence: it combines disjunctively rather than resolving to a single
 declaration, so a contributing `deprecated = true` deprecates the location even
-when the use site declares `deprecated = false`. [Deprecation](#deprecation) is
+when the use site declares `deprecated = false`. [Deprecation](#deprecation---deprecated) is
 authoritative for it. The general precedence governs `description` and any
 future annotation that resolves to at most one value.
 
@@ -2884,16 +2922,23 @@ Validators MUST skip a definition only when it is optional and the corresponding
 value does not exist in the TOML document. In every other case, the validator
 MUST validate the value against the definition.
 
+This section is the single authority for how `optional` interacts with
+references, composition, alternatives, and conditional branches.
+
 For a named `type` reference, optionality is inherited: the referencing slot is
 optional if either the use site or any definition in the reference chain
 declares `optional = true`. An explicit `optional = false` cannot cancel an
-inherited `true`. In contrast, `optional` values contributed only through
-`allof` components do not affect presence, as defined under
-[Conjunctive Composition](#conjunctive-composition---allof). The presence of a
+inherited `true`. In contrast, `optional` on the local definition determines
+whether a composed node may be absent, and `optional` values contributed only
+through `allof` components do not affect presence; such a value has meaning only
+when that component is referenced normally with `type`. The presence of a
 `oneof` or `anyof` slot is governed only by `optional` on the union definition
 or inherited through a named `type` reference to that union. `optional`
 declared inside an alternative does not make the union slot optional because
-no alternative is selected when the slot is absent.
+no alternative is selected when the slot is absent. Optionality likewise belongs
+to a conditional definition rather than to its branches: an `optional`
+annotation inside a `then` or `else` branch does not make the conditional slot
+optional, because no branch is selected when the slot is absent.
 
 ### Pattern - `pattern`
 
@@ -2901,7 +2946,9 @@ This property is valid on a definition whose selected type is the built-in
 `string`, and, as a [per-member constraint](#per-member-value-constraints), on a
 non-tuple `array` or `collection` whose effective member type is the built-in
 `string`. It cannot be attached to another built-in type, an alternative
-selector, or a named type reference. Schema loaders MUST reject an incompatible
+selector, or a named type reference, as
+[Schema Definition Properties](#schema-definition-properties) requires. Schema
+loaders MUST reject an incompatible
 `pattern` at schema-load time rather than silently ignoring it. On a
 `collection`, `pattern` constrains dynamic entry values while
 [`keypattern`](#key-pattern---keypattern) constrains their keys.
@@ -3321,7 +3368,8 @@ decides the outcome.
    interpretation.
 3. **Context restrictions on built-ins.** If step 2 selected `any` or
    `collection`, apply the context restrictions defined under
-   [Types table](#types-table---types). These restrictions are applied to the
+   [Type Reference Restrictions](#type-reference-restrictions). These
+   restrictions are applied to the
    normalized name, so `"types.any"` and `"types.collection"` are restricted
    exactly as the bare spellings are. `then` and `else` accept no built-in at all,
    so any reference reaching step 2 from those properties is an error.

--- a/SPEC.md
+++ b/SPEC.md
@@ -12,7 +12,7 @@ The schema format follows the TOML specification, meaning that a TOML Schema is 
 ## Conformance Terminology
 
 The key words **MUST**, **MUST NOT**, **REQUIRED**, **SHOULD**, **SHOULD NOT**,
-and **MAY** in this document are to be interpreted as described in
+**MAY**, and **OPTIONAL** in this document are to be interpreted as described in
 [BCP 14](https://www.rfc-editor.org/info/bcp14) when, and only when, they
 appear in all capitals.
 
@@ -368,6 +368,9 @@ and the preferred term is the one to use in new text.
 
 ## First Glance
 
+*This section is informative. It illustrates the language through a worked pair
+of documents; the normative rules are stated in the sections that follow.*
+
 ### TOML example
 Let's look at the TOML example displayed on the front page of [toml.io](https://toml.io/en/):
 
@@ -514,11 +517,11 @@ A TOML Schema file has the following structure:
 ### Top-level Structure Conditions
 
  - `[toml-schema]`: table with information and metadata of the schema.
-   - **Required**
+   - **REQUIRED**
  - `[types]`: table with definitions of types to be reused in elements.
-   - _Optional_
+   - **OPTIONAL**
  - `[elements]`: table with the overall structure of the TOML document, its tables, properties, and conditions.
-   - **Required**
+   - **REQUIRED**
 
 Any other top-level table or key-value pair MUST NOT appear in a TOML Schema document.
 
@@ -544,9 +547,9 @@ version = "1.0.0"
 ### Supported Properties
 
  - `version`: the TOML Schema language version used by this schema document. **Type:** string.
-   - **Required**.
+   - **REQUIRED**.
  - `meta`: subtable reserved for any custom user-provided metadata. **Type:** table.
-   - **Optional**.
+   - **OPTIONAL**.
 
 Custom properties and tables MUST NOT appear directly under `toml-schema`; they
 MAY appear only inside the `toml-schema.meta` table.
@@ -1116,7 +1119,7 @@ The formats use the following portable rules:
 - `uuid` consists of exactly 32 hexadecimal digits, case-insensitive, displayed
   in groups of 8, 4, 4, 4, and 12 digits separated by hyphens.
 - `uri` MUST match the RFC 3986 `URI` production rather than `relative-ref`.
-  It is ASCII; non-ASCII components must be percent-encoded. Every percent
+  It is ASCII; non-ASCII components MUST be percent-encoded. Every percent
   escape MUST contain exactly two hexadecimal digits.
 - `hostname` is ASCII and case-insensitive. After excluding one optional final
   root dot, its total length MUST be from 1 through 253 characters. Each
@@ -1166,7 +1169,7 @@ These properties define inclusive value ranges. The **comparable kinds** are:
  - `integer`
  - date and/or time types: `offset-date-time`, `local-date-time`, `local-date`, and `local-time`
 
-`min` and `max` may be declared only on a definition whose type resolves to
+`min` and `max` MAY be declared only on a definition whose type resolves to
 exactly one comparable kind, and on an `array` or a `collection` whose members
 do, as the next paragraph describes.
 
@@ -1926,8 +1929,8 @@ kind of its own, with one another. When the local selector is `oneof` or
 `anyof`, all of its
 alternatives MUST resolve to the same effective kind before `allof` can be
 applied; a multi-kind local union combined with `allof` is indeterminate and
-MUST be rejected at schema-load time. Scalar and array components must have the
-same kind as the local definition. Structured components must all be `table` or
+MUST be rejected at schema-load time. Scalar and array components MUST have the
+same kind as the local definition. Structured components MUST all be `table` or
 all be `collection`; a `table` and a `collection` are not interchangeable for
 composition because they have different unknown-key semantics. A component
 whose alternatives resolve to different kinds is likewise indeterminate and
@@ -2628,7 +2631,7 @@ evaluated, so dependencies may apply transitively.
 #### Mutual Exclusion - `mutuallyexclusive`
 
 `mutuallyexclusive` is a non-empty array of groups. Each group is an array of
-at least two unique child-name strings. At most one member of each group may be
+at least two unique child-name strings. At most one member of each group MAY be
 present.
 
 ```toml
@@ -4206,10 +4209,11 @@ target child definitions as dynamic collection entries. The
 collision when one definition needs both a schema property and a target child
 with the same name.
 
-The self-schema validates property value shapes, selector exclusivity,
-conditional completeness, tuple-versus-homogeneous array structure, nested child
-applicability, string formats, sibling-rule structures, annotations, and the
-selective `children` namespace.
+The self-schema validates property value shapes, selector mutual exclusivity —
+that no more than one selector is declared, though not that at least one selector
+is present — conditional completeness, tuple-versus-homogeneous array structure,
+nested child applicability, string formats, sibling-rule structures, annotations,
+and the selective `children` namespace.
 
 Rules that require resolving the schema's reference graph cannot be expressed
 that way and remain schema-load semantics:
@@ -4231,6 +4235,9 @@ semantics:
 
  - `version` rejecting a major-version-zero value, which the Semantic Versioning
    `pattern` in the self-schema necessarily accepts;
+ - rejecting a definition that declares no selector, no nested child definition,
+   and no `allof`, which the self-schema accepts today because it cannot require
+   that at least one of a selector, a nested child, or an `allof` be present;
  - `min` being less than or equal to `max`, `minlength` being less than or equal
    to `maxlength`, and a boundary's TOML kind agreeing with the type it
    constrains; and

--- a/SPEC.md
+++ b/SPEC.md
@@ -72,7 +72,7 @@ the other.
   definition with nested child definitions and no explicit selector is an
   **implicit table** (`type = "table"`), and a definition whose only applicator
   is `allof` is a **pure mixin** whose effective type comes from its components.
-  See [Types Table](#types-table---types) and
+  See [Selectors](#selectors) and
   [Composition Supplying the Local Skeleton](#composition-supplying-the-local-skeleton).
 
 - **Schema type**. The type a definition *selects* through `type`: a built-in
@@ -282,25 +282,42 @@ and the preferred term is the one to use in new text.
   - [Schema Versioning](#schema-versioning)
 - [Elements Table - `[elements]`](#elements-table---elements)
 - [Types Table - `[types]`](#types-table---types)
-  - [Type Reference Restrictions](#type-reference-restrictions)
+- [Schema Definitions](#schema-definitions)
   - [Schema Definition Properties](#schema-definition-properties)
     - [Local and Effective Checks](#local-and-effective-checks)
   - [Quoted and Special Keys](#quoted-and-special-keys)
-  - [Scalar and Unconstrained Built-in Types](#scalar-and-unconstrained-built-in-types)
-    - [Allowed Values - `allowedvalues`](#allowed-values---allowedvalues)
+  - [Selectors](#selectors)
+    - [Scalar and Unconstrained Built-in Types](#scalar-and-unconstrained-built-in-types)
+    - [Type Reference](#type-reference)
+    - [Type Reference Restrictions](#type-reference-restrictions)
+    - [Alternative Types - `oneof` and `anyof`](#alternative-types---oneof-and-anyof)
+    - [Conditional Selection - `if`, `then`, and `else`](#conditional-selection---if-then-and-else)
+      - [The Discriminator Key and Closed Branches](#the-discriminator-key-and-closed-branches)
+  - [Annotations](#annotations)
+    - [Description - `description`](#description---description)
+    - [Default - `default`](#default---default)
+    - [Deprecation - `deprecated`](#deprecation---deprecated)
+  - [Constraints](#constraints)
+    - [Optionality - `optional`](#optionality---optional)
+    - [Minimum Value / Maximum Value - `min` and `max`](#minimum-value--maximum-value---min-and-max)
+    - [Length - `minlength` and `maxlength`](#length---minlength-and-maxlength)
+    - [Pattern - `pattern`](#pattern---pattern)
     - [String Format - `format`](#string-format---format)
-  - [Minimum Value / Maximum Value - `min` and `max`](#minimum-value--maximum-value---min-and-max)
-  - [Length - `minlength` and `maxlength`](#length---minlength-and-maxlength)
+    - [Allowed Values - `allowedvalues`](#allowed-values---allowedvalues)
+    - [Array Uniqueness - `uniqueitems`](#array-uniqueness---uniqueitems)
+    - [Per-Member Value Constraints](#per-member-value-constraints)
+    - [Sibling Presence Rules](#sibling-presence-rules)
+      - [Dependencies - `dependentrequired`](#dependencies---dependentrequired)
+      - [Mutual Exclusion - `mutuallyexclusive`](#mutual-exclusion---mutuallyexclusive)
+      - [Exactly One - `exactlyone`](#exactly-one---exactlyone)
   - [Container Types](#container-types)
     - [Tables](#tables)
     - [Arrays](#arrays)
       - [Observations on Conditions to Arrays](#observations-on-conditions-to-arrays)
       - [Array Item Schemas and Arrays of Tables](#array-item-schemas-and-arrays-of-tables)
       - [Tuple / Positional Array Validation - `items`](#tuple--positional-array-validation---items)
-      - [Array Uniqueness - `uniqueitems`](#array-uniqueness---uniqueitems)
     - [Collection of Elements for Dynamic Keys](#collection-of-elements-for-dynamic-keys)
-    - [Per-Member Value Constraints](#per-member-value-constraints)
-  - [Type Reference](#type-reference)
+    - [Key Pattern - `keypattern`](#key-pattern---keypattern)
   - [Conjunctive Composition - `allof`](#conjunctive-composition---allof)
     - [Composition Supplying the Local Skeleton](#composition-supplying-the-local-skeleton)
     - [The Effective Definition](#the-effective-definition)
@@ -308,20 +325,6 @@ and the preferred term is the one to use in new text.
     - [Determinate Fixed-Child Set](#determinate-fixed-child-set)
     - [Effective Closure Set](#effective-closure-set)
     - [Composition Examples](#composition-examples)
-  - [Alternative Types - `oneof` and `anyof`](#alternative-types---oneof-and-anyof)
-  - [Conditional Selection - `if`, `then`, and `else`](#conditional-selection---if-then-and-else)
-    - [The Discriminator Key and Closed Branches](#the-discriminator-key-and-closed-branches)
-  - [Sibling Presence Rules](#sibling-presence-rules)
-    - [Dependencies - `dependentrequired`](#dependencies---dependentrequired)
-    - [Mutual Exclusion - `mutuallyexclusive`](#mutual-exclusion---mutuallyexclusive)
-    - [Exactly One - `exactlyone`](#exactly-one---exactlyone)
-  - [Annotations](#annotations)
-  - [Description - `description`](#description---description)
-  - [Default - `default`](#default---default)
-  - [Deprecation - `deprecated`](#deprecation---deprecated)
-  - [Optionality - `optional`](#optionality---optional)
-  - [Pattern - `pattern`](#pattern---pattern)
-  - [Key Pattern - `keypattern`](#key-pattern---keypattern)
 - [Validation and Data Model](#validation-and-data-model)
   - [Parsed Value Equality](#parsed-value-equality)
   - [Expressiveness and Validation Scope](#expressiveness-and-validation-scope)
@@ -652,122 +655,7 @@ unambiguous, a reusable type name MUST NOT begin with the literal characters
 `float`, `boolean`, `offset-date-time`, `local-date-time`, `local-date`,
 `local-time`, `array`, `table`, and `collection`.
 
-`type`, `oneof`, `anyof`, and the `if`/`then`/`else` triple are alternative
-ways to select the type of the current definition. A definition MUST declare
-at most one selector, and two constructs supply the selection in place of one:
-
-- a definition with nested child definitions MAY omit all selectors and is then
-  treated as `type = "table"`; and
-- a definition whose only applicator is a non-empty `allof` MAY omit all
-  selectors and all nested child definitions, and then takes its effective type
-  from that composition. [Composition Supplying the Local
-  Skeleton](#composition-supplying-the-local-skeleton) is authoritative for when
-  such a definition is valid and for the code a loader reports when it is not.
-
-Schema loaders MUST reject a definition that combines selectors, contains only
-part of a conditional triple, or declares no selector, no nested child
-definitions, and no `allof`. `type` accepts either a built-in type name or a
-named reusable definition from `[types]`. Container member types are selected separately with
-`itemtype`: it validates each member of an `array` or each dynamically keyed
-value of a `collection`. `itemtype` requires the same definition to declare the
-built-in `type = "array"` or `type = "collection"`; it cannot be attached to
-another built-in or to a named type reference.
-
-Nested child definitions are valid only when the current node selects the
-built-in `table` or `collection` type, or when the node omits a selector and is
-therefore an implicit table. Schema loaders MUST reject child definitions attached to
-a scalar, `array`, named type reference, `oneof`, `anyof`, or conditional node rather than
-silently ignoring them.
-
-```toml
-[types]
-
-[types.<typename>]
-type = "<type-reference>"
-description = "<human-readable description>"
-format = "<email|uuid|uri|hostname|ipv4|ipv6>"
-itemtype = "<type-reference>"
-items = [ "<type-reference>", ... ]
-oneof = [ "<type-reference>", ... ]
-anyof = [ "<type-reference>", ... ]
-if = { key = "<direct-child-name>", equals = <toml-value> }
-# or: if = { key = "<direct-child-name>", in = [ <toml-value>, ... ] }
-then = "types.<typename>"
-else = "types.<typename>"
-allof = [ "<type-reference>", ... ]
-allowedvalues = [ <array-with-enumeration-of-allowed-values> ]
-pattern = "<string-regex-for-string-validation>"
-keypattern = "<string-regex-for-collection-key-validation>"
-optional = true|false
-min = <integer | float | offset-date-time | local-date-time | local-date | local-time>
-max = <integer | float | offset-date-time | local-date-time | local-date | local-time>
-minlength = <integer>
-maxlength = <integer>
-uniqueitems = true|false
-dependentrequired = { <fixed-child> = [ "<fixed-child>", ... ], ... }
-mutuallyexclusive = [ [ "<fixed-child>", "<fixed-child>", ... ], ... ]
-exactlyone = [ [ "<fixed-child>", "<fixed-child>", ... ], ... ]
-default = <toml-value>
-deprecated = true|false
-```
-
-### Type Reference Restrictions
-
-This section is the single authority for which references each reference
-position accepts. Every other mention of these restrictions in this
-specification points here rather than restating them.
-
-| Position | Bare built-in name | Named `[types]` reference | Reference to a pure mixin | Reference edge |
-| --- | --- | --- | --- | --- |
-| `type` | Any built-in. `collection` only when the effective definition obtains an `itemtype` locally or from a compatible `allof` component | Yes | Yes | Non-consuming |
-| `itemtype` | Any built-in except `collection` | Yes | Yes | Consuming |
-| `items` | Any built-in except `collection` | Yes | Yes | Consuming |
-| `oneof`, `anyof` | Any built-in except `any` and `collection` | Yes | Yes | Non-consuming |
-| `allof` | Any built-in except `any` and `collection` | Yes | Yes | Non-consuming |
-| `then`, `else` | None; a bare built-in reference is invalid in either | Yes, and both branches MUST resolve to the same effective type, which MUST be `table` or `collection` | Yes, subject to that same kind requirement | Non-consuming |
-
-The two restricted built-ins are restricted for one reason each:
-
-- `collection` is valid for `type` only when the effective definition obtains
-  an `itemtype` locally or from a compatible `allof` component. It MUST NOT be
-  used as a bare reference in `itemtype`, `items`, `oneof`, `anyof`, `allof`,
-  `then`, or `else`, because those locations cannot supply the collection's dynamic-value
-  rule. Schema loaders MUST reject such references at schema-load time.
-- `any` is valid for `type`, `itemtype`, and `items`, but it MUST NOT appear
-  directly in `oneof`, `anyof`, `allof`, `then`, or `else`. Schema loaders MUST
-  reject a direct `any` component at schema-load time.
-
-These restrictions apply to bare built-in references, not to named reusable
-definitions. A named definition that declares a complete collection or selects
-`type = "any"` remains a valid reference. A
-[pure mixin](#composition-supplying-the-local-skeleton) is an ordinary named
-definition once its components determine its effective type, so it may be
-referenced wherever any other named definition may be, subject to the same kind
-requirement the position imposes on a named reference. What a definition may
-declare *beside* a named reference is stated under
-[Type Reference](#type-reference).
-
-Every named reference used by `type`, `itemtype`, `items`, `oneof`, `anyof`,
-`allof`, `then`, or `else`
-MUST resolve to a definition in `[types]`. Schema loaders MUST reject unresolved
-references at schema-load time, including references in definitions that are
-optional or not exercised by the document being validated. The ordered algorithm
-that turns a reference string into a built-in type or a reusable definition is
-defined under [Reference Resolution](#reference-resolution), which is
-authoritative for how the restrictions above are applied. An element MUST NOT
-reference another element, as
-[Elements Table](#elements-table---elements) requires.
-
-Type-selection and composition references MUST be acyclic. A cycle composed of
-named `type` aliases, `oneof` alternatives, `anyof` alternatives, conditional
-branches, or `allof` components — the positions the table above marks
-**non-consuming** — cannot resolve to a concrete definition and
-schema loaders MUST reject it at schema-load time. Structural recursion through
-table or collection children, array `itemtype`, or tuple `items` — the
-**consuming** positions — remains valid
-because each recursive step consumes a nested document value.
-[Cycle Legality](#cycle-legality) states this classification in terms of the
-reference graph and is authoritative for deciding which cycles are legal.
+## Schema Definitions
 
 ### Schema Definition Properties
 
@@ -776,8 +664,8 @@ detailed sections below remain authoritative.
 
 | Property | Applicable definition |
 | --- | --- |
-| `type` | Selects one built-in or named type; at most one selector per definition, per [Types Table](#types-table---types) |
-| `oneof`, `anyof` | Select the current node from one or more alternatives; at most one selector per definition, per [Types Table](#types-table---types) |
+| `type` | Selects one built-in or named type; at most one selector per definition, per [Selectors](#selectors) |
+| `oneof`, `anyof` | Select the current node from one or more alternatives; at most one selector per definition, per [Selectors](#selectors) |
 | `if`, `then`, `else` | Exhaustively select one of two named table-like definitions from a direct child's parsed value |
 | `allof` | Conjunctively applies one or more compatible type references in addition to the local definition; alone, it also supplies an omitted selector, per [Composition Supplying the Local Skeleton](#composition-supplying-the-local-skeleton) |
 | `description`, `optional`, `default`, `deprecated` | Any definition, including a named reference or alternative selector |
@@ -911,7 +799,7 @@ definition is a schema property, while a table-header path segment below that
 definition is normally a target child definition.
 
 A schema definition with nested child definitions and no explicit selector is an
-implicit table, as [Types Table](#types-table---types) defines. This lets
+implicit table, as [Selectors](#selectors) defines. This lets
 schemas describe target keys that would
 otherwise share a name with schema properties when the parent does not also use
 the property.
@@ -1016,7 +904,68 @@ Here `elements.plugin.type = "table"` selects the parent type, while
 Without the `children` segment, TOML would require `type` to be both a string
 and a table at the same path.
 
-### Scalar and Unconstrained Built-in Types
+### Selectors
+
+`type`, `oneof`, `anyof`, and the `if`/`then`/`else` triple are alternative
+ways to select the type of the current definition. A definition MUST declare
+at most one selector, and two constructs supply the selection in place of one:
+
+- a definition with nested child definitions MAY omit all selectors and is then
+  treated as `type = "table"`; and
+- a definition whose only applicator is a non-empty `allof` MAY omit all
+  selectors and all nested child definitions, and then takes its effective type
+  from that composition. [Composition Supplying the Local
+  Skeleton](#composition-supplying-the-local-skeleton) is authoritative for when
+  such a definition is valid and for the code a loader reports when it is not.
+
+Schema loaders MUST reject a definition that combines selectors, contains only
+part of a conditional triple, or declares no selector, no nested child
+definitions, and no `allof`. `type` accepts either a built-in type name or a
+named reusable definition from `[types]`. Container member types are selected separately with
+`itemtype`: it validates each member of an `array` or each dynamically keyed
+value of a `collection`. `itemtype` requires the same definition to declare the
+built-in `type = "array"` or `type = "collection"`; it cannot be attached to
+another built-in or to a named type reference.
+
+Nested child definitions are valid only when the current node selects the
+built-in `table` or `collection` type, or when the node omits a selector and is
+therefore an implicit table. Schema loaders MUST reject child definitions attached to
+a scalar, `array`, named type reference, `oneof`, `anyof`, or conditional node rather than
+silently ignoring them.
+
+```toml
+[types]
+
+[types.<typename>]
+type = "<type-reference>"
+description = "<human-readable description>"
+format = "<email|uuid|uri|hostname|ipv4|ipv6>"
+itemtype = "<type-reference>"
+items = [ "<type-reference>", ... ]
+oneof = [ "<type-reference>", ... ]
+anyof = [ "<type-reference>", ... ]
+if = { key = "<direct-child-name>", equals = <toml-value> }
+# or: if = { key = "<direct-child-name>", in = [ <toml-value>, ... ] }
+then = "types.<typename>"
+else = "types.<typename>"
+allof = [ "<type-reference>", ... ]
+allowedvalues = [ <array-with-enumeration-of-allowed-values> ]
+pattern = "<string-regex-for-string-validation>"
+keypattern = "<string-regex-for-collection-key-validation>"
+optional = true|false
+min = <integer | float | offset-date-time | local-date-time | local-date | local-time>
+max = <integer | float | offset-date-time | local-date-time | local-date | local-time>
+minlength = <integer>
+maxlength = <integer>
+uniqueitems = true|false
+dependentrequired = { <fixed-child> = [ "<fixed-child>", ... ], ... }
+mutuallyexclusive = [ [ "<fixed-child>", "<fixed-child>", ... ], ... ]
+exactlyone = [ [ "<fixed-child>", "<fixed-child>", ... ], ... ]
+default = <toml-value>
+deprecated = true|false
+```
+
+#### Scalar and Unconstrained Built-in Types
 
 The unconstrained built-in type is:
 
@@ -1033,66 +982,828 @@ The scalar built-in types are:
 - Local Date: `local-date`
 - Local Time: `local-time`
 
-#### Allowed Values - `allowedvalues`
+#### Type Reference
 
-`allowedvalues` provides an enumeration for a scalar or unconstrained built-in
-type. On an `array` or a `collection` it is instead a
-[per-member constraint](#per-member-value-constraints) and enumerates the values
-permitted for each item or each dynamic entry, as also described
-under [Observations on Conditions to Arrays](#observations-on-conditions-to-arrays).
-It is invalid on a `table`.
+A type reference applies a built-in type or inherits the rules of a named reusable type. Both `[types]` definitions and `[elements]` definitions may use type references. The `type` property selects the current node's type; built-in and named references use the same syntax.
 
-The `allowedvalues` array MUST contain at least one entry. Every entry on a
-definition that is neither an `array` nor a `collection` MUST have the TOML kind
-selected by that definition;
-`type = "any"` is the exception and permits entries of any TOML kind. Numeric
-equality between integers and floats does not make their TOML kinds
-interchangeable for this schema-load check. A malformed enumeration MUST be
-rejected at schema-load time.
+When `type` selects a named reusable definition, the reference inherits that
+definition's validation rules as-is. This inheritance includes `optional`, as
+[Optionality](#optionality---optional) defines. In version 1.0, the
+referencing definition MAY additionally declare only `allof`, `description`,
+`optional`, `default`, and `deprecated`; it MUST NOT declare any other sibling
+property or child definition. `allof` adds conjunctive components rather than
+overriding the named reference. A local `default` is the use-site annotation
+defined under [Default](#default---default), and `deprecated = false` cannot
+cancel deprecation inherited from a reference. In particular, validation
+constraints such as `pattern`,
+`keypattern`, `min`, `max`, `minlength`, `maxlength`, `allowedvalues`,
+`itemtype`, and `items` cannot be added or overridden at the reference site.
+Schema loaders MUST reject such schemas at schema-load time.
 
-For a definition that is neither an `array` nor a `collection`, when
-`allowedvalues` is combined with `pattern`, `format`,
-`min`, `max`, `minlength`, or `maxlength` on the same definition, every entry in
-`allowedvalues` MUST satisfy every applicable constraint. A schema containing an
-entry that violates one of those constraints is malformed, and schema loaders
-MUST reject it at schema-load time. This is a consistency check on the
-enumeration itself; it describes nothing about how a document value is
-validated. For offset date-times, this boundary check uses instant
-ordering even though subsequent `allowedvalues` membership uses parsed-value
-equality; equivalent instants with different retained local fields or offsets
-therefore compare equal for a boundary but remain distinct enumeration values.
+To specialize validation rules, declare another named reusable definition rather than adding constraints to a reference:
 
-After a schema with `allowedvalues` has been loaded successfully, each document
-value governed by that definition — each item or dynamic-entry value, for an
-`array` or `collection` definition —
-is evaluated in the following order:
+```toml
+[types.lowercaseName]
+type = "string"
+pattern = "^[a-z]+$"
 
-1. The value's parsed TOML kind MUST be the kind the definition selects for it,
-   through `type` or, for container members, through `itemtype`. A kind mismatch
-   is a
-   validation error regardless of `allowedvalues`, and membership in the
-   enumeration never satisfies the type check. For example, a definition with
-   `type = "integer"` and `allowedvalues = [ 80, 443 ]` rejects the document
-   value `80.0` even though [Parsed Value Equality](#parsed-value-equality)
-   makes `80.0` equal to `80`. The unconstrained `any` selects no kind and
-   imposes no such restriction.
-2. Every other assertion that applies to the value is evaluated, including the
-   assertions declared on the definition itself and those contributed by `allof`
-   components. Validators MUST NOT skip an assertion on the grounds that the
-   enumeration was already checked while loading the schema: that schema-load
-   check covers only the definition's own constraints listed above, and a
-   composed constraint does not participate in it.
-3. The value MUST be a member of `allowedvalues` according to
-   [Parsed Value Equality](#parsed-value-equality).
+[elements.name]
+type = "types.lowercaseName"
+description = "Display name"
+optional = true
+```
 
-The value is valid for that definition only when all three steps succeed.
+The following is invalid because `pattern` attempts to override the referenced definition:
+
+```toml
+[types.name]
+type = "string"
+pattern = "^[a-z]+$"
+
+[elements.name]
+type = "types.name"
+pattern = "^[A-Z]+$" # invalid
+```
+
+```toml
+[types]
+
+    [types.nameType]
+    type="string"
+    pattern="[a-zA-Z]"  # unanchored: matches any string containing a letter
+
+    [types.serverType.name]
+    type = "types.nameType"
+
+    [types.serverType.enabled]
+    type = "boolean"
+
+[elements]
+
+    [elements.datacenter]
+    type="table"
+
+        [elements.datacenter.name]
+        type="types.nameType"
+
+        [elements.datacenter.tags]
+        type = "array"
+        itemtype = "string"
+
+        [elements.datacenter.servers]
+        type = "collection"
+        itemtype = "types.serverType"
+```
+
+#### Type Reference Restrictions
+
+This section is the single authority for which references each reference
+position accepts. Every other mention of these restrictions in this
+specification points here rather than restating them.
+
+| Position | Bare built-in name | Named `[types]` reference | Reference to a pure mixin | Reference edge |
+| --- | --- | --- | --- | --- |
+| `type` | Any built-in. `collection` only when the effective definition obtains an `itemtype` locally or from a compatible `allof` component | Yes | Yes | Non-consuming |
+| `itemtype` | Any built-in except `collection` | Yes | Yes | Consuming |
+| `items` | Any built-in except `collection` | Yes | Yes | Consuming |
+| `oneof`, `anyof` | Any built-in except `any` and `collection` | Yes | Yes | Non-consuming |
+| `allof` | Any built-in except `any` and `collection` | Yes | Yes | Non-consuming |
+| `then`, `else` | None; a bare built-in reference is invalid in either | Yes, and both branches MUST resolve to the same effective type, which MUST be `table` or `collection` | Yes, subject to that same kind requirement | Non-consuming |
+
+The two restricted built-ins are restricted for one reason each:
+
+- `collection` is valid for `type` only when the effective definition obtains
+  an `itemtype` locally or from a compatible `allof` component. It MUST NOT be
+  used as a bare reference in `itemtype`, `items`, `oneof`, `anyof`, `allof`,
+  `then`, or `else`, because those locations cannot supply the collection's dynamic-value
+  rule. Schema loaders MUST reject such references at schema-load time.
+- `any` is valid for `type`, `itemtype`, and `items`, but it MUST NOT appear
+  directly in `oneof`, `anyof`, `allof`, `then`, or `else`. Schema loaders MUST
+  reject a direct `any` component at schema-load time.
+
+These restrictions apply to bare built-in references, not to named reusable
+definitions. A named definition that declares a complete collection or selects
+`type = "any"` remains a valid reference. A
+[pure mixin](#composition-supplying-the-local-skeleton) is an ordinary named
+definition once its components determine its effective type, so it may be
+referenced wherever any other named definition may be, subject to the same kind
+requirement the position imposes on a named reference. What a definition may
+declare *beside* a named reference is stated under
+[Type Reference](#type-reference).
+
+Every named reference used by `type`, `itemtype`, `items`, `oneof`, `anyof`,
+`allof`, `then`, or `else`
+MUST resolve to a definition in `[types]`. Schema loaders MUST reject unresolved
+references at schema-load time, including references in definitions that are
+optional or not exercised by the document being validated. The ordered algorithm
+that turns a reference string into a built-in type or a reusable definition is
+defined under [Reference Resolution](#reference-resolution), which is
+authoritative for how the restrictions above are applied. An element MUST NOT
+reference another element, as
+[Elements Table](#elements-table---elements) requires.
+
+Type-selection and composition references MUST be acyclic. A cycle composed of
+named `type` aliases, `oneof` alternatives, `anyof` alternatives, conditional
+branches, or `allof` components — the positions the table above marks
+**non-consuming** — cannot resolve to a concrete definition and
+schema loaders MUST reject it at schema-load time. Structural recursion through
+table or collection children, array `itemtype`, or tuple `items` — the
+**consuming** positions — remains valid
+because each recursive step consumes a nested document value.
+[Cycle Legality](#cycle-legality) states this classification in terms of the
+reference graph and is authoritative for deciding which cycles are legal.
+
+#### Alternative Types - `oneof` and `anyof`
+
+Use `oneof` or `anyof` when a value may validate against alternative type references.
+
+- `oneof`: exactly one referenced type must validate.
+- `anyof`: at least one referenced type must validate.
+
+These properties can be used anywhere a schema definition can appear, including an `[elements]` field, a reusable `[types]` definition, and a type referenced through `itemtype` for array or collection items. Which references an alternative may name is stated under
+[Type Reference Restrictions](#type-reference-restrictions); use a named
+reusable definition when an alternative needs a fully defined collection, an
+intentionally unconstrained named branch, or any other constraint.
+
+`type`, `oneof`, `anyof`, and the conditional triple all select the current
+node's type, and a definition declares at most one of them, as
+[Selectors](#selectors) requires.
+
+The array assigned to `oneof` or `anyof` MUST contain at least one type
+reference. A union definition MAY additionally declare only `description`,
+`optional`, `default`, `deprecated`, and `allof`; it MUST NOT declare another
+validation property or any nested child definition. Schema loaders MUST reject
+empty unions and other union siblings at schema-load time. Constraints required
+by an alternative belong in a named reusable definition referenced by the
+union.
+
+The alternatives of a `oneof` or `anyof` array MUST be distinct. A repeated
+alternative adds no branch and, for `oneof`, cannot be the exactly-one match.
+Duplication is judged on resolved identity, after the optional `types.` prefix
+has been removed, so `oneof = [ "types.stringId", "stringId" ]` names the same
+definition twice and is malformed. Schema loaders MUST reject a duplicate
+alternative at schema-load time. This differs from
+[`items`](#tuple--positional-array-validation---items), where an entry denotes a
+tuple position rather than an alternative and repetition is meaningful.
+
+A union contributes nothing to the
+[determinate fixed-child set](#determinate-fixed-child-set) of the node it
+selects, because no alternative is chosen until a document value exists. It does
+contribute at validation time: when an alternative is evaluated against a
+document node, that alternative's fixed children join the node's
+[effective closure set](#effective-closure-set) for that evaluation, so a key
+the alternative declares is a known key of the node and MUST NOT be reported as
+unexpected. This is what lets a union be composed into a table with `allof`
+without the alternatives' own children becoming unknown keys.
+
+When alternatives contain annotations, only successful alternatives contribute
+them, and only for a value that is present. Deprecation warnings follow the
+successful-alternative rule: `oneof` reports the warning of its single
+successful alternative, and `anyof` reports the warnings of every successful
+alternative, deduplicated as [Diagnostics](#diagnostics) requires. Consequently,
+a deprecated successful alternative contributes a warning even when another
+successful `anyof` alternative is not deprecated; this preserves all annotations
+attached to definitions that accepted the value. Alternative `default`
+annotations are governed by [Default](#default---default): they are never
+combined into the slot's effective default and never cause a schema-load
+conflict. For a present value, an implementation MAY surface the default of each
+successful alternative as a hint, deduplicated by
+[Parsed Value Equality](#parsed-value-equality). An alternative that fails
+validation contributes neither defaults nor deprecation warnings; what happens to
+its diagnostics is defined under
+[Alternative and Branch Commit and Discard](#alternative-and-branch-commit-and-discard).
+
+Examples:
+
+```toml
+[types.stringId]
+type = "string"
+pattern = "^[a-z]+$"
+
+[types.integerId]
+type = "integer"
+min = 1
+
+[elements.id]
+anyof = [ "types.stringId", "types.integerId" ]
+
+[elements.simpleId]
+oneof = [ "string", "integer" ]
+```
+
+Use a named reusable definition whenever an alternative needs constraints such as `pattern`, `min`, `allowedvalues`, `itemtype`, or child fields.
+
+```toml
+[types.dependencyVersion]
+type = "string"
+pattern = "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+
+[types.inlineDependency]
+type = "table"
+
+[types.dependency]
+oneof = [ "types.dependencyVersion", "types.inlineDependency" ]
+```
+
+For container items with alternative types, use a named wrapper:
+
+```toml
+[types.dnsValue]
+oneof = [ "types.ipAddress", "types.hostname" ]
+
+[elements.dns]
+type = "collection"
+itemtype = "types.dnsValue"
+```
+
+A named container definition can also be an alternative. This models formats
+that accept either one table or an array of the same table shape:
+
+```toml
+[types.cascadeEntry]
+type = "table"
+
+    [types.cascadeEntry.params]
+    type = "table"
+    optional = true
+
+[types.cascadeEntries]
+type = "array"
+itemtype = "types.cascadeEntry"
+
+[elements.cascade]
+oneof = [ "types.cascadeEntry", "types.cascadeEntries" ]
+```
+
+#### Conditional Selection - `if`, `then`, and `else`
+
+The `if`, `then`, and `else` properties form one exhaustive selector for a
+table-like node. The condition inspects one direct child of the current parsed
+table and selects one of two named reusable definitions:
+
+```toml
+[types.sqliteDatabase]
+type = "table"
+
+    [types.sqliteDatabase.engine]
+    type = "string"
+    allowedvalues = [ "sqlite" ]
+
+    [types.sqliteDatabase.path]
+    type = "string"
+
+[types.serverDatabase]
+type = "table"
+
+    [types.serverDatabase.engine]
+    type = "string"
+    allowedvalues = [ "postgresql", "mysql" ]
+
+    [types.serverDatabase.host]
+    type = "string"
+
+[types.database]
+if = { key = "engine", equals = "sqlite" }
+then = "types.sqliteDatabase"
+else = "types.serverDatabase"
+```
+
+Both branches declare `engine`, the key the condition reads. That is required
+rather than stylistic: see
+[The Discriminator Key and Closed Branches](#the-discriminator-key-and-closed-branches)
+below.
+
+`if` MUST be an inline table containing `key` and exactly one of `equals` or
+`in`. It MUST contain no other members.
+
+Because `if` is also a legal child key, an `if = { ... }` key/value entry is
+always the conditional selector, while a table header such as
+`[types.example.if]` is always a child definition named `if`. Consequently the
+condition MUST use inline-table syntax and can never be written as
+`[types.example.if]`. A definition that needs a target child named `if` writes
+that child through the `children` namespace, as described under
+[Quoted and Special Keys](#quoted-and-special-keys). A conditional definition
+has no nested child definitions of its own, so the two spellings never compete
+within one conditional definition, but a loader still MUST NOT infer the
+selector from a table-form `if`.
+
+- `key` MUST be a string naming one direct child key of the parsed table being
+  validated. It is a decoded TOML key, not a dotted document path, and it does
+  not have to name a schema-declared child, because a conditional definition has
+  no nested child definitions of its own. An empty or literal dotted key is
+  permitted.
+- `equals` accepts one TOML value. The condition succeeds when the child exists
+  and is equal to that value according to [Parsed Value Equality](#parsed-value-equality).
+- `in` MUST be a non-empty array. The condition succeeds when the child exists
+  and is equal to at least one array entry according to Parsed Value Equality.
+
+If the named child is absent, the condition is false. A validator MUST apply
+only the selected branch: `then` when the condition is true and `else` when it
+is false. The condition itself emits no document-validation diagnostic.
+Validation diagnostics and deprecation annotations come only from the selected
+branch. A branch default does not become the conditional slot's effective
+default; for a present value, an implementation MAY surface the selected
+branch's default as a hint.
+
+The condition reads a direct child of a parsed table. When the document value at
+a conditional node is not a table — a scalar, an array, or an array of tables —
+no direct child can be read, so the condition cannot be satisfied and is false,
+exactly as it is for an absent child. `else` is therefore the selected branch.
+Because both branches MUST resolve to the same table-like effective type, that
+value cannot validate against either branch, and the node is invalid. A
+validator MUST report this as a kind mismatch against the common branch kind at
+the node's location, using the `type-mismatch` code defined under
+[Validation Codes](#validation-codes), and MUST NOT report the branch's internal
+`missing-required` or `unknown-key` diagnostics for a value that is not a table
+at all. It MUST NOT report a diagnostic describing the condition, which never
+fails on its own.
+
+Consequently, a `default` on a conditional definition MUST be a table. A
+non-table default cannot satisfy either branch, so a schema loader MUST reject
+it at schema-load time under the default-validation rule stated below.
+
+Like a union, the conditional triple contributes nothing to the
+[determinate fixed-child set](#determinate-fixed-child-set) of the node it
+selects. The selected branch's fixed children join the node's
+[effective closure set](#effective-closure-set) at validation time, so the keys
+the matched branch declares are known keys of that node, while keys declared
+only by the branch that was not selected are not.
+
+`then` and `else` MUST each be a string naming a reusable definition in
+`[types]`, and both definitions MUST resolve
+to the same effective type, which MUST be `table` or `collection`, as
+[Type Reference Restrictions](#type-reference-restrictions) states.
+Schema loaders MUST reject unresolved branches, different branch kinds,
+branches that do not resolve to a table-like kind, and cycles through
+conditional branches.
+
+The conditional triple is one of the four selectors a definition declares at
+most one of, as [Selectors](#selectors) requires. A conditional
+definition MAY additionally declare only `allof`,
+`description`, `optional`, `default`, and `deprecated`; it MUST NOT contain
+kind-specific validation properties or nested child definitions. An `allof`
+component MUST be compatible with the common branch kind and is applied
+conjunctively with whichever branch is selected.
+
+Optionality belongs to the conditional definition, as
+[Optionality](#optionality---optional) defines. A default on the conditional
+definition MUST validate against the branch selected by that default at
+schema-load time.
+
+Example with a multi-value condition:
+
+```toml
+[types.database]
+if = { key = "engine", in = [ "postgresql", "mysql" ] }
+then = "types.serverDatabase"
+else = "types.embeddedDatabase"
+```
+
+Additional alternatives can be expressed by referencing another conditional
+definition from `then` or `else`.
+
+##### The Discriminator Key and Closed Branches
+
+The key named by `if.key` is ordinary application data. It is read to select a
+branch, and it is then validated by the selected branch like any other key. A
+conditional definition contributes no fixed children of its own, so nothing
+declares the discriminator on the node's behalf.
+
+A branch that declares fixed children is closed against exactly those children,
+as [Effective Closure Set](#effective-closure-set) defines. If such a branch
+omits the discriminator, the key the condition just read is not in the node's
+effective closure set and a validator MUST report it as an unknown key, so the
+conditional can never accept a document. Every closed branch MUST therefore
+declare the discriminator itself.
+
+Schema loaders MUST reject a conditional definition when a branch has a
+non-empty [determinate fixed-child set](#determinate-fixed-child-set) that does
+not contain the key named by `if.key`. That set is computed at schema-load time,
+so this check catches the common authoring mistake without resolving
+document-dependent shapes. A branch whose fixed children are contributed only by
+a nested union or conditional has an empty determinate set, and a loader cannot
+decide the question for it; the same unknown-key rule still applies at
+validation time, and authors remain responsible for declaring the discriminator
+in every shape a branch can take.
+
+Two branch shapes need no declaration and are not rejected: a branch that is an
+open table, whose effective closure set is empty and which therefore accepts the
+discriminator as arbitrary data, and a branch that is a `collection`, whose
+dynamic-entry rules accept the discriminator when its `keypattern` and
+`itemtype` permit it.
+
+The `else` branch is subject to the same rule as `then`. An `else` branch is
+selected both when the discriminator holds a different value and when it is
+absent, so a closed `else` branch typically declares the discriminator with
+`optional = true`, with `allowedvalues` excluding the value that selects `then`,
+or with both. In the example above, `types.serverDatabase` declares `engine`
+with `allowedvalues = [ "postgresql", "mysql" ]`, which both admits the key and
+rejects a value that should have selected the other branch.
+
+### Annotations
+
+`description`, `default`, and `deprecated` are **annotations**. Unlike the
+assertions defined below, an annotation never decides validity: it cannot make a
+document valid or invalid, and removing every annotation from a schema leaves
+the set of documents that schema accepts unchanged. The sections below define
+each annotation; this section defines what they attach to and how one effective
+value is obtained when a definition is reached indirectly.
+
+**Attachment.** An annotation attaches to the document node being validated —
+identified by its [instance path](#instance-path) — not to the schema definition
+that carries it. The same definition applied at several nodes annotates each node
+separately, and a definition applied to no node annotates nothing. Consequences:
+
+- A definition used as an array `itemtype` annotates every present item node, not
+  the array. A deprecated `itemtype` applied to an array of one hundred items
+  therefore produces one hundred warnings, one per item node, and never a single
+  warning for the array.
+- A definition used as a `collection` `itemtype` annotates every present
+  dynamically keyed entry, once per entry.
+- A definition reached through `items` annotates the one indexed node it
+  validates.
+- An absent optional slot holds no node, so it carries no annotation and produces
+  no deprecation warning.
+
+Every annotation-derived diagnostic therefore carries the instance path of the
+node it annotates. The severity and code of such a diagnostic are assigned by
+[Diagnostics](#diagnostics); this section defines only what annotations attach
+to.
+
+**Effective annotation.** For one document location, the participants that may
+carry an annotation are the use site, each definition along that use site's
+`type` reference chain, each `allof` component of the effective definition, the
+`oneof` or `anyof` alternative that succeeded, and the conditional branch that
+was selected. The general precedence is:
+
+1. an annotation declared at the use site takes precedence over the same
+   annotation obtained through that use site's `type` reference chain, and
+   within the chain the nearest declaration takes precedence over a more distant
+   one;
+2. `allof` components, union alternatives, and conditional branches contribute
+   annotations for the location they help validate, but never override an
+   annotation the use site or its reference chain already supplies.
+
+`deprecated` is an exception to point 2 and does not follow the general
+precedence: it combines disjunctively rather than resolving to a single
+declaration, so a contributing `deprecated = true` deprecates the location even
+when the use site declares `deprecated = false`. [Deprecation](#deprecation---deprecated) is
+authoritative for it. The general precedence governs `description` and any
+future annotation that resolves to at most one value.
+
+Each annotation then resolves its own contributions as follows.
+
+`description` follows the general precedence and resolves to at most one value.
+A use-site `description` overrides the one carried by the definition it
+references, and the nearest description along a reference chain overrides a more
+distant one; the use site is the more specific statement about that location, so
+it wins. Descriptions carried by `allof` components, by the successful union
+alternative, and by the selected conditional branch never replace that value.
+Where a single description is required — an editor hover, for instance — the
+effective description is the use-site or reference-chain value if one exists,
+and otherwise nothing. An implementation MAY additionally expose the
+contributed descriptions as documentation, in a stable order: `allof`
+components in declaration order, then the successful alternative or selected
+branch. It MUST NOT merge or concatenate contributions into a value it presents
+as a single authored description, and it MUST NOT reject a schema because two
+participants carry different descriptions.
+
+`default` does not follow this general precedence alone, because it is
+machine-readable and must resolve to exactly one value. Its precedence and
+conflict rules, including the `allof` and union rules, are defined under
+[Default](#default---default) and are authoritative.
+
+`deprecated` is a per-node warning. It fires once for each present document node
+whose effective definition is deprecated, and duplicate warnings contributed by
+more than one successful path are deduplicated as
+[Diagnostics](#diagnostics) requires. It fires per node and never per definition,
+so the count follows the attachment rules above. Deprecation is not inherited
+downward: a deprecated parent produces one warning at the parent's instance path,
+and a descendant produces a warning only when its own effective definition is
+deprecated. When a union or conditional definition is itself deprecated, that
+warning is reported at the node's own instance path in addition to any warning
+contributed by the successful alternative or selected branch, and the two are
+distinct instance paths only when the alternative or branch annotates a
+descendant.
+
+#### Description - `description`
+
+`description` is an optional human-readable string that documents a schema definition. It may be used on reusable types, elements, and nested definitions. Implementations and tooling MAY use it for documentation, suggestions, and autocompletion; it does not affect validation. Its precedence when a definition is reached through a reference, composition, an alternative, or a conditional branch is defined under [Annotations](#annotations).
+
+```toml
+[types.game]
+type = "table"
+description = "A game object."
+
+    [types.game.id]
+    type = "string"
+    description = "Unique identifier for the game."
+
+[elements.game]
+type = "array"
+description = "A list of games."
+itemtype = "types.game"
+```
+
+#### Default - `default`
+
+`default` is a machine-readable annotation containing any TOML value. Like the
+other annotations, it attaches to the document node a definition validates, and
+to the slot that node occupies, as described under [Annotations](#annotations);
+unlike them, it MUST resolve to exactly one value, and the rules below are
+authoritative for that resolution.
+
+Because `default` is also a legal child key, a `default = <value>` key/value
+entry is always the annotation, while a table header such as
+`[elements.options.default]` is always a child definition named `default`.
+Consequently, a table-valued default MUST use inline-table syntax, for example
+`default = { min = 1, max = 10 }`. A definition that needs both the annotation
+and a child named `default` writes the child through the `children` namespace,
+as described under [Quoted and Special Keys](#quoted-and-special-keys).
+
+A default is not a validation assertion and never changes the document being
+validated. It does not insert a missing value, satisfy a required definition,
+or change the parsed TOML data returned by an implementation. Tools MAY expose
+it as a suggestion or effective-configuration hint through schema metadata.
+Version 1.0 does not define an operation that materializes defaults.
+
+Despite being an annotation, a declared default MUST validate as a present
+value against the full effective definition at schema-load time. Default
+validation applies all references, composition, alternatives, fixed children,
+sibling rules, and ordinary constraints, but does not emit a deprecation
+warning. A loader MUST reject an incompatible default. This is one of the
+schema-load checks that read the effective rather than the local view, as
+[Local and Effective Checks](#local-and-effective-checks) records.
+
+A default declared directly at a use site takes precedence over one inherited
+through its `type` reference. Without a use-site default, the referenced
+default is inherited. Defaults contributed by `allof` components are compared using
+[Parsed Value Equality](#parsed-value-equality). Equal defaults are
+deduplicated. If components contribute unequal defaults and the local
+definition has no default, the schema is malformed because it has no single
+effective default. A valid local default resolves that annotation conflict and
+must still satisfy every component.
+
+Alternative selectors do not contribute to a slot's effective default. The
+effective default of a slot whose selector resolves to `oneof` or `anyof` is
+determined only by a use-site `default`, a default inherited through the named
+`type` reference chain that resolves to the union, and defaults composed
+through `allof`, using the precedence and conflict rules above. A `default`
+declared on an individual alternative is never aggregated into the union's
+effective default and never causes a schema-load conflict, even when several
+`anyof` alternatives declare unequal defaults. A loader MUST NOT reject a
+schema solely because two alternatives declare defaults, equal or unequal.
+Resolving effective defaults therefore never requires deciding whether two
+alternatives can match the same value.
+
+When a union slot is absent, only this effective default applies; if none
+exists, the slot has no default. When the slot value is present, `default` does
+not change it, so alternative defaults surfaced under the successful-alternative
+rule are informational hints. An implementation MAY expose the default of each
+successful alternative, deduplicated by
+[Parsed Value Equality](#parsed-value-equality), but MUST NOT treat multiple
+present-value alternative defaults as an error.
 
 Example:
+
 ```toml
-[types.colorType]
-type="string"
-allowedvalues=[ "red", "black", "blue" ]
+[elements.retries]
+type = "integer"
+optional = true
+default = 3
 ```
+
+#### Deprecation - `deprecated`
+
+`deprecated` is a boolean annotation. When `true`, it advises that the present
+value at that schema location should no longer be used and may be removed in a
+future version.
+
+Deprecation never makes a document invalid. A successfully validated present
+value produces a warning diagnostic with the code `deprecated`; an absent
+optional value produces no warning. A deprecated parent produces one warning at
+the parent's instance path rather than one warning for every descendant. The
+instance path a deprecation warning is reported at, and how many warnings a
+deprecated array `itemtype` or collection `itemtype` produces, follow the
+attachment rules under [Annotations](#annotations). Whether a node counts as
+successfully validated for this purpose is decided by the annotation step of
+[Keyword Evaluation Order](#keyword-evaluation-order).
+
+Deprecation propagates through named references. Across `allof`, any
+contributing `deprecated = true` deprecates the location, and a local
+`deprecated = false` cannot cancel it. Which warning a definition contributes
+when it is reached through an alternative or a conditional branch is defined
+under [Annotations](#annotations). A non-boolean `deprecated`
+value is a schema-load error. Authors SHOULD use `description` for migration or
+replacement guidance.
+
+Example:
+
+```toml
+[elements.legacy-timeout]
+type = "integer"
+deprecated = true
+description = "Use request-timeout instead."
+optional = true
+```
+
+### Constraints
+
+#### Optionality - `optional`
+
+A definition may be marked optional in the schema. By default, `optional` is
+`false`, and the structure is required.
+
+Validators MUST skip a definition only when it is optional and the corresponding
+value does not exist in the TOML document. In every other case, the validator
+MUST validate the value against the definition.
+
+This section is the single authority for how `optional` interacts with
+references, composition, alternatives, and conditional branches.
+
+For a named `type` reference, optionality is inherited: the referencing slot is
+optional if either the use site or any definition in the reference chain
+declares `optional = true`. An explicit `optional = false` cannot cancel an
+inherited `true`. In contrast, `optional` on the local definition determines
+whether a composed node may be absent, and `optional` values contributed only
+through `allof` components do not affect presence; such a value has meaning only
+when that component is referenced normally with `type`. The presence of a
+`oneof` or `anyof` slot is governed only by `optional` on the union definition
+or inherited through a named `type` reference to that union. `optional`
+declared inside an alternative does not make the union slot optional because
+no alternative is selected when the slot is absent. Optionality likewise belongs
+to a conditional definition rather than to its branches: an `optional`
+annotation inside a `then` or `else` branch does not make the conditional slot
+optional, because no branch is selected when the slot is absent.
+
+#### Minimum Value / Maximum Value - `min` and `max`
+
+These properties define inclusive value ranges. The **comparable kinds** are:
+
+ - `float`
+ - `integer`
+ - date and/or time types: `offset-date-time`, `local-date-time`, `local-date`, and `local-time`
+
+`min` and `max` MAY be declared only on a definition whose type resolves to
+exactly one comparable kind, and on an `array` or a `collection` whose members
+do, as the per-member reading below describes.
+
+A `min` or `max` boundary MUST be a TOML value that is comparable with the effective type: `integer` or `float` boundaries for `integer` and `float` values, and matching temporal boundaries for temporal values.
+
+`nan`, `+nan`, and `-nan` are not valid `min` or `max` boundaries because NaN is unordered. `inf`, `+inf`, and `-inf` are valid float boundaries, but they are not valid boundaries on a definition whose comparable kind is `integer`; an infinite boundary has no integer counterpart and constrains no integer value, so schema loaders MUST reject it there at schema-load time.
+
+Date/time boundaries compare only against values of the same TOML temporal type. For example, an `offset-date-time` boundary applies to `offset-date-time` values, not to `local-date-time` values.
+
+Numeric ranges use mathematical ordering after TOML parsing. Integer-to-integer
+ordering MUST remain exact across the full signed 64-bit range. Mixed
+integer/float ordering MUST compare the exact integer with the parsed binary
+floating-point value without first rounding the integer to that floating-point
+format. Positive and negative zero have the same position. A document NaN is
+unordered and never satisfies a range constraint.
+
+Offset date-times are ordered by the instant they identify after applying their
+offset; representations of the same instant compare equal even when their local
+fields and offsets differ. Local date-times, local dates, and local times are
+ordered lexicographically by their parsed fields, from the largest component to
+the smallest, including fractional seconds. No timezone or daylight-saving
+conversion is applied to a local temporal value.
+
+When both `min` and `max` are present, `min` MUST be less than or equal to `max`
+under the same ordering this section defines for validation: mathematical
+ordering for numeric boundaries, instant ordering for `offset-date-time`
+boundaries, and parsed-field ordering for `local-date-time`, `local-date`, and
+`local-time` boundaries. A schema violating that rule is malformed and schema
+loaders MUST reject it at schema-load time. The comparison is always defined
+because the unordered boundary values excluded above are not valid boundaries in
+the first place.
+
+On an `array` or a `collection`, `min` and `max` are
+[per-member constraints](#per-member-value-constraints) and apply to each item
+or each dynamic entry. That section is authoritative for the per-member reading,
+for how the member type is resolved through `itemtype` and through the
+alternatives of a referenced `oneof` or `anyof`, and for the schema-load
+rejection of a member type that is indeterminate or of the wrong kind. The
+interaction between array range
+boundaries and `allowedvalues` is defined under
+[Observations on Conditions to Arrays](#observations-on-conditions-to-arrays).
+
+#### Length - `minlength` and `maxlength`
+
+These properties MUST be used only to define the allowed length of a `string`,
+an `array`, or a `collection`.
+
+`minlength` and `maxlength` are valid only on definitions whose selected type is
+the built-in `string`, `array`, or `collection`. They cannot be attached to
+another built-in type, an alternative selector, or a named type reference, as
+[Schema Definition Properties](#schema-definition-properties) requires.
+Schema loaders MUST reject an incompatible length constraint at schema-load time rather
+than silently ignoring it.
+
+Both `minlength` and `maxlength` MUST be integers `>= 0`. When both are present, `minlength` MUST be less than or equal to `maxlength`. A schema violating either rule is malformed and schema loaders MUST reject it at schema-load time.
+
+For `string` values, length is counted as the number of Unicode scalar values after TOML parsing and escape processing. It is not the number of UTF-8 bytes, UTF-16 code units, or user-perceived grapheme clusters. For example, `"\U0001F600"` has length 1, while `"e\u0301"` has length 2 because it is composed of two Unicode scalar values.
+
+For an `array`, length is its number of items. For a `collection`, length is
+the number of dynamic entries to which `itemtype` applies; fixed child
+definitions are excluded from the count.
+
+On an `array` or a `collection` these two properties always bound the
+container's own member count. They are deliberately excluded from the
+[per-member value-constraint subset](#per-member-value-constraints), which
+explains why, and a per-member length bound is written on the definition the
+container's `itemtype` reaches.
+
+#### Pattern - `pattern`
+
+`pattern` constrains a parsed TOML string with a regular expression.
+
+`pattern` is valid on a definition whose selected type is the built-in
+`string`, and, as a [per-member constraint](#per-member-value-constraints), on a
+non-tuple `array` or `collection` whose effective member type is the built-in
+`string`. It cannot be attached to another built-in type, an alternative
+selector, or a named type reference, as
+[Schema Definition Properties](#schema-definition-properties) requires. Schema
+loaders MUST reject an incompatible
+`pattern` at schema-load time rather than silently ignoring it. On a
+`collection`, `pattern` constrains dynamic entry values while
+[`keypattern`](#key-pattern---keypattern) constrains their keys.
+
+The portable TOML Schema regular-expression profile consists of literals,
+escaped metacharacters, the character escapes `\t`, `\n`, `\r`, `\f`, `\v`, and
+`\a`, `.`, character classes and ranges, negated character
+classes, concatenation, alternation, capturing and non-capturing groups, the
+anchors `^` and `$`, and the greedy quantifiers `?`, `*`, `+`, `{n}`, `{n,}`,
+and `{n,m}`. These constructs use the syntax documented by the
+[RE2 syntax reference](https://github.com/google/re2/wiki/Syntax). Implementations MUST
+support this profile.
+
+The listed character escapes are portable because each denotes one fixed control
+character, so no engine can disagree about what it matches. They are portable
+both standalone and inside a character class, so `[ \t]` is a portable pattern.
+
+Character-class shorthands such as `\d`, `\s`, and `\w` are outside the
+portable profile because regular-expression engines disagree about whether
+they use ASCII or Unicode membership. Write the intended set explicitly instead:
+`[0-9]` rather than `\d`. Unicode property classes such as
+`\p{L}`, inline flag groups such as `(?i)`, backreferences, look-around
+assertions, atomic groups, conditionals, recursion, and the non-greedy and
+possessive quantifier forms such as `*?` and `*+` are also outside the
+portable profile.
+
+**Patterns are compiled at schema-load time.** A schema loader MUST compile
+every `pattern` value when it loads the schema, whether or not any document
+exercises it. A pattern that does not compile — `"["`, `"{2,1}"`, or a trailing
+backslash, for example — makes the schema malformed, and the loader MUST reject
+it at schema-load time with the `invalid-pattern` code. An implementation MUST
+NOT defer a compilation failure to match time, MUST NOT treat an uncompilable
+pattern as a failed match, and MUST NOT treat it as a satisfied constraint.
+
+A construct outside the portable profile is likewise a schema-load error,
+reported with the `unsupported-pattern` code. A loader operating in its
+conformant TOML Schema 1.0 mode MUST reject a `pattern`
+that uses one, even when the underlying engine could compile it. An
+implementation MAY offer an additional, explicitly named and documented extended
+pattern profile that accepts further constructs, but that profile MUST NOT be
+the default, and a schema accepted only under it is not a TOML Schema 1.0
+schema. Portability is the whole purpose of naming a profile: if a
+non-portable construct were merely discouraged, the same schema would be a
+load error on one implementation, an ASCII-only match on a second, and a
+Unicode match on a third, which is precisely the interoperability split the
+profile exists to prevent. Conformance suites MUST use only the portable
+profile. The engine an implementation matches these expressions with, and the
+resource limits it applies to compilation and matching, are additionally
+constrained by
+[Regular-Expression Safety](#regular-expression-safety).
+
+**Unicode semantics.** A pattern is compiled from, and matched against, the
+decoded parsed string: a sequence of Unicode scalar values. The TOML parser has
+already applied string escapes such as `\u00E9`, so a loader never sees TOML
+escape syntax in a pattern. Matching operates on Unicode scalar values, never on
+UTF-8 bytes, UTF-16 code units, or grapheme clusters, and the count semantics of
+`{n,m}` follow that same unit. `.` matches exactly one scalar value other than
+a line feed. A character class matches one scalar value from its members, and a
+range such as `[a-z]` or `[À-Ö]` is an inclusive range over Unicode code
+points; a range whose start code point is greater than its end code point does
+not compile and is therefore a schema-load error. A negated class matches any
+scalar value not listed, including a line feed.
+
+Matching is case-sensitive and applies no case folding. No Unicode
+normalization is applied to the pattern or to the subject before matching:
+both are compared as the exact decoded scalar sequences the TOML parser
+produced, consistent with the string rule under
+[Parsed Value Equality](#parsed-value-equality). Two strings that are
+canonically equivalent but differently composed are therefore distinct
+subjects, and an implementation MUST NOT normalize either operand.
+
+The pattern is not implicitly anchored. A value validates if the regular
+expression matches anywhere in the string. Authors who require a full-string
+match MUST anchor the expression with `^` and `$`.
+
+Patterns are evaluated without multiline or dot-all modes. `^` matches only
+the start of the complete parsed string, `$` matches only its end (not a
+position before a final line feed), and `.` does not match a line feed. These
+rules also apply when an implementation uses a regular-expression engine with
+different defaults.
 
 #### String Format - `format`
 
@@ -1163,82 +1874,322 @@ type = "string"
 format = "uuid"
 ```
 
-### Minimum Value / Maximum Value - `min` and `max`
+#### Allowed Values - `allowedvalues`
 
-These properties define inclusive value ranges. The **comparable kinds** are:
+`allowedvalues` provides an enumeration for a scalar or unconstrained built-in
+type. On an `array` or a `collection` it is instead a
+[per-member constraint](#per-member-value-constraints) and enumerates the values
+permitted for each item or each dynamic entry, as also described
+under [Observations on Conditions to Arrays](#observations-on-conditions-to-arrays).
+It is invalid on a `table`.
 
- - `float`
- - `integer`
- - date and/or time types: `offset-date-time`, `local-date-time`, `local-date`, and `local-time`
+The `allowedvalues` array MUST contain at least one entry. Every entry on a
+definition that is neither an `array` nor a `collection` MUST have the TOML kind
+selected by that definition;
+`type = "any"` is the exception and permits entries of any TOML kind. Numeric
+equality between integers and floats does not make their TOML kinds
+interchangeable for this schema-load check. A malformed enumeration MUST be
+rejected at schema-load time.
 
-`min` and `max` MAY be declared only on a definition whose type resolves to
-exactly one comparable kind, and on an `array` or a `collection` whose members
-do, as the per-member reading below describes.
+For a definition that is neither an `array` nor a `collection`, when
+`allowedvalues` is combined with `pattern`, `format`,
+`min`, `max`, `minlength`, or `maxlength` on the same definition, every entry in
+`allowedvalues` MUST satisfy every applicable constraint. A schema containing an
+entry that violates one of those constraints is malformed, and schema loaders
+MUST reject it at schema-load time. This is a consistency check on the
+enumeration itself; it describes nothing about how a document value is
+validated. For offset date-times, this boundary check uses instant
+ordering even though subsequent `allowedvalues` membership uses parsed-value
+equality; equivalent instants with different retained local fields or offsets
+therefore compare equal for a boundary but remain distinct enumeration values.
 
-A `min` or `max` boundary MUST be a TOML value that is comparable with the effective type: `integer` or `float` boundaries for `integer` and `float` values, and matching temporal boundaries for temporal values.
+After a schema with `allowedvalues` has been loaded successfully, each document
+value governed by that definition — each item or dynamic-entry value, for an
+`array` or `collection` definition —
+is evaluated in the following order:
 
-`nan`, `+nan`, and `-nan` are not valid `min` or `max` boundaries because NaN is unordered. `inf`, `+inf`, and `-inf` are valid float boundaries, but they are not valid boundaries on a definition whose comparable kind is `integer`; an infinite boundary has no integer counterpart and constrains no integer value, so schema loaders MUST reject it there at schema-load time.
+1. The value's parsed TOML kind MUST be the kind the definition selects for it,
+   through `type` or, for container members, through `itemtype`. A kind mismatch
+   is a
+   validation error regardless of `allowedvalues`, and membership in the
+   enumeration never satisfies the type check. For example, a definition with
+   `type = "integer"` and `allowedvalues = [ 80, 443 ]` rejects the document
+   value `80.0` even though [Parsed Value Equality](#parsed-value-equality)
+   makes `80.0` equal to `80`. The unconstrained `any` selects no kind and
+   imposes no such restriction.
+2. Every other assertion that applies to the value is evaluated, including the
+   assertions declared on the definition itself and those contributed by `allof`
+   components. Validators MUST NOT skip an assertion on the grounds that the
+   enumeration was already checked while loading the schema: that schema-load
+   check covers only the definition's own constraints listed above, and a
+   composed constraint does not participate in it.
+3. The value MUST be a member of `allowedvalues` according to
+   [Parsed Value Equality](#parsed-value-equality).
 
-Date/time boundaries compare only against values of the same TOML temporal type. For example, an `offset-date-time` boundary applies to `offset-date-time` values, not to `local-date-time` values.
+The value is valid for that definition only when all three steps succeed.
 
-Numeric ranges use mathematical ordering after TOML parsing. Integer-to-integer
-ordering MUST remain exact across the full signed 64-bit range. Mixed
-integer/float ordering MUST compare the exact integer with the parsed binary
-floating-point value without first rounding the integer to that floating-point
-format. Positive and negative zero have the same position. A document NaN is
-unordered and never satisfies a range constraint.
+Example:
+```toml
+[types.colorType]
+type="string"
+allowedvalues=[ "red", "black", "blue" ]
+```
 
-Offset date-times are ordered by the instant they identify after applying their
-offset; representations of the same instant compare equal even when their local
-fields and offsets differ. Local date-times, local dates, and local times are
-ordered lexicographically by their parsed fields, from the largest component to
-the smallest, including fractional seconds. No timezone or daylight-saving
-conversion is applied to a local temporal value.
+#### Array Uniqueness - `uniqueitems`
 
-When both `min` and `max` are present, `min` MUST be less than or equal to `max`
-under the same ordering this section defines for validation: mathematical
-ordering for numeric boundaries, instant ordering for `offset-date-time`
-boundaries, and parsed-field ordering for `local-date-time`, `local-date`, and
-`local-time` boundaries. A schema violating that rule is malformed and schema
-loaders MUST reject it at schema-load time. The comparison is always defined
-because the unordered boundary values excluded above are not valid boundaries in
-the first place.
+`uniqueitems` is a boolean property valid only on a definition whose selected
+type is the built-in `array`. When it is `true`, no two items in the document
+array may be equal. When it is `false` or absent, the schema imposes no
+uniqueness condition. It applies to homogeneous arrays, tuple arrays, and
+arrays whose item type is otherwise unconstrained.
 
-On an `array` or a `collection`, `min` and `max` are
-[per-member constraints](#per-member-value-constraints) and apply to each item
-or each dynamic entry. That section is authoritative for the per-member reading,
-for how the member type is resolved through `itemtype` and through the
-alternatives of a referenced `oneof` or `anyof`, and for the schema-load
-rejection of a member type that is indeterminate or of the wrong kind. The
-interaction between array range
-boundaries and `allowedvalues` is defined under
-[Observations on Conditions to Arrays](#observations-on-conditions-to-arrays).
+Items are compared using
+[Parsed Value Equality](#parsed-value-equality), recursively for arrays and
+tables.
 
-### Length - `minlength` and `maxlength`
+Uniqueness compares complete item values. Version 1.0 does not define a
+field-selecting operation such as `uniqueBy`; two tables that share an `id` but
+differ elsewhere remain distinct. A schema loader MUST reject a non-boolean
+`uniqueitems` value or its use on a non-array definition.
 
-These properties MUST be used only to define the allowed length of a `string`,
-an `array`, or a `collection`.
+#### Per-Member Value Constraints
 
-`minlength` and `maxlength` are valid only on definitions whose selected type is
-the built-in `string`, `array`, or `collection`. They cannot be attached to
-another built-in type, an alternative selector, or a named type reference, as
-[Schema Definition Properties](#schema-definition-properties) requires.
-Schema loaders MUST reject an incompatible length constraint at schema-load time rather
-than silently ignoring it.
+Five value constraints form the **per-member value-constraint subset**:
+`allowedvalues`, `min`, `max`, `pattern`, and `format`. Any of them MAY be
+declared directly on a definition that selects the built-in `type = "array"` or
+the built-in `type = "collection"`. Declared there, a constraint does not
+describe the container. It applies to **each item** of the array and to **each
+dynamically keyed entry** of the collection. The subset is identical for the two
+containers, because an array item and a collection entry are the same thing: one
+member value that the container's `itemtype` governs.
 
-Both `minlength` and `maxlength` MUST be integers `>= 0`. When both are present, `minlength` MUST be less than or equal to `maxlength`. A schema violating either rule is malformed and schema loaders MUST reject it at schema-load time.
+Declaring a per-member constraint inline is exactly equivalent to declaring that
+same constraint on the member definition the container's `itemtype` reaches. The
+two spellings MUST validate identically, and authors MAY choose either. Inline
+is the shorter spelling for a container whose members need one or two
+constraints; a named `itemtype` definition is the reusable one.
 
-For `string` values, length is counted as the number of Unicode scalar values after TOML parsing and escape processing. It is not the number of UTF-8 bytes, UTF-16 code units, or user-perceived grapheme clusters. For example, `"\U0001F600"` has length 1, while `"e\u0301"` has length 2 because it is composed of two Unicode scalar values.
+```toml
+[elements.ports]
+type = "array"
+itemtype = "integer"
+min = 1
+max = 65535
 
-For an `array`, length is its number of items. For a `collection`, length is
-the number of dynamic entries to which `itemtype` applies; fixed child
-definitions are excluded from the count.
+[elements.hosts]
+type = "collection"
+itemtype = "string"
+format = "hostname"
+keypattern = "^[a-z][a-z0-9-]*$"
+```
 
-On an `array` or a `collection` these two properties always bound the
-container's own member count. They are deliberately excluded from the
-[per-member value-constraint subset](#per-member-value-constraints), which
-explains why, and a per-member length bound is written on the definition the
-container's `itemtype` reaches.
+On a `collection`, `pattern` constrains each dynamic entry's **value** while
+`keypattern` constrains each dynamic entry's **key**. The two are independent,
+apply to different subjects, and MAY be combined on the same definition.
+
+Because the two spellings are equivalent, declaring the **same** constraint both
+inline and on the resolved `itemtype` definition is a schema-load error, and
+schema loaders MUST reject it with `exclusive-properties`. This specification
+defines no precedence between them and needs none: a schema that would say the
+same thing twice says it once instead. Different constraints MAY be split across
+the two spellings and then apply conjunctively. The check compares the inline
+constraint against the constraint the resolved `itemtype` definition declares
+itself; a constraint that definition acquires from its own `allof` is not part
+of the check and merges conjunctively as
+[Merging by TOML Kind](#merging-by-toml-kind) requires.
+
+A per-member constraint obeys the same applicability rule its own section
+states, applied to the **member** type rather than to the container:
+
+- `pattern` and `format` require the effective member type to be the built-in
+  `string`, as [Pattern](#pattern---pattern) and
+  [String Format](#string-format---format) require of a string constraint.
+- `min` and `max` require the effective member type to resolve to exactly one
+  comparable kind, as
+  [Minimum Value / Maximum Value](#minimum-value--maximum-value---min-and-max)
+  requires.
+- every `allowedvalues` entry MUST have a TOML kind the effective member type
+  permits, as [Allowed Values](#allowed-values---allowedvalues) requires.
+
+The member type is the one the container's `itemtype` selects, resolved through
+named references and through the alternatives of a referenced `oneof` or
+`anyof`, which MUST all resolve to the same kind. When a container declares no
+`itemtype`, its members are unconstrained `any`: `allowedvalues` still applies
+and enumerates values of any TOML kind, while `min`, `max`, `pattern`, and
+`format` have no determinate member kind to apply to. Schema loaders MUST reject
+a per-member constraint whose member type is indeterminate or of the wrong kind
+at schema-load time.
+
+`items` is mutually exclusive with the whole subset. A tuple position is
+described by the reusable definition named at that position, so a constraint
+that would apply uniformly to every member has no meaning beside a positional
+definition.
+
+**`minlength` and `maxlength` are deliberately not in the subset.** On an
+`array` or a `collection` those two spellings are already taken: they constrain
+the **container**, bounding an array's item count and a collection's
+dynamic-entry count, as [Length](#length---minlength-and-maxlength) defines.
+That meaning is unchanged. One spelling cannot mean both "this container holds
+at least two members" and "each member is a string of at least two characters",
+and reinterpreting it per member on a container whose members happen to be
+strings would make the same keyword mean different things in two schemas that
+differ only in their `itemtype`. Per-member string length is therefore expressed
+through `itemtype`:
+
+```toml
+[types.shortName]
+type = "string"
+minlength = 1
+maxlength = 32
+
+[elements.tags]
+type = "array"
+itemtype = "types.shortName"
+minlength = 1
+```
+
+Here `minlength = 1` on `elements.tags` requires at least one tag, while the
+bounds inside `types.shortName` govern each tag's length in characters. This is
+the one exception to the symmetry above, and it exists because the spelling is
+occupied, not because container members are otherwise privileged.
+
+#### Sibling Presence Rules
+
+Version 1.0 defines three presence-only rules for direct fixed children of an
+effective `table` or `collection`. They inspect parsed key presence, never a
+child's value, and never follow a dotted string as a document path.
+
+##### Dependencies - `dependentrequired`
+
+`dependentrequired` is a non-empty inline table. Each member maps one trigger
+child name to a non-empty array of unique child names. When the trigger is
+present, every listed child MUST also be present.
+
+Because `dependentrequired` is also a legal child key, a
+`dependentrequired = { ... }` key/value entry is always the sibling rule, while
+a table header such as `[types.example.dependentrequired]` is always a child
+definition named `dependentrequired`. A definition that needs both the rule and
+a child of that name writes the child through the `children` namespace, as
+described under [Quoted and Special Keys](#quoted-and-special-keys).
+
+Dependencies are directional. If `a` requires `b`, the presence of `b` does not
+require `a` unless a reverse mapping is declared. Every triggered mapping is
+evaluated, so dependencies may apply transitively.
+
+Example:
+
+```toml
+[types.dependency]
+type = "table"
+dependentrequired = { branch = [ "git" ], tag = [ "git" ], rev = [ "git" ] }
+
+    [types.dependency.git]
+    type = "string"
+    optional = true
+
+    [types.dependency.branch]
+    type = "string"
+    optional = true
+
+    [types.dependency.tag]
+    type = "string"
+    optional = true
+
+    [types.dependency.rev]
+    type = "string"
+    optional = true
+```
+
+##### Mutual Exclusion - `mutuallyexclusive`
+
+`mutuallyexclusive` is a non-empty array of groups. Each group is an array of
+at least two unique child-name strings. At most one member of each group MAY be
+present.
+
+Zero or one present member satisfies a group.
+
+Example:
+
+```toml
+[types.source]
+type = "table"
+mutuallyexclusive = [ [ "git", "path" ], [ "branch", "tag", "rev" ] ]
+
+    [types.source.git]
+    type = "string"
+    optional = true
+
+    [types.source.path]
+    type = "string"
+    optional = true
+
+    [types.source.branch]
+    type = "string"
+    optional = true
+
+    [types.source.tag]
+    type = "string"
+    optional = true
+
+    [types.source.rev]
+    type = "string"
+    optional = true
+```
+
+##### Exactly One - `exactlyone`
+
+`exactlyone` has the same shape as `mutuallyexclusive`, but exactly one member
+of every group MUST be present.
+
+This allows every group member to remain individually `optional = true` while
+the group still requires one choice.
+
+Example:
+
+```toml
+[types.readmeTable]
+type = "table"
+exactlyone = [ [ "file", "text" ] ]
+
+    [types.readmeTable.file]
+    type = "string"
+    optional = true
+
+    [types.readmeTable.text]
+    type = "string"
+    optional = true
+```
+
+Every name in these three properties MUST identify a direct fixed child in the
+[determinate fixed-child set](#determinate-fixed-child-set) of the definition
+after `allof` composition. Operand resolution and the `table`-or-`collection`
+applicability of these rules are therefore effective rather than local checks,
+as [Local and Effective Checks](#local-and-effective-checks) records. Operands
+are resolved when the schema is loaded, so
+they MUST NOT be resolved against the validation-time
+[effective closure set](#effective-closure-set); only the presence check itself
+happens while a document is validated. A quoted string containing a
+dot identifies a literal dotted child key, and a child written through the
+`children` namespace is named by its target key rather than by the literal
+string `children`. Dynamic collection keys are not fixed children and cannot be
+operands, while a collection's explicitly defined children participate normally.
+
+Because a `oneof` or `anyof` selector and a conditional selector contribute
+nothing to the determinate set, an operand that only such an alternative or
+branch could supply names no fixed child and MUST be rejected at schema-load
+time. Declare those operands as local fixed children instead — `optional = true`
+ones when the document may omit them — or move the rule into the alternatives or
+branches that define the children.
+
+Schema loaders MUST reject a rule with the wrong TOML value type, an empty
+mapping or group list, a group with fewer than two members, a duplicate name
+within one dependency array or group, an unknown fixed-child name, or use on an
+incompatible effective type. Loaders are not required to prove general logical
+satisfiability between multiple valid rules.
+
+Ordinary requiredness is evaluated together with these rules. An absent
+optional trigger has no effect. A non-optional child remains required even if a
+presence group would otherwise permit its absence.
 
 ### Container Types
 
@@ -1259,7 +2210,7 @@ identically.
 
 If a schema definition has nested child definitions but does not declare a
 selector, it is an implicit table, as
-[Types Table](#types-table---types) defines.
+[Selectors](#selectors) defines.
 
 The **fixed children** of a table, for the purpose of the rules below, are its
 own nested child definitions together with the children contributed by every
@@ -1470,23 +2421,6 @@ type = "array"
 items = [ "types.coordinate", "types.label" ]
 ```
 
-##### Array Uniqueness - `uniqueitems`
-
-`uniqueitems` is a boolean property valid only on a definition whose selected
-type is the built-in `array`. When it is `true`, no two items in the document
-array may be equal. When it is `false` or absent, the schema imposes no
-uniqueness condition. It applies to homogeneous arrays, tuple arrays, and
-arrays whose item type is otherwise unconstrained.
-
-Items are compared using
-[Parsed Value Equality](#parsed-value-equality), recursively for arrays and
-tables.
-
-Uniqueness compares complete item values. Version 1.0 does not define a
-field-selecting operation such as `uniqueBy`; two tables that share an `id` but
-differ elsewhere remain distinct. A schema loader MUST reject a non-boolean
-`uniqueitems` value or its use on a non-array definition.
-
 #### Collection of Elements for Dynamic Keys
 
 One can set an element of type `collection` when there is a need to have multiple children with dynamic, user-provided keys or table headers.
@@ -1629,179 +2563,56 @@ TOML Schema:
 
 A `collection` may be represented as subtables of a common table in a TOML document.
 
-#### Per-Member Value Constraints
+#### Key Pattern - `keypattern`
 
-Five value constraints form the **per-member value-constraint subset**:
-`allowedvalues`, `min`, `max`, `pattern`, and `format`. Any of them MAY be
-declared directly on a definition that selects the built-in `type = "array"` or
-the built-in `type = "collection"`. Declared there, a constraint does not
-describe the container. It applies to **each item** of the array and to **each
-dynamically keyed entry** of the collection. The subset is identical for the two
-containers, because an array item and a collection entry are the same thing: one
-member value that the container's `itemtype` governs.
+`keypattern` constrains the keys of a collection's dynamically named entries
+with a regular expression.
 
-Declaring a per-member constraint inline is exactly equivalent to declaring that
-same constraint on the member definition the container's `itemtype` reaches. The
-two spellings MUST validate identically, and authors MAY choose either. Inline
-is the shorter spelling for a container whose members need one or two
-constraints; a named `itemtype` definition is the reusable one.
+`keypattern` may only be used on a `collection`. It constrains the **keys** (entry names) of the
+collection's dynamic children: every dynamically keyed entry must match the provided regular
+expression. It does not validate entry *values* — that is the role of `itemtype`. It is
+therefore orthogonal to `itemtype` and may be combined with it.
 
-```toml
-[elements.ports]
-type = "array"
-itemtype = "integer"
-min = 1
-max = 65535
+`keypattern` is invalid on any non-`collection` type (scalars, `array`, plain
+`table`), and a schema loader MUST reject a schema that uses it elsewhere.
 
-[elements.hosts]
-type = "collection"
-itemtype = "string"
-format = "hostname"
-keypattern = "^[a-z][a-z0-9-]*$"
-```
+Keys that are explicitly declared as fixed child definitions of the collection (schema-restricted
+key-value pairs) are validated by their own definitions and are not subject to `keypattern`. Only
+dynamic, user-provided keys are matched against the pattern.
 
-On a `collection`, `pattern` constrains each dynamic entry's **value** while
-`keypattern` constrains each dynamic entry's **key**. The two are independent,
-apply to different subjects, and MAY be combined on the same definition.
+Implementations MUST support the same portable RE2 regular-expression profile as
+[`pattern`](#pattern---pattern), and every rule that section states about
+regular expressions applies unchanged to `keypattern`: schema-load compilation,
+rejection of uncompilable patterns and of constructs outside the portable
+profile, Unicode scalar-value matching, character-class and range behavior,
+case sensitivity, and the absence of Unicode normalization. The subject is the
+decoded TOML key rather than a string value; keys are matched as the exact
+decoded scalar sequences the TOML parser produced, so a quoted key and a bare
+key that decode to the same characters are the same subject. Like `pattern`,
+`keypattern` is not implicitly
+anchored: a key validates if the regular expression matches anywhere in the key
+string. Authors who require a full-key match MUST anchor the expression with
+`^` and `$`.
 
-Because the two spellings are equivalent, declaring the **same** constraint both
-inline and on the resolved `itemtype` definition is a schema-load error, and
-schema loaders MUST reject it with `exclusive-properties`. This specification
-defines no precedence between them and needs none: a schema that would say the
-same thing twice says it once instead. Different constraints MAY be split across
-the two spellings and then apply conjunctively. The check compares the inline
-constraint against the constraint the resolved `itemtype` definition declares
-itself; a constraint that definition acquires from its own `allof` is not part
-of the check and merges conjunctively as
-[Merging by TOML Kind](#merging-by-toml-kind) requires.
-
-A per-member constraint obeys the same applicability rule its own section
-states, applied to the **member** type rather than to the container:
-
-- `pattern` and `format` require the effective member type to be the built-in
-  `string`, as [Pattern](#pattern---pattern) and
-  [String Format](#string-format---format) require of a string constraint.
-- `min` and `max` require the effective member type to resolve to exactly one
-  comparable kind, as
-  [Minimum Value / Maximum Value](#minimum-value--maximum-value---min-and-max)
-  requires.
-- every `allowedvalues` entry MUST have a TOML kind the effective member type
-  permits, as [Allowed Values](#allowed-values---allowedvalues) requires.
-
-The member type is the one the container's `itemtype` selects, resolved through
-named references and through the alternatives of a referenced `oneof` or
-`anyof`, which MUST all resolve to the same kind. When a container declares no
-`itemtype`, its members are unconstrained `any`: `allowedvalues` still applies
-and enumerates values of any TOML kind, while `min`, `max`, `pattern`, and
-`format` have no determinate member kind to apply to. Schema loaders MUST reject
-a per-member constraint whose member type is indeterminate or of the wrong kind
-at schema-load time.
-
-`items` is mutually exclusive with the whole subset. A tuple position is
-described by the reusable definition named at that position, so a constraint
-that would apply uniformly to every member has no meaning beside a positional
-definition.
-
-**`minlength` and `maxlength` are deliberately not in the subset.** On an
-`array` or a `collection` those two spellings are already taken: they constrain
-the **container**, bounding an array's item count and a collection's
-dynamic-entry count, as [Length](#length---minlength-and-maxlength) defines.
-That meaning is unchanged. One spelling cannot mean both "this container holds
-at least two members" and "each member is a string of at least two characters",
-and reinterpreting it per member on a container whose members happen to be
-strings would make the same keyword mean different things in two schemas that
-differ only in their `itemtype`. Per-member string length is therefore expressed
-through `itemtype`:
+Example:
 
 ```toml
-[types.shortName]
-type = "string"
-minlength = 1
-maxlength = 32
-
-[elements.tags]
-type = "array"
-itemtype = "types.shortName"
-minlength = 1
+[types.listOfServersType]
+type       = "collection"
+itemtype   = "types.serverType"
+minlength  = 1
+keypattern = "^server_[0-9]+$"
 ```
 
-Here `minlength = 1` on `elements.tags` requires at least one tag, while the
-bounds inside `types.shortName` govern each tag's length in characters. This is
-the one exception to the symmetry above, and it exists because the spelling is
-occupied, not because container members are otherwise privileged.
-
-### Type Reference
-
-A type reference applies a built-in type or inherits the rules of a named reusable type. Both `[types]` definitions and `[elements]` definitions may use type references. The `type` property selects the current node's type; built-in and named references use the same syntax.
-
-When `type` selects a named reusable definition, the reference inherits that
-definition's validation rules as-is. This inheritance includes `optional`, as
-[Optionality](#optionality---optional) defines. In version 1.0, the
-referencing definition MAY additionally declare only `allof`, `description`,
-`optional`, `default`, and `deprecated`; it MUST NOT declare any other sibling
-property or child definition. `allof` adds conjunctive components rather than
-overriding the named reference. A local `default` is the use-site annotation
-defined under [Default](#default---default), and `deprecated = false` cannot
-cancel deprecation inherited from a reference. In particular, validation
-constraints such as `pattern`,
-`keypattern`, `min`, `max`, `minlength`, `maxlength`, `allowedvalues`,
-`itemtype`, and `items` cannot be added or overridden at the reference site.
-Schema loaders MUST reject such schemas at schema-load time.
-
-To specialize validation rules, declare another named reusable definition rather than adding constraints to a reference:
+Against a TOML document:
 
 ```toml
-[types.lowercaseName]
-type = "string"
-pattern = "^[a-z]+$"
-
-[elements.name]
-type = "types.lowercaseName"
-description = "Display name"
-optional = true
+[servers.server_01]   # accepted
+[servers.server_02]   # accepted
+[servers.alpha]       # rejected: key does not match ^server_[0-9]+$
 ```
 
-The following is invalid because `pattern` attempts to override the referenced definition:
-
-```toml
-[types.name]
-type = "string"
-pattern = "^[a-z]+$"
-
-[elements.name]
-type = "types.name"
-pattern = "^[A-Z]+$" # invalid
-```
-
-```toml
-[types]
-
-    [types.nameType]
-    type="string"
-    pattern="[a-zA-Z]"  # unanchored: matches any string containing a letter
-
-    [types.serverType.name]
-    type = "types.nameType"
-
-    [types.serverType.enabled]
-    type = "boolean"
-
-[elements]
-
-    [elements.datacenter]
-    type="table"
-
-        [elements.datacenter.name]
-        type="types.nameType"
-
-        [elements.datacenter.tags]
-        type = "array"
-        itemtype = "string"
-
-        [elements.datacenter.servers]
-        type = "collection"
-        itemtype = "types.serverType"
-```
+This mirrors JSON Schema's `propertyNames: { pattern: ... }`, applied to TOML maps.
 
 ### Conjunctive Composition - `allof`
 
@@ -1888,7 +2699,7 @@ special case for collections.
 
 A definition that declares no selector, no nested child definition, and no
 `allof` determines nothing at all, and it remains a schema-load error under
-[Types Table](#types-table---types).
+[Selectors](#selectors).
 
 #### The Effective Definition
 
@@ -2303,808 +3114,6 @@ references MUST resolve at schema-load time, and composition/type-selection
 cycles are malformed. Structural recursion that consumes a child or container
 member remains valid.
 
-### Alternative Types - `oneof` and `anyof`
-
-Use `oneof` or `anyof` when a value may validate against alternative type references.
-
-- `oneof`: exactly one referenced type must validate.
-- `anyof`: at least one referenced type must validate.
-
-These properties can be used anywhere a schema definition can appear, including an `[elements]` field, a reusable `[types]` definition, and a type referenced through `itemtype` for array or collection items. Which references an alternative may name is stated under
-[Type Reference Restrictions](#type-reference-restrictions); use a named
-reusable definition when an alternative needs a fully defined collection, an
-intentionally unconstrained named branch, or any other constraint.
-
-`type`, `oneof`, `anyof`, and the conditional triple all select the current
-node's type, and a definition declares at most one of them, as
-[Types Table](#types-table---types) requires.
-
-The array assigned to `oneof` or `anyof` MUST contain at least one type
-reference. A union definition MAY additionally declare only `description`,
-`optional`, `default`, `deprecated`, and `allof`; it MUST NOT declare another
-validation property or any nested child definition. Schema loaders MUST reject
-empty unions and other union siblings at schema-load time. Constraints required
-by an alternative belong in a named reusable definition referenced by the
-union.
-
-The alternatives of a `oneof` or `anyof` array MUST be distinct. A repeated
-alternative adds no branch and, for `oneof`, cannot be the exactly-one match.
-Duplication is judged on resolved identity, after the optional `types.` prefix
-has been removed, so `oneof = [ "types.stringId", "stringId" ]` names the same
-definition twice and is malformed. Schema loaders MUST reject a duplicate
-alternative at schema-load time. This differs from
-[`items`](#tuple--positional-array-validation---items), where an entry denotes a
-tuple position rather than an alternative and repetition is meaningful.
-
-A union contributes nothing to the
-[determinate fixed-child set](#determinate-fixed-child-set) of the node it
-selects, because no alternative is chosen until a document value exists. It does
-contribute at validation time: when an alternative is evaluated against a
-document node, that alternative's fixed children join the node's
-[effective closure set](#effective-closure-set) for that evaluation, so a key
-the alternative declares is a known key of the node and MUST NOT be reported as
-unexpected. This is what lets a union be composed into a table with `allof`
-without the alternatives' own children becoming unknown keys.
-
-When alternatives contain annotations, only successful alternatives contribute
-them, and only for a value that is present. Deprecation warnings follow the
-successful-alternative rule: `oneof` reports the warning of its single
-successful alternative, and `anyof` reports the warnings of every successful
-alternative, deduplicated as [Diagnostics](#diagnostics) requires. Consequently,
-a deprecated successful alternative contributes a warning even when another
-successful `anyof` alternative is not deprecated; this preserves all annotations
-attached to definitions that accepted the value. Alternative `default`
-annotations are governed by [Default](#default---default): they are never
-combined into the slot's effective default and never cause a schema-load
-conflict. For a present value, an implementation MAY surface the default of each
-successful alternative as a hint, deduplicated by
-[Parsed Value Equality](#parsed-value-equality). An alternative that fails
-validation contributes neither defaults nor deprecation warnings; what happens to
-its diagnostics is defined under
-[Alternative and Branch Commit and Discard](#alternative-and-branch-commit-and-discard).
-
-Examples:
-
-```toml
-[types.stringId]
-type = "string"
-pattern = "^[a-z]+$"
-
-[types.integerId]
-type = "integer"
-min = 1
-
-[elements.id]
-anyof = [ "types.stringId", "types.integerId" ]
-
-[elements.simpleId]
-oneof = [ "string", "integer" ]
-```
-
-Use a named reusable definition whenever an alternative needs constraints such as `pattern`, `min`, `allowedvalues`, `itemtype`, or child fields.
-
-```toml
-[types.dependencyVersion]
-type = "string"
-pattern = "^[0-9]+\\.[0-9]+\\.[0-9]+$"
-
-[types.inlineDependency]
-type = "table"
-
-[types.dependency]
-oneof = [ "types.dependencyVersion", "types.inlineDependency" ]
-```
-
-For container items with alternative types, use a named wrapper:
-
-```toml
-[types.dnsValue]
-oneof = [ "types.ipAddress", "types.hostname" ]
-
-[elements.dns]
-type = "collection"
-itemtype = "types.dnsValue"
-```
-
-A named container definition can also be an alternative. This models formats
-that accept either one table or an array of the same table shape:
-
-```toml
-[types.cascadeEntry]
-type = "table"
-
-    [types.cascadeEntry.params]
-    type = "table"
-    optional = true
-
-[types.cascadeEntries]
-type = "array"
-itemtype = "types.cascadeEntry"
-
-[elements.cascade]
-oneof = [ "types.cascadeEntry", "types.cascadeEntries" ]
-```
-
-### Conditional Selection - `if`, `then`, and `else`
-
-The `if`, `then`, and `else` properties form one exhaustive selector for a
-table-like node. The condition inspects one direct child of the current parsed
-table and selects one of two named reusable definitions:
-
-```toml
-[types.sqliteDatabase]
-type = "table"
-
-    [types.sqliteDatabase.engine]
-    type = "string"
-    allowedvalues = [ "sqlite" ]
-
-    [types.sqliteDatabase.path]
-    type = "string"
-
-[types.serverDatabase]
-type = "table"
-
-    [types.serverDatabase.engine]
-    type = "string"
-    allowedvalues = [ "postgresql", "mysql" ]
-
-    [types.serverDatabase.host]
-    type = "string"
-
-[types.database]
-if = { key = "engine", equals = "sqlite" }
-then = "types.sqliteDatabase"
-else = "types.serverDatabase"
-```
-
-Both branches declare `engine`, the key the condition reads. That is required
-rather than stylistic: see
-[The Discriminator Key and Closed Branches](#the-discriminator-key-and-closed-branches)
-below.
-
-`if` MUST be an inline table containing `key` and exactly one of `equals` or
-`in`. It MUST contain no other members.
-
-Because `if` is also a legal child key, an `if = { ... }` key/value entry is
-always the conditional selector, while a table header such as
-`[types.example.if]` is always a child definition named `if`. Consequently the
-condition MUST use inline-table syntax and can never be written as
-`[types.example.if]`. A definition that needs a target child named `if` writes
-that child through the `children` namespace, as described under
-[Quoted and Special Keys](#quoted-and-special-keys). A conditional definition
-has no nested child definitions of its own, so the two spellings never compete
-within one conditional definition, but a loader still MUST NOT infer the
-selector from a table-form `if`.
-
-- `key` MUST be a string naming one direct child key of the parsed table being
-  validated. It is a decoded TOML key, not a dotted document path, and it does
-  not have to name a schema-declared child, because a conditional definition has
-  no nested child definitions of its own. An empty or literal dotted key is
-  permitted.
-- `equals` accepts one TOML value. The condition succeeds when the child exists
-  and is equal to that value according to [Parsed Value Equality](#parsed-value-equality).
-- `in` MUST be a non-empty array. The condition succeeds when the child exists
-  and is equal to at least one array entry according to Parsed Value Equality.
-
-If the named child is absent, the condition is false. A validator MUST apply
-only the selected branch: `then` when the condition is true and `else` when it
-is false. The condition itself emits no document-validation diagnostic.
-Validation diagnostics and deprecation annotations come only from the selected
-branch. A branch default does not become the conditional slot's effective
-default; for a present value, an implementation MAY surface the selected
-branch's default as a hint.
-
-The condition reads a direct child of a parsed table. When the document value at
-a conditional node is not a table — a scalar, an array, or an array of tables —
-no direct child can be read, so the condition cannot be satisfied and is false,
-exactly as it is for an absent child. `else` is therefore the selected branch.
-Because both branches MUST resolve to the same table-like effective type, that
-value cannot validate against either branch, and the node is invalid. A
-validator MUST report this as a kind mismatch against the common branch kind at
-the node's location, using the `type-mismatch` code defined under
-[Validation Codes](#validation-codes), and MUST NOT report the branch's internal
-`missing-required` or `unknown-key` diagnostics for a value that is not a table
-at all. It MUST NOT report a diagnostic describing the condition, which never
-fails on its own.
-
-Consequently, a `default` on a conditional definition MUST be a table. A
-non-table default cannot satisfy either branch, so a schema loader MUST reject
-it at schema-load time under the default-validation rule stated below.
-
-Like a union, the conditional triple contributes nothing to the
-[determinate fixed-child set](#determinate-fixed-child-set) of the node it
-selects. The selected branch's fixed children join the node's
-[effective closure set](#effective-closure-set) at validation time, so the keys
-the matched branch declares are known keys of that node, while keys declared
-only by the branch that was not selected are not.
-
-`then` and `else` MUST each be a string naming a reusable definition in
-`[types]`, and both definitions MUST resolve
-to the same effective type, which MUST be `table` or `collection`, as
-[Type Reference Restrictions](#type-reference-restrictions) states.
-Schema loaders MUST reject unresolved branches, different branch kinds,
-branches that do not resolve to a table-like kind, and cycles through
-conditional branches.
-
-The conditional triple is one of the four selectors a definition declares at
-most one of, as [Types Table](#types-table---types) requires. A conditional
-definition MAY additionally declare only `allof`,
-`description`, `optional`, `default`, and `deprecated`; it MUST NOT contain
-kind-specific validation properties or nested child definitions. An `allof`
-component MUST be compatible with the common branch kind and is applied
-conjunctively with whichever branch is selected.
-
-Optionality belongs to the conditional definition, as
-[Optionality](#optionality---optional) defines. A default on the conditional
-definition MUST validate against the branch selected by that default at
-schema-load time.
-
-Example with a multi-value condition:
-
-```toml
-[types.database]
-if = { key = "engine", in = [ "postgresql", "mysql" ] }
-then = "types.serverDatabase"
-else = "types.embeddedDatabase"
-```
-
-Additional alternatives can be expressed by referencing another conditional
-definition from `then` or `else`.
-
-#### The Discriminator Key and Closed Branches
-
-The key named by `if.key` is ordinary application data. It is read to select a
-branch, and it is then validated by the selected branch like any other key. A
-conditional definition contributes no fixed children of its own, so nothing
-declares the discriminator on the node's behalf.
-
-A branch that declares fixed children is closed against exactly those children,
-as [Effective Closure Set](#effective-closure-set) defines. If such a branch
-omits the discriminator, the key the condition just read is not in the node's
-effective closure set and a validator MUST report it as an unknown key, so the
-conditional can never accept a document. Every closed branch MUST therefore
-declare the discriminator itself.
-
-Schema loaders MUST reject a conditional definition when a branch has a
-non-empty [determinate fixed-child set](#determinate-fixed-child-set) that does
-not contain the key named by `if.key`. That set is computed at schema-load time,
-so this check catches the common authoring mistake without resolving
-document-dependent shapes. A branch whose fixed children are contributed only by
-a nested union or conditional has an empty determinate set, and a loader cannot
-decide the question for it; the same unknown-key rule still applies at
-validation time, and authors remain responsible for declaring the discriminator
-in every shape a branch can take.
-
-Two branch shapes need no declaration and are not rejected: a branch that is an
-open table, whose effective closure set is empty and which therefore accepts the
-discriminator as arbitrary data, and a branch that is a `collection`, whose
-dynamic-entry rules accept the discriminator when its `keypattern` and
-`itemtype` permit it.
-
-The `else` branch is subject to the same rule as `then`. An `else` branch is
-selected both when the discriminator holds a different value and when it is
-absent, so a closed `else` branch typically declares the discriminator with
-`optional = true`, with `allowedvalues` excluding the value that selects `then`,
-or with both. In the example above, `types.serverDatabase` declares `engine`
-with `allowedvalues = [ "postgresql", "mysql" ]`, which both admits the key and
-rejects a value that should have selected the other branch.
-
-### Sibling Presence Rules
-
-Version 1.0 defines three presence-only rules for direct fixed children of an
-effective `table` or `collection`. They inspect parsed key presence, never a
-child's value, and never follow a dotted string as a document path.
-
-#### Dependencies - `dependentrequired`
-
-`dependentrequired` is a non-empty inline table. Each member maps one trigger
-child name to a non-empty array of unique child names. When the trigger is
-present, every listed child MUST also be present.
-
-Because `dependentrequired` is also a legal child key, a
-`dependentrequired = { ... }` key/value entry is always the sibling rule, while
-a table header such as `[types.example.dependentrequired]` is always a child
-definition named `dependentrequired`. A definition that needs both the rule and
-a child of that name writes the child through the `children` namespace, as
-described under [Quoted and Special Keys](#quoted-and-special-keys).
-
-Dependencies are directional. If `a` requires `b`, the presence of `b` does not
-require `a` unless a reverse mapping is declared. Every triggered mapping is
-evaluated, so dependencies may apply transitively.
-
-Example:
-
-```toml
-[types.dependency]
-type = "table"
-dependentrequired = { branch = [ "git" ], tag = [ "git" ], rev = [ "git" ] }
-
-    [types.dependency.git]
-    type = "string"
-    optional = true
-
-    [types.dependency.branch]
-    type = "string"
-    optional = true
-
-    [types.dependency.tag]
-    type = "string"
-    optional = true
-
-    [types.dependency.rev]
-    type = "string"
-    optional = true
-```
-
-#### Mutual Exclusion - `mutuallyexclusive`
-
-`mutuallyexclusive` is a non-empty array of groups. Each group is an array of
-at least two unique child-name strings. At most one member of each group MAY be
-present.
-
-Zero or one present member satisfies a group.
-
-Example:
-
-```toml
-[types.source]
-type = "table"
-mutuallyexclusive = [ [ "git", "path" ], [ "branch", "tag", "rev" ] ]
-
-    [types.source.git]
-    type = "string"
-    optional = true
-
-    [types.source.path]
-    type = "string"
-    optional = true
-
-    [types.source.branch]
-    type = "string"
-    optional = true
-
-    [types.source.tag]
-    type = "string"
-    optional = true
-
-    [types.source.rev]
-    type = "string"
-    optional = true
-```
-
-#### Exactly One - `exactlyone`
-
-`exactlyone` has the same shape as `mutuallyexclusive`, but exactly one member
-of every group MUST be present.
-
-This allows every group member to remain individually `optional = true` while
-the group still requires one choice.
-
-Example:
-
-```toml
-[types.readmeTable]
-type = "table"
-exactlyone = [ [ "file", "text" ] ]
-
-    [types.readmeTable.file]
-    type = "string"
-    optional = true
-
-    [types.readmeTable.text]
-    type = "string"
-    optional = true
-```
-
-Every name in these three properties MUST identify a direct fixed child in the
-[determinate fixed-child set](#determinate-fixed-child-set) of the definition
-after `allof` composition. Operand resolution and the `table`-or-`collection`
-applicability of these rules are therefore effective rather than local checks,
-as [Local and Effective Checks](#local-and-effective-checks) records. Operands
-are resolved when the schema is loaded, so
-they MUST NOT be resolved against the validation-time
-[effective closure set](#effective-closure-set); only the presence check itself
-happens while a document is validated. A quoted string containing a
-dot identifies a literal dotted child key, and a child written through the
-`children` namespace is named by its target key rather than by the literal
-string `children`. Dynamic collection keys are not fixed children and cannot be
-operands, while a collection's explicitly defined children participate normally.
-
-Because a `oneof` or `anyof` selector and a conditional selector contribute
-nothing to the determinate set, an operand that only such an alternative or
-branch could supply names no fixed child and MUST be rejected at schema-load
-time. Declare those operands as local fixed children instead — `optional = true`
-ones when the document may omit them — or move the rule into the alternatives or
-branches that define the children.
-
-Schema loaders MUST reject a rule with the wrong TOML value type, an empty
-mapping or group list, a group with fewer than two members, a duplicate name
-within one dependency array or group, an unknown fixed-child name, or use on an
-incompatible effective type. Loaders are not required to prove general logical
-satisfiability between multiple valid rules.
-
-Ordinary requiredness is evaluated together with these rules. An absent
-optional trigger has no effect. A non-optional child remains required even if a
-presence group would otherwise permit its absence.
-
-### Annotations
-
-`description`, `default`, and `deprecated` are **annotations**. Unlike the
-assertions defined above, an annotation never decides validity: it cannot make a
-document valid or invalid, and removing every annotation from a schema leaves
-the set of documents that schema accepts unchanged. The sections below define
-each annotation; this section defines what they attach to and how one effective
-value is obtained when a definition is reached indirectly.
-
-**Attachment.** An annotation attaches to the document node being validated —
-identified by its [instance path](#instance-path) — not to the schema definition
-that carries it. The same definition applied at several nodes annotates each node
-separately, and a definition applied to no node annotates nothing. Consequences:
-
-- A definition used as an array `itemtype` annotates every present item node, not
-  the array. A deprecated `itemtype` applied to an array of one hundred items
-  therefore produces one hundred warnings, one per item node, and never a single
-  warning for the array.
-- A definition used as a `collection` `itemtype` annotates every present
-  dynamically keyed entry, once per entry.
-- A definition reached through `items` annotates the one indexed node it
-  validates.
-- An absent optional slot holds no node, so it carries no annotation and produces
-  no deprecation warning.
-
-Every annotation-derived diagnostic therefore carries the instance path of the
-node it annotates. The severity and code of such a diagnostic are assigned by
-[Diagnostics](#diagnostics); this section defines only what annotations attach
-to.
-
-**Effective annotation.** For one document location, the participants that may
-carry an annotation are the use site, each definition along that use site's
-`type` reference chain, each `allof` component of the effective definition, the
-`oneof` or `anyof` alternative that succeeded, and the conditional branch that
-was selected. The general precedence is:
-
-1. an annotation declared at the use site takes precedence over the same
-   annotation obtained through that use site's `type` reference chain, and
-   within the chain the nearest declaration takes precedence over a more distant
-   one;
-2. `allof` components, union alternatives, and conditional branches contribute
-   annotations for the location they help validate, but never override an
-   annotation the use site or its reference chain already supplies.
-
-`deprecated` is an exception to point 2 and does not follow the general
-precedence: it combines disjunctively rather than resolving to a single
-declaration, so a contributing `deprecated = true` deprecates the location even
-when the use site declares `deprecated = false`. [Deprecation](#deprecation---deprecated) is
-authoritative for it. The general precedence governs `description` and any
-future annotation that resolves to at most one value.
-
-Each annotation then resolves its own contributions as follows.
-
-`description` follows the general precedence and resolves to at most one value.
-A use-site `description` overrides the one carried by the definition it
-references, and the nearest description along a reference chain overrides a more
-distant one; the use site is the more specific statement about that location, so
-it wins. Descriptions carried by `allof` components, by the successful union
-alternative, and by the selected conditional branch never replace that value.
-Where a single description is required — an editor hover, for instance — the
-effective description is the use-site or reference-chain value if one exists,
-and otherwise nothing. An implementation MAY additionally expose the
-contributed descriptions as documentation, in a stable order: `allof`
-components in declaration order, then the successful alternative or selected
-branch. It MUST NOT merge or concatenate contributions into a value it presents
-as a single authored description, and it MUST NOT reject a schema because two
-participants carry different descriptions.
-
-`default` does not follow this general precedence alone, because it is
-machine-readable and must resolve to exactly one value. Its precedence and
-conflict rules, including the `allof` and union rules, are defined under
-[Default](#default---default) and are authoritative.
-
-`deprecated` is a per-node warning. It fires once for each present document node
-whose effective definition is deprecated, and duplicate warnings contributed by
-more than one successful path are deduplicated as
-[Diagnostics](#diagnostics) requires. It fires per node and never per definition,
-so the count follows the attachment rules above. Deprecation is not inherited
-downward: a deprecated parent produces one warning at the parent's instance path,
-and a descendant produces a warning only when its own effective definition is
-deprecated. When a union or conditional definition is itself deprecated, that
-warning is reported at the node's own instance path in addition to any warning
-contributed by the successful alternative or selected branch, and the two are
-distinct instance paths only when the alternative or branch annotates a
-descendant.
-
-### Description - `description`
-
-`description` is an optional human-readable string that documents a schema definition. It may be used on reusable types, elements, and nested definitions. Implementations and tooling MAY use it for documentation, suggestions, and autocompletion; it does not affect validation. Its precedence when a definition is reached through a reference, composition, an alternative, or a conditional branch is defined under [Annotations](#annotations).
-
-```toml
-[types.game]
-type = "table"
-description = "A game object."
-
-    [types.game.id]
-    type = "string"
-    description = "Unique identifier for the game."
-
-[elements.game]
-type = "array"
-description = "A list of games."
-itemtype = "types.game"
-```
-
-### Default - `default`
-
-`default` is a machine-readable annotation containing any TOML value. Like the
-other annotations, it attaches to the document node a definition validates, and
-to the slot that node occupies, as described under [Annotations](#annotations);
-unlike them, it MUST resolve to exactly one value, and the rules below are
-authoritative for that resolution.
-
-Because `default` is also a legal child key, a `default = <value>` key/value
-entry is always the annotation, while a table header such as
-`[elements.options.default]` is always a child definition named `default`.
-Consequently, a table-valued default MUST use inline-table syntax, for example
-`default = { min = 1, max = 10 }`. A definition that needs both the annotation
-and a child named `default` writes the child through the `children` namespace,
-as described under [Quoted and Special Keys](#quoted-and-special-keys).
-
-A default is not a validation assertion and never changes the document being
-validated. It does not insert a missing value, satisfy a required definition,
-or change the parsed TOML data returned by an implementation. Tools MAY expose
-it as a suggestion or effective-configuration hint through schema metadata.
-Version 1.0 does not define an operation that materializes defaults.
-
-Despite being an annotation, a declared default MUST validate as a present
-value against the full effective definition at schema-load time. Default
-validation applies all references, composition, alternatives, fixed children,
-sibling rules, and ordinary constraints, but does not emit a deprecation
-warning. A loader MUST reject an incompatible default. This is one of the
-schema-load checks that read the effective rather than the local view, as
-[Local and Effective Checks](#local-and-effective-checks) records.
-
-A default declared directly at a use site takes precedence over one inherited
-through its `type` reference. Without a use-site default, the referenced
-default is inherited. Defaults contributed by `allof` components are compared using
-[Parsed Value Equality](#parsed-value-equality). Equal defaults are
-deduplicated. If components contribute unequal defaults and the local
-definition has no default, the schema is malformed because it has no single
-effective default. A valid local default resolves that annotation conflict and
-must still satisfy every component.
-
-Alternative selectors do not contribute to a slot's effective default. The
-effective default of a slot whose selector resolves to `oneof` or `anyof` is
-determined only by a use-site `default`, a default inherited through the named
-`type` reference chain that resolves to the union, and defaults composed
-through `allof`, using the precedence and conflict rules above. A `default`
-declared on an individual alternative is never aggregated into the union's
-effective default and never causes a schema-load conflict, even when several
-`anyof` alternatives declare unequal defaults. A loader MUST NOT reject a
-schema solely because two alternatives declare defaults, equal or unequal.
-Resolving effective defaults therefore never requires deciding whether two
-alternatives can match the same value.
-
-When a union slot is absent, only this effective default applies; if none
-exists, the slot has no default. When the slot value is present, `default` does
-not change it, so alternative defaults surfaced under the successful-alternative
-rule are informational hints. An implementation MAY expose the default of each
-successful alternative, deduplicated by
-[Parsed Value Equality](#parsed-value-equality), but MUST NOT treat multiple
-present-value alternative defaults as an error.
-
-Example:
-
-```toml
-[elements.retries]
-type = "integer"
-optional = true
-default = 3
-```
-
-### Deprecation - `deprecated`
-
-`deprecated` is a boolean annotation. When `true`, it advises that the present
-value at that schema location should no longer be used and may be removed in a
-future version.
-
-Deprecation never makes a document invalid. A successfully validated present
-value produces a warning diagnostic with the code `deprecated`; an absent
-optional value produces no warning. A deprecated parent produces one warning at
-the parent's instance path rather than one warning for every descendant. The
-instance path a deprecation warning is reported at, and how many warnings a
-deprecated array `itemtype` or collection `itemtype` produces, follow the
-attachment rules under [Annotations](#annotations). Whether a node counts as
-successfully validated for this purpose is decided by the annotation step of
-[Keyword Evaluation Order](#keyword-evaluation-order).
-
-Deprecation propagates through named references. Across `allof`, any
-contributing `deprecated = true` deprecates the location, and a local
-`deprecated = false` cannot cancel it. Which warning a definition contributes
-when it is reached through an alternative or a conditional branch is defined
-under [Annotations](#annotations). A non-boolean `deprecated`
-value is a schema-load error. Authors SHOULD use `description` for migration or
-replacement guidance.
-
-Example:
-
-```toml
-[elements.legacy-timeout]
-type = "integer"
-deprecated = true
-description = "Use request-timeout instead."
-optional = true
-```
-
-### Optionality - `optional`
-
-A definition may be marked optional in the schema. By default, `optional` is
-`false`, and the structure is required.
-
-Validators MUST skip a definition only when it is optional and the corresponding
-value does not exist in the TOML document. In every other case, the validator
-MUST validate the value against the definition.
-
-This section is the single authority for how `optional` interacts with
-references, composition, alternatives, and conditional branches.
-
-For a named `type` reference, optionality is inherited: the referencing slot is
-optional if either the use site or any definition in the reference chain
-declares `optional = true`. An explicit `optional = false` cannot cancel an
-inherited `true`. In contrast, `optional` on the local definition determines
-whether a composed node may be absent, and `optional` values contributed only
-through `allof` components do not affect presence; such a value has meaning only
-when that component is referenced normally with `type`. The presence of a
-`oneof` or `anyof` slot is governed only by `optional` on the union definition
-or inherited through a named `type` reference to that union. `optional`
-declared inside an alternative does not make the union slot optional because
-no alternative is selected when the slot is absent. Optionality likewise belongs
-to a conditional definition rather than to its branches: an `optional`
-annotation inside a `then` or `else` branch does not make the conditional slot
-optional, because no branch is selected when the slot is absent.
-
-### Pattern - `pattern`
-
-`pattern` constrains a parsed TOML string with a regular expression.
-
-`pattern` is valid on a definition whose selected type is the built-in
-`string`, and, as a [per-member constraint](#per-member-value-constraints), on a
-non-tuple `array` or `collection` whose effective member type is the built-in
-`string`. It cannot be attached to another built-in type, an alternative
-selector, or a named type reference, as
-[Schema Definition Properties](#schema-definition-properties) requires. Schema
-loaders MUST reject an incompatible
-`pattern` at schema-load time rather than silently ignoring it. On a
-`collection`, `pattern` constrains dynamic entry values while
-[`keypattern`](#key-pattern---keypattern) constrains their keys.
-
-The portable TOML Schema regular-expression profile consists of literals,
-escaped metacharacters, the character escapes `\t`, `\n`, `\r`, `\f`, `\v`, and
-`\a`, `.`, character classes and ranges, negated character
-classes, concatenation, alternation, capturing and non-capturing groups, the
-anchors `^` and `$`, and the greedy quantifiers `?`, `*`, `+`, `{n}`, `{n,}`,
-and `{n,m}`. These constructs use the syntax documented by the
-[RE2 syntax reference](https://github.com/google/re2/wiki/Syntax). Implementations MUST
-support this profile.
-
-The listed character escapes are portable because each denotes one fixed control
-character, so no engine can disagree about what it matches. They are portable
-both standalone and inside a character class, so `[ \t]` is a portable pattern.
-
-Character-class shorthands such as `\d`, `\s`, and `\w` are outside the
-portable profile because regular-expression engines disagree about whether
-they use ASCII or Unicode membership. Write the intended set explicitly instead:
-`[0-9]` rather than `\d`. Unicode property classes such as
-`\p{L}`, inline flag groups such as `(?i)`, backreferences, look-around
-assertions, atomic groups, conditionals, recursion, and the non-greedy and
-possessive quantifier forms such as `*?` and `*+` are also outside the
-portable profile.
-
-**Patterns are compiled at schema-load time.** A schema loader MUST compile
-every `pattern` value when it loads the schema, whether or not any document
-exercises it. A pattern that does not compile — `"["`, `"{2,1}"`, or a trailing
-backslash, for example — makes the schema malformed, and the loader MUST reject
-it at schema-load time with the `invalid-pattern` code. An implementation MUST
-NOT defer a compilation failure to match time, MUST NOT treat an uncompilable
-pattern as a failed match, and MUST NOT treat it as a satisfied constraint.
-
-A construct outside the portable profile is likewise a schema-load error,
-reported with the `unsupported-pattern` code. A loader operating in its
-conformant TOML Schema 1.0 mode MUST reject a `pattern`
-that uses one, even when the underlying engine could compile it. An
-implementation MAY offer an additional, explicitly named and documented extended
-pattern profile that accepts further constructs, but that profile MUST NOT be
-the default, and a schema accepted only under it is not a TOML Schema 1.0
-schema. Portability is the whole purpose of naming a profile: if a
-non-portable construct were merely discouraged, the same schema would be a
-load error on one implementation, an ASCII-only match on a second, and a
-Unicode match on a third, which is precisely the interoperability split the
-profile exists to prevent. Conformance suites MUST use only the portable
-profile. The engine an implementation matches these expressions with, and the
-resource limits it applies to compilation and matching, are additionally
-constrained by
-[Regular-Expression Safety](#regular-expression-safety).
-
-**Unicode semantics.** A pattern is compiled from, and matched against, the
-decoded parsed string: a sequence of Unicode scalar values. The TOML parser has
-already applied string escapes such as `\u00E9`, so a loader never sees TOML
-escape syntax in a pattern. Matching operates on Unicode scalar values, never on
-UTF-8 bytes, UTF-16 code units, or grapheme clusters, and the count semantics of
-`{n,m}` follow that same unit. `.` matches exactly one scalar value other than
-a line feed. A character class matches one scalar value from its members, and a
-range such as `[a-z]` or `[À-Ö]` is an inclusive range over Unicode code
-points; a range whose start code point is greater than its end code point does
-not compile and is therefore a schema-load error. A negated class matches any
-scalar value not listed, including a line feed.
-
-Matching is case-sensitive and applies no case folding. No Unicode
-normalization is applied to the pattern or to the subject before matching:
-both are compared as the exact decoded scalar sequences the TOML parser
-produced, consistent with the string rule under
-[Parsed Value Equality](#parsed-value-equality). Two strings that are
-canonically equivalent but differently composed are therefore distinct
-subjects, and an implementation MUST NOT normalize either operand.
-
-The pattern is not implicitly anchored. A value validates if the regular
-expression matches anywhere in the string. Authors who require a full-string
-match MUST anchor the expression with `^` and `$`.
-
-Patterns are evaluated without multiline or dot-all modes. `^` matches only
-the start of the complete parsed string, `$` matches only its end (not a
-position before a final line feed), and `.` does not match a line feed. These
-rules also apply when an implementation uses a regular-expression engine with
-different defaults.
-
-### Key Pattern - `keypattern`
-
-`keypattern` constrains the keys of a collection's dynamically named entries
-with a regular expression.
-
-`keypattern` may only be used on a `collection`. It constrains the **keys** (entry names) of the
-collection's dynamic children: every dynamically keyed entry must match the provided regular
-expression. It does not validate entry *values* — that is the role of `itemtype`. It is
-therefore orthogonal to `itemtype` and may be combined with it.
-
-`keypattern` is invalid on any non-`collection` type (scalars, `array`, plain
-`table`), and a schema loader MUST reject a schema that uses it elsewhere.
-
-Keys that are explicitly declared as fixed child definitions of the collection (schema-restricted
-key-value pairs) are validated by their own definitions and are not subject to `keypattern`. Only
-dynamic, user-provided keys are matched against the pattern.
-
-Implementations MUST support the same portable RE2 regular-expression profile as
-[`pattern`](#pattern---pattern), and every rule that section states about
-regular expressions applies unchanged to `keypattern`: schema-load compilation,
-rejection of uncompilable patterns and of constructs outside the portable
-profile, Unicode scalar-value matching, character-class and range behavior,
-case sensitivity, and the absence of Unicode normalization. The subject is the
-decoded TOML key rather than a string value; keys are matched as the exact
-decoded scalar sequences the TOML parser produced, so a quoted key and a bare
-key that decode to the same characters are the same subject. Like `pattern`,
-`keypattern` is not implicitly
-anchored: a key validates if the regular expression matches anywhere in the key
-string. Authors who require a full-key match MUST anchor the expression with
-`^` and `$`.
-
-Example:
-
-```toml
-[types.listOfServersType]
-type       = "collection"
-itemtype   = "types.serverType"
-minlength  = 1
-keypattern = "^server_[0-9]+$"
-```
-
-Against a TOML document:
-
-```toml
-[servers.server_01]   # accepted
-[servers.server_02]   # accepted
-[servers.alpha]       # rejected: key does not match ^server_[0-9]+$
-```
-
-This mirrors JSON Schema's `propertyNames: { pattern: ... }`, applied to TOML maps.
-
 ## Validation and Data Model
 
 TOML Schema validation does not modify the parsed TOML data model.
@@ -3309,7 +3318,7 @@ the steps that depend on it begin:
    selector exclusivity: at most one of `type`, `oneof`, `anyof`, and the
    conditional triple, and at least one unless the definition is an implicit
    table or a [pure mixin](#composition-supplying-the-local-skeleton), both
-   described under [Types Table](#types-table---types). It also includes the
+   described under [Selectors](#selectors). It also includes the
    exclusion between `items` and the
    [per-member value-constraint subset](#per-member-value-constraints) and the
    rejection of a per-member constraint that is also declared on the definition

--- a/SPEC.md
+++ b/SPEC.md
@@ -41,7 +41,7 @@ mixing them:
 A term that names something on one side MUST NOT be read as its counterpart on
 the other.
 
-### Schema-side terms
+### Schema-Side Terms
 
 - **Schema definition** (also **definition**). One coherent set of rules that
   governs a single position. A definition is written as a TOML table or
@@ -53,7 +53,7 @@ the other.
 
 - **Element**. A definition that is a direct child of `[elements]`; it describes
   one top-level key of the validated document. See
-  [Elements table](#elements-table---elements). Elements follow the same rules as
+  [Elements Table](#elements-table---elements). Elements follow the same rules as
   `[types]` definitions except that an element MUST NOT reference another
   element.
 
@@ -72,7 +72,7 @@ the other.
   definition with nested child definitions and no explicit selector is an
   **implicit table** (`type = "table"`), and a definition whose only applicator
   is `allof` is a **pure mixin** whose effective type comes from its components.
-  See [Types table](#types-table---types) and
+  See [Types Table](#types-table---types) and
   [Composition Supplying the Local Skeleton](#composition-supplying-the-local-skeleton).
 
 - **Schema type**. The type a definition *selects* through `type`: a built-in
@@ -89,13 +89,14 @@ the other.
   effective type, not from the written schema type. A definition's effective type
   has a coarse category — a scalar of a specific scalar type, `array`, `table`,
   or `collection` — and that category is what a composition MUST agree on and
-  what a parsed value's **TOML kind** (below) is checked against. Some existing
-  prose in this document spells this concept *effective kind* or *effective TOML
-  kind*; those are the same concept, and *effective type* is the preferred term.
+  what a parsed value's **TOML kind** (below) is checked against. Earlier
+  drafts of this document spelled this concept *effective kind* or *effective
+  TOML kind*; those are the same concept, and *effective type* is the preferred
+  term.
 
 - **Named type** / **reusable definition**. A definition under `[types]`,
   referenced by name from a selector, `itemtype`, `items`, or `allof`. See
-  [Types table](#types-table---types).
+  [Types Table](#types-table---types).
 
 - **Type reference** / **reference**. A string that names a built-in type or a
   named reusable definition, accepted by `type`, `itemtype`, `items`, `oneof`,
@@ -196,7 +197,7 @@ the other.
   validated; the document value is validated against it as a whole.
   [The Effective Definition](#the-effective-definition) is authoritative.
 
-### Document-side terms
+### Document-Side Terms
 
 - **Key**. A decoded TOML key of the parsed document — the identifier of a table
   entry or the name of a top-level key. Keys are compared as decoded values, not
@@ -245,7 +246,7 @@ the other.
   node and of a schema location, respectively. Their grammars are defined under
   [Instance Path](#instance-path) and [Schema Path](#schema-path).
 
-### Deprecated near-synonym mapping
+### Deprecated Near-Synonym Mapping
 
 Some prose written before this section was added uses a near-synonym for one of
 the terms above. A later editorial pass SHOULD replace each deprecated spelling
@@ -267,20 +268,20 @@ and the preferred term is the one to use in new text.
 
 - [Conformance Terminology](#conformance-terminology)
 - [Terminology](#terminology)
-  - [Schema-side terms](#schema-side-terms)
-  - [Document-side terms](#document-side-terms)
-  - [Deprecated near-synonym mapping](#deprecated-near-synonym-mapping)
+  - [Schema-Side Terms](#schema-side-terms)
+  - [Document-Side Terms](#document-side-terms)
+  - [Deprecated Near-Synonym Mapping](#deprecated-near-synonym-mapping)
 - [First Glance](#first-glance)
-  - [TOML example](#toml-example)
-  - [TOML Schema example](#toml-schema-example)
+  - [TOML Example](#toml-example)
+  - [TOML Schema Example](#toml-schema-example)
 - [TOML Language Version](#toml-language-version)
 - [Schema Structure Reference](#schema-structure-reference)
-  - [Top-level Structure Conditions](#top-level-structure-conditions)
+  - [Top-Level Structure Conditions](#top-level-structure-conditions)
 - [Metadata Table - `[toml-schema]`](#metadata-table---toml-schema)
   - [Supported Properties](#supported-properties)
   - [Schema Versioning](#schema-versioning)
-- [Elements table - `[elements]`](#elements-table---elements)
-- [Types table - `[types]`](#types-table---types)
+- [Elements Table - `[elements]`](#elements-table---elements)
+- [Types Table - `[types]`](#types-table---types)
   - [Type Reference Restrictions](#type-reference-restrictions)
   - [Schema Definition Properties](#schema-definition-properties)
     - [Local and Effective Checks](#local-and-effective-checks)
@@ -309,7 +310,7 @@ and the preferred term is the one to use in new text.
     - [Composition Examples](#composition-examples)
   - [Alternative Types - `oneof` and `anyof`](#alternative-types---oneof-and-anyof)
   - [Conditional Selection - `if`, `then`, and `else`](#conditional-selection---if-then-and-else)
-    - [The discriminator key and closed branches](#the-discriminator-key-and-closed-branches)
+    - [The Discriminator Key and Closed Branches](#the-discriminator-key-and-closed-branches)
   - [Sibling Presence Rules](#sibling-presence-rules)
     - [Dependencies - `dependentrequired`](#dependencies---dependentrequired)
     - [Mutual Exclusion - `mutuallyexclusive`](#mutual-exclusion---mutuallyexclusive)
@@ -352,10 +353,10 @@ and the preferred term is the one to use in new text.
   - [Extensibility](#extensibility)
   - [Command-Line Exit Status](#command-line-exit-status)
   - [Code Registry](#code-registry)
-    - [Discovery codes](#discovery-codes)
-    - [Schema-load codes](#schema-load-codes)
-    - [Validation codes](#validation-codes)
-  - [Informative examples](#informative-examples)
+    - [Discovery Codes](#discovery-codes)
+    - [Schema-Load Codes](#schema-load-codes)
+    - [Validation Codes](#validation-codes)
+  - [Informative Examples](#informative-examples)
 - [Schema Self-Validation](#schema-self-validation)
 - [Security Considerations](#security-considerations)
   - [Schema Discovery and Retrieval](#schema-discovery-and-retrieval)
@@ -371,7 +372,7 @@ and the preferred term is the one to use in new text.
 *This section is informative. It illustrates the language through a worked pair
 of documents; the normative rules are stated in the sections that follow.*
 
-### TOML example
+### TOML Example
 Let's look at the TOML example displayed on the front page of [toml.io](https://toml.io/en/):
 
 ```toml
@@ -400,7 +401,7 @@ ip = "10.0.0.2"
 role = "backend"
 ```
 
-### TOML Schema example
+### TOML Schema Example
 
 Example of a TOML Schema that validates the TOML document above:
 
@@ -514,7 +515,7 @@ A TOML Schema file has the following structure:
 [elements]
 ```
 
-### Top-level Structure Conditions
+### Top-Level Structure Conditions
 
  - `[toml-schema]`: table with information and metadata of the schema.
    - **REQUIRED**
@@ -586,7 +587,7 @@ language version: the first TOML Schema language version is `1.0.0`. A `0.y.z`
 value is well-formed Semantic Versioning but is not a TOML Schema language
 version, and a schema loader MUST reject it as an unsupported major version.
 
-## Elements table - `[elements]`
+## Elements Table - `[elements]`
 
 The `[elements]` table is the root schema for the TOML document being validated. Schema authors use it to describe the application data that may appear at the top level of the TOML document.
 
@@ -622,7 +623,7 @@ enabled = true
 
 Use `[elements]` for document-specific keys. Use `[types]` for reusable definitions that can be referenced from `[elements]` or from other reusable types. Elements follow the same structure and validation rules as types, except that elements cannot reference other elements. To reuse conditions and structures, define them under `[types]` and reference them from `[elements]`.
 
-## Types table - `[types]`
+## Types Table - `[types]`
 
 The `[types]` table is for use when there is a need for custom, reusable types of structure or properties. A type is referenced in an element or another type with a type reference.
 
@@ -652,7 +653,7 @@ unambiguous, a reusable type name MUST NOT begin with the literal characters
 `local-time`, `array`, `table`, and `collection`.
 
 `type`, `oneof`, `anyof`, and the `if`/`then`/`else` triple are alternative
-ways to select the type of the current schema node. A definition MUST declare
+ways to select the type of the current definition. A definition MUST declare
 at most one selector, and two constructs supply the selection in place of one:
 
 - a definition with nested child definitions MAY omit all selectors and is then
@@ -723,7 +724,7 @@ specification points here rather than restating them.
 | `items` | Any built-in except `collection` | Yes | Yes | Consuming |
 | `oneof`, `anyof` | Any built-in except `any` and `collection` | Yes | Yes | Non-consuming |
 | `allof` | Any built-in except `any` and `collection` | Yes | Yes | Non-consuming |
-| `then`, `else` | None; a bare built-in reference is invalid in either | Yes, and both branches MUST resolve to the same effective kind, which MUST be `table` or `collection` | Yes, subject to that same kind requirement | Non-consuming |
+| `then`, `else` | None; a bare built-in reference is invalid in either | Yes, and both branches MUST resolve to the same effective type, which MUST be `table` or `collection` | Yes, subject to that same kind requirement | Non-consuming |
 
 The two restricted built-ins are restricted for one reason each:
 
@@ -755,7 +756,7 @@ that turns a reference string into a built-in type or a reusable definition is
 defined under [Reference Resolution](#reference-resolution), which is
 authoritative for how the restrictions above are applied. An element MUST NOT
 reference another element, as
-[Elements table](#elements-table---elements) requires.
+[Elements Table](#elements-table---elements) requires.
 
 Type-selection and composition references MUST be acyclic. A cycle composed of
 named `type` aliases, `oneof` alternatives, `anyof` alternatives, conditional
@@ -775,8 +776,8 @@ detailed sections below remain authoritative.
 
 | Property | Applicable definition |
 | --- | --- |
-| `type` | Selects one built-in or named type; at most one selector per definition, per [Types table](#types-table---types) |
-| `oneof`, `anyof` | Select the current node from one or more alternatives; at most one selector per definition, per [Types table](#types-table---types) |
+| `type` | Selects one built-in or named type; at most one selector per definition, per [Types Table](#types-table---types) |
+| `oneof`, `anyof` | Select the current node from one or more alternatives; at most one selector per definition, per [Types Table](#types-table---types) |
 | `if`, `then`, `else` | Exhaustively select one of two named table-like definitions from a direct child's parsed value |
 | `allof` | Conjunctively applies one or more compatible type references in addition to the local definition; alone, it also supplies an omitted selector, per [Composition Supplying the Local Skeleton](#composition-supplying-the-local-skeleton) |
 | `description`, `optional`, `default`, `deprecated` | Any definition, including a named reference or alternative selector |
@@ -910,7 +911,7 @@ definition is a schema property, while a table-header path segment below that
 definition is normally a target child definition.
 
 A schema definition with nested child definitions and no explicit selector is an
-implicit table, as [Types table](#types-table---types) defines. This lets
+implicit table, as [Types Table](#types-table---types) defines. This lets
 schemas describe target keys that would
 otherwise share a name with schema properties when the parent does not also use
 the property.
@@ -1096,7 +1097,17 @@ allowedvalues=[ "red", "black", "blue" ]
 #### String Format - `format`
 
 `format` applies a standardized semantic assertion to a parsed TOML string.
-It MUST be one of the following case-sensitive names:
+
+`format` is valid on a definition whose selected type is the built-in
+`string`, and, as a [per-member constraint](#per-member-value-constraints), on a
+non-tuple `array` or `collection` whose effective member type is the built-in
+`string`. It cannot be attached to another built-in type, an alternative
+selector, or a named type reference, as
+[Schema Definition Properties](#schema-definition-properties) requires. A schema
+loader MUST reject an unsupported
+format name or incompatible use at schema-load time rather than ignoring it.
+
+The value of `format` MUST be one of the following case-sensitive names:
 
 | Format | Required syntax |
 | --- | --- |
@@ -1133,15 +1144,6 @@ The formats use the following portable rules:
   It does not accept a URI host's brackets or a zone identifier. An embedded
   IPv4 suffix follows the `ipv4` rules above.
 
-`format` is valid on a definition whose selected type is the built-in
-`string`, and, as a [per-member constraint](#per-member-value-constraints), on a
-non-tuple `array` or `collection` whose effective member type is the built-in
-`string`. It cannot be attached to another built-in type, an alternative
-selector, or a named type reference, as
-[Schema Definition Properties](#schema-definition-properties) requires. A schema
-loader MUST reject an unsupported
-format name or incompatible use at schema-load time rather than ignoring it.
-
 When `format` is combined with `allowedvalues`, every allowed string MUST
 satisfy the format at schema-load time. `format` is independent of `pattern`,
 `minlength`, and `maxlength`; a document string MUST satisfy every declared
@@ -1171,19 +1173,9 @@ These properties define inclusive value ranges. The **comparable kinds** are:
 
 `min` and `max` MAY be declared only on a definition whose type resolves to
 exactly one comparable kind, and on an `array` or a `collection` whose members
-do, as the next paragraph describes.
+do, as the per-member reading below describes.
 
-On an `array` or a `collection`, `min` and `max` are
-[per-member constraints](#per-member-value-constraints) and apply to each item
-or each dynamic entry. That section is authoritative for the per-member reading,
-for how the member type is resolved through `itemtype` and through the
-alternatives of a referenced `oneof` or `anyof`, and for the schema-load
-rejection of a member type that is indeterminate or of the wrong kind. The
-interaction between array range
-boundaries and `allowedvalues` is defined under
-[Observations on Conditions to Arrays](#observations-on-conditions-to-arrays).
-
-A `min` or `max` boundary MUST be a TOML value that is comparable with the schema type: `integer` or `float` boundaries for `integer` and `float` values, and matching temporal boundaries for temporal values.
+A `min` or `max` boundary MUST be a TOML value that is comparable with the effective type: `integer` or `float` boundaries for `integer` and `float` values, and matching temporal boundaries for temporal values.
 
 `nan`, `+nan`, and `-nan` are not valid `min` or `max` boundaries because NaN is unordered. `inf`, `+inf`, and `-inf` are valid float boundaries, but they are not valid boundaries on a definition whose comparable kind is `integer`; an infinite boundary has no integer counterpart and constrains no integer value, so schema loaders MUST reject it there at schema-load time.
 
@@ -1212,18 +1204,20 @@ loaders MUST reject it at schema-load time. The comparison is always defined
 because the unordered boundary values excluded above are not valid boundaries in
 the first place.
 
+On an `array` or a `collection`, `min` and `max` are
+[per-member constraints](#per-member-value-constraints) and apply to each item
+or each dynamic entry. That section is authoritative for the per-member reading,
+for how the member type is resolved through `itemtype` and through the
+alternatives of a referenced `oneof` or `anyof`, and for the schema-load
+rejection of a member type that is indeterminate or of the wrong kind. The
+interaction between array range
+boundaries and `allowedvalues` is defined under
+[Observations on Conditions to Arrays](#observations-on-conditions-to-arrays).
+
 ### Length - `minlength` and `maxlength`
 
 These properties MUST be used only to define the allowed length of a `string`,
 an `array`, or a `collection`.
-
-For `string` values, length is counted as the number of Unicode scalar values after TOML parsing and escape processing. It is not the number of UTF-8 bytes, UTF-16 code units, or user-perceived grapheme clusters. For example, `"\U0001F600"` has length 1, while `"e\u0301"` has length 2 because it is composed of two Unicode scalar values.
-
-For an `array`, length is its number of items. For a `collection`, length is
-the number of dynamic entries to which `itemtype` applies; fixed child
-definitions are excluded from the count.
-
-Both `minlength` and `maxlength` MUST be integers `>= 0`. When both are present, `minlength` MUST be less than or equal to `maxlength`. A schema violating either rule is malformed and schema loaders MUST reject it at schema-load time.
 
 `minlength` and `maxlength` are valid only on definitions whose selected type is
 the built-in `string`, `array`, or `collection`. They cannot be attached to
@@ -1231,6 +1225,14 @@ another built-in type, an alternative selector, or a named type reference, as
 [Schema Definition Properties](#schema-definition-properties) requires.
 Schema loaders MUST reject an incompatible length constraint at schema-load time rather
 than silently ignoring it.
+
+Both `minlength` and `maxlength` MUST be integers `>= 0`. When both are present, `minlength` MUST be less than or equal to `maxlength`. A schema violating either rule is malformed and schema loaders MUST reject it at schema-load time.
+
+For `string` values, length is counted as the number of Unicode scalar values after TOML parsing and escape processing. It is not the number of UTF-8 bytes, UTF-16 code units, or user-perceived grapheme clusters. For example, `"\U0001F600"` has length 1, while `"e\u0301"` has length 2 because it is composed of two Unicode scalar values.
+
+For an `array`, length is its number of items. For a `collection`, length is
+the number of dynamic entries to which `itemtype` applies; fixed child
+definitions are excluded from the count.
 
 On an `array` or a `collection` these two properties always bound the
 container's own member count. They are deliberately excluded from the
@@ -1257,7 +1259,7 @@ identically.
 
 If a schema definition has nested child definitions but does not declare a
 selector, it is an implicit table, as
-[Types table](#types-table---types) defines.
+[Types Table](#types-table---types) defines.
 
 The **fixed children** of a table, for the purpose of the rules below, are its
 own nested child definitions together with the children contributed by every
@@ -1277,7 +1279,7 @@ of the following rules to it:
 
 The third rule is what makes a closed table reject misspelled and undeclared
 keys. It is the same rule the root applies under
-[Elements table](#elements-table---elements).
+[Elements Table](#elements-table---elements).
 
 A table with no fixed children is **open**. Validators MUST accept any TOML
 table value without validating its contents, including its keys. This is useful
@@ -1290,7 +1292,7 @@ effective rather than the local view; the complete list is under
 
 An open table is not the same as an empty root `[elements]` table. An open table
 accepts any keys; an empty `[elements]` table accepts no application data at
-all, as described under [Elements table](#elements-table---elements).
+all, as described under [Elements Table](#elements-table---elements).
 
 #### Arrays
 
@@ -1432,20 +1434,6 @@ itemtype = "types.pointType"
 
 Use `items` to validate each array entry by position with an exact length.
 
-Example:
-
-```toml
-[types.coordinate]
-type = "float"
-
-[types.label]
-type = "string"
-
-[types.coordinateLabel]
-type = "array"
-items = [ "types.coordinate", "types.label" ]
-```
-
 Semantics:
 
  - `items` is ordered, and each index validates against the corresponding referenced type.
@@ -1467,6 +1455,20 @@ Semantics:
    position rather than an alternative, so a tuple whose positions share a type,
    such as `items = [ "types.coordinate", "types.coordinate" ]`, is valid and
    repetition is meaningful.
+
+Example:
+
+```toml
+[types.coordinate]
+type = "float"
+
+[types.label]
+type = "string"
+
+[types.coordinateLabel]
+type = "array"
+items = [ "types.coordinate", "types.label" ]
+```
 
 ##### Array Uniqueness - `uniqueitems`
 
@@ -1535,7 +1537,8 @@ entry's value against the item definition, as
 are not optional remain required, exactly as in a closed table.
 
 This difference in unknown-key semantics is why `table` and `collection` are not
-interchangeable for `allof` composition.
+interchangeable for `allof` composition. Because a `collection` is never closed,
+schema authors SHOULD prefer a closed `table` when the key set really is fixed.
 
 A `collection` may additionally constrain the **keys** (entry names) of its dynamic children with `keypattern`. See [Key Pattern - `keypattern`](#key-pattern---keypattern).
 
@@ -1550,7 +1553,8 @@ applying `itemtype` only to all other keys. For example, `itemtype = "any"`
 makes unknown keys forward-compatible while fixed children still receive their
 declared validation. Authors choosing this pattern trade typo detection on
 unknown keys for extensibility; use a closed `table` when undeclared keys must
-be rejected.
+be rejected. Schema authors SHOULD prefer a closed `table` when the upstream
+format defines a stable, exhaustive key set.
 
 This precedence also supports open extension namespaces with typed well-known
 entries. For example, a `pyproject.toml` schema can define `[tool]` as a
@@ -1558,9 +1562,9 @@ collection of open tables, then add fixed `[tool.ruff]` and `[tool.uv]` child
 definitions with their respective schemas. Other tool names continue to use the
 collection's general `itemtype`.
 
+Example:
 
-**Example:**
-The below example shows a table `servers` that is a `collection`.
+The example below shows a table `servers` that is a `collection`.
 Each server MUST be given a key and follow the defined structure of `types.serverType`.
 A server may also have a DNS table with user-provided key names.
 
@@ -1737,8 +1741,9 @@ referencing definition MAY additionally declare only `allof`, `description`,
 `optional`, `default`, and `deprecated`; it MUST NOT declare any other sibling
 property or child definition. `allof` adds conjunctive components rather than
 overriding the named reference. A local `default` is the use-site annotation
-described below, and `deprecated = false` cannot cancel deprecation inherited
-from a reference. In particular, validation constraints such as `pattern`,
+defined under [Default](#default---default), and `deprecated = false` cannot
+cancel deprecation inherited from a reference. In particular, validation
+constraints such as `pattern`,
 `keypattern`, `min`, `max`, `minlength`, `maxlength`, `allowedvalues`,
 `itemtype`, and `items` cannot be added or overridden at the reference site.
 Schema loaders MUST reject such schemas at schema-load time.
@@ -1883,7 +1888,7 @@ special case for collections.
 
 A definition that declares no selector, no nested child definition, and no
 `allof` determines nothing at all, and it remains a schema-load error under
-[Types table](#types-table---types).
+[Types Table](#types-table---types).
 
 #### The Effective Definition
 
@@ -1923,11 +1928,11 @@ the checks [Local and Effective Checks](#local-and-effective-checks) lists as
 effective; every other applicability and exclusivity check remains local.
 
 A composition is well formed only when its participants agree on kind.
-Every component MUST resolve to an effective TOML kind compatible with the
+Every component MUST resolve to an effective type compatible with the
 local definition, or, when the local definition is a pure mixin and states no
 kind of its own, with one another. When the local selector is `oneof` or
 `anyof`, all of its
-alternatives MUST resolve to the same effective kind before `allof` can be
+alternatives MUST resolve to the same effective type before `allof` can be
 applied; a multi-kind local union combined with `allof` is indeterminate and
 MUST be rejected at schema-load time. Scalar and array components MUST have the
 same kind as the local definition. Structured components MUST all be `table` or
@@ -2292,7 +2297,7 @@ The fixed child escapes both dynamic-entry rules: `schemaVersion` is an
 dynamic entries.
 
 An `allof` component may itself contain `oneof`, `anyof`, or another `allof`
-when its effective kind is unambiguous. A composed definition may be referenced
+when its effective type is unambiguous. A composed definition may be referenced
 from `type`, `itemtype`, `items`, `oneof`, `anyof`, `allof`, `then`, or `else`. All composition
 references MUST resolve at schema-load time, and composition/type-selection
 cycles are malformed. Structural recursion that consumes a child or container
@@ -2312,7 +2317,7 @@ intentionally unconstrained named branch, or any other constraint.
 
 `type`, `oneof`, `anyof`, and the conditional triple all select the current
 node's type, and a definition declares at most one of them, as
-[Types table](#types-table---types) requires.
+[Types Table](#types-table---types) requires.
 
 The array assigned to `oneof` or `anyof` MUST contain at least one type
 reference. A union definition MAY additionally declare only `description`,
@@ -2330,6 +2335,35 @@ definition twice and is malformed. Schema loaders MUST reject a duplicate
 alternative at schema-load time. This differs from
 [`items`](#tuple--positional-array-validation---items), where an entry denotes a
 tuple position rather than an alternative and repetition is meaningful.
+
+A union contributes nothing to the
+[determinate fixed-child set](#determinate-fixed-child-set) of the node it
+selects, because no alternative is chosen until a document value exists. It does
+contribute at validation time: when an alternative is evaluated against a
+document node, that alternative's fixed children join the node's
+[effective closure set](#effective-closure-set) for that evaluation, so a key
+the alternative declares is a known key of the node and MUST NOT be reported as
+unexpected. This is what lets a union be composed into a table with `allof`
+without the alternatives' own children becoming unknown keys.
+
+When alternatives contain annotations, only successful alternatives contribute
+them, and only for a value that is present. Deprecation warnings follow the
+successful-alternative rule: `oneof` reports the warning of its single
+successful alternative, and `anyof` reports the warnings of every successful
+alternative, deduplicated as [Diagnostics](#diagnostics) requires. Consequently,
+a deprecated successful alternative contributes a warning even when another
+successful `anyof` alternative is not deprecated; this preserves all annotations
+attached to definitions that accepted the value. Alternative `default`
+annotations are governed by [Default](#default---default): they are never
+combined into the slot's effective default and never cause a schema-load
+conflict. For a present value, an implementation MAY surface the default of each
+successful alternative as a hint, deduplicated by
+[Parsed Value Equality](#parsed-value-equality). An alternative that fails
+validation contributes neither defaults nor deprecation warnings; what happens to
+its diagnostics is defined under
+[Alternative and Branch Commit and Discard](#alternative-and-branch-commit-and-discard).
+
+Examples:
 
 ```toml
 [types.stringId]
@@ -2391,33 +2425,6 @@ itemtype = "types.cascadeEntry"
 oneof = [ "types.cascadeEntry", "types.cascadeEntries" ]
 ```
 
-A union contributes nothing to the
-[determinate fixed-child set](#determinate-fixed-child-set) of the node it
-selects, because no alternative is chosen until a document value exists. It does
-contribute at validation time: when an alternative is evaluated against a
-document node, that alternative's fixed children join the node's
-[effective closure set](#effective-closure-set) for that evaluation, so a key
-the alternative declares is a known key of the node and MUST NOT be reported as
-unexpected. This is what lets a union be composed into a table with `allof`
-without the alternatives' own children becoming unknown keys.
-
-When alternatives contain annotations, only successful alternatives contribute
-them, and only for a value that is present. Deprecation warnings follow the
-successful-alternative rule: `oneof` reports the warning of its single
-successful alternative, and `anyof` reports the warnings of every successful
-alternative, deduplicated as [Diagnostics](#diagnostics) requires. Consequently,
-a deprecated successful alternative contributes a warning even when another
-successful `anyof` alternative is not deprecated; this preserves all annotations
-attached to definitions that accepted the value. Alternative `default`
-annotations are governed by [Default](#default---default): they are never
-combined into the slot's effective default and never cause a schema-load
-conflict. For a present value, an implementation MAY surface the default of each
-successful alternative as a hint, deduplicated by
-[Parsed Value Equality](#parsed-value-equality). An alternative that fails
-validation contributes neither defaults nor deprecation warnings; what happens to
-its diagnostics is defined under
-[Alternative and Branch Commit and Discard](#alternative-and-branch-commit-and-discard).
-
 ### Conditional Selection - `if`, `then`, and `else`
 
 The `if`, `then`, and `else` properties form one exhaustive selector for a
@@ -2453,7 +2460,7 @@ else = "types.serverDatabase"
 
 Both branches declare `engine`, the key the condition reads. That is required
 rather than stylistic: see
-[The discriminator key and closed branches](#the-discriminator-key-and-closed-branches)
+[The Discriminator Key and Closed Branches](#the-discriminator-key-and-closed-branches)
 below.
 
 `if` MUST be an inline table containing `key` and exactly one of `equals` or
@@ -2492,11 +2499,11 @@ The condition reads a direct child of a parsed table. When the document value at
 a conditional node is not a table — a scalar, an array, or an array of tables —
 no direct child can be read, so the condition cannot be satisfied and is false,
 exactly as it is for an absent child. `else` is therefore the selected branch.
-Because both branches MUST resolve to the same table-like effective kind, that
+Because both branches MUST resolve to the same table-like effective type, that
 value cannot validate against either branch, and the node is invalid. A
 validator MUST report this as a kind mismatch against the common branch kind at
 the node's location, using the `type-mismatch` code defined under
-[Validation codes](#validation-codes), and MUST NOT report the branch's internal
+[Validation Codes](#validation-codes), and MUST NOT report the branch's internal
 `missing-required` or `unknown-key` diagnostics for a value that is not a table
 at all. It MUST NOT report a diagnostic describing the condition, which never
 fails on its own.
@@ -2514,14 +2521,14 @@ only by the branch that was not selected are not.
 
 `then` and `else` MUST each be a string naming a reusable definition in
 `[types]`, and both definitions MUST resolve
-to the same effective kind, which MUST be `table` or `collection`, as
+to the same effective type, which MUST be `table` or `collection`, as
 [Type Reference Restrictions](#type-reference-restrictions) states.
 Schema loaders MUST reject unresolved branches, different branch kinds,
 branches that do not resolve to a table-like kind, and cycles through
 conditional branches.
 
 The conditional triple is one of the four selectors a definition declares at
-most one of, as [Types table](#types-table---types) requires. A conditional
+most one of, as [Types Table](#types-table---types) requires. A conditional
 definition MAY additionally declare only `allof`,
 `description`, `optional`, `default`, and `deprecated`; it MUST NOT contain
 kind-specific validation properties or nested child definitions. An `allof`
@@ -2545,7 +2552,7 @@ else = "types.embeddedDatabase"
 Additional alternatives can be expressed by referencing another conditional
 definition from `then` or `else`.
 
-#### The discriminator key and closed branches
+#### The Discriminator Key and Closed Branches
 
 The key named by `if.key` is ordinary application data. It is read to select a
 branch, and it is then validated by the selected branch like any other key. A
@@ -2602,6 +2609,12 @@ definition named `dependentrequired`. A definition that needs both the rule and
 a child of that name writes the child through the `children` namespace, as
 described under [Quoted and Special Keys](#quoted-and-special-keys).
 
+Dependencies are directional. If `a` requires `b`, the presence of `b` does not
+require `a` unless a reverse mapping is declared. Every triggered mapping is
+evaluated, so dependencies may apply transitively.
+
+Example:
+
 ```toml
 [types.dependency]
 type = "table"
@@ -2624,15 +2637,15 @@ dependentrequired = { branch = [ "git" ], tag = [ "git" ], rev = [ "git" ] }
     optional = true
 ```
 
-Dependencies are directional. If `a` requires `b`, the presence of `b` does not
-require `a` unless a reverse mapping is declared. Every triggered mapping is
-evaluated, so dependencies may apply transitively.
-
 #### Mutual Exclusion - `mutuallyexclusive`
 
 `mutuallyexclusive` is a non-empty array of groups. Each group is an array of
 at least two unique child-name strings. At most one member of each group MAY be
 present.
+
+Zero or one present member satisfies a group.
+
+Example:
 
 ```toml
 [types.source]
@@ -2660,12 +2673,15 @@ mutuallyexclusive = [ [ "git", "path" ], [ "branch", "tag", "rev" ] ]
     optional = true
 ```
 
-Zero or one present member satisfies a group.
-
 #### Exactly One - `exactlyone`
 
 `exactlyone` has the same shape as `mutuallyexclusive`, but exactly one member
 of every group MUST be present.
+
+This allows every group member to remain individually `optional = true` while
+the group still requires one choice.
+
+Example:
 
 ```toml
 [types.readmeTable]
@@ -2680,9 +2696,6 @@ exactlyone = [ [ "file", "text" ] ]
     type = "string"
     optional = true
 ```
-
-This allows every group member to remain individually `optional = true` while
-the group still requires one choice.
 
 Every name in these three properties MUST identify a direct fixed child in the
 [determinate fixed-child set](#determinate-fixed-child-set) of the definition
@@ -2708,7 +2721,7 @@ branches that define the children.
 Schema loaders MUST reject a rule with the wrong TOML value type, an empty
 mapping or group list, a group with fewer than two members, a duplicate name
 within one dependency array or group, an unknown fixed-child name, or use on an
-incompatible effective kind. Loaders are not required to prove general logical
+incompatible effective type. Loaders are not required to prove general logical
 satisfiability between multiple valid rules.
 
 Ordinary requiredness is evaluated together with these rules. An absent
@@ -2828,13 +2841,6 @@ to the slot that node occupies, as described under [Annotations](#annotations);
 unlike them, it MUST resolve to exactly one value, and the rules below are
 authoritative for that resolution.
 
-```toml
-[elements.retries]
-type = "integer"
-optional = true
-default = 3
-```
-
 Because `default` is also a legal child key, a `default = <value>` key/value
 entry is always the annotation, while a table header such as
 `[elements.options.default]` is always a child definition named `default`.
@@ -2880,25 +2886,26 @@ alternatives can match the same value.
 
 When a union slot is absent, only this effective default applies; if none
 exists, the slot has no default. When the slot value is present, `default` does
-not change it, so alternative defaults surfaced under the successful-branch
+not change it, so alternative defaults surfaced under the successful-alternative
 rule are informational hints. An implementation MAY expose the default of each
 successful alternative, deduplicated by
 [Parsed Value Equality](#parsed-value-equality), but MUST NOT treat multiple
 present-value alternative defaults as an error.
+
+Example:
+
+```toml
+[elements.retries]
+type = "integer"
+optional = true
+default = 3
+```
 
 ### Deprecation - `deprecated`
 
 `deprecated` is a boolean annotation. When `true`, it advises that the present
 value at that schema location should no longer be used and may be removed in a
 future version.
-
-```toml
-[elements.legacy-timeout]
-type = "integer"
-deprecated = true
-description = "Use request-timeout instead."
-optional = true
-```
 
 Deprecation never makes a document invalid. A successfully validated present
 value produces a warning diagnostic with the code `deprecated`; an absent
@@ -2912,14 +2919,26 @@ successfully validated for this purpose is decided by the annotation step of
 
 Deprecation propagates through named references. Across `allof`, any
 contributing `deprecated = true` deprecates the location, and a local
-`deprecated = false` cannot cancel it. Alternative branches follow the
-successful-branch annotation rules defined above. A non-boolean `deprecated`
+`deprecated = false` cannot cancel it. Which warning a definition contributes
+when it is reached through an alternative or a conditional branch is defined
+under [Annotations](#annotations). A non-boolean `deprecated`
 value is a schema-load error. Authors SHOULD use `description` for migration or
 replacement guidance.
 
+Example:
+
+```toml
+[elements.legacy-timeout]
+type = "integer"
+deprecated = true
+description = "Use request-timeout instead."
+optional = true
+```
+
 ### Optionality - `optional`
 
-Properties may be defined as optional in the schema. By default, optional equals false, and the structure is required.
+A definition may be marked optional in the schema. By default, `optional` is
+`false`, and the structure is required.
 
 Validators MUST skip a definition only when it is optional and the corresponding
 value does not exist in the TOML document. In every other case, the validator
@@ -2945,7 +2964,9 @@ optional, because no branch is selected when the slot is absent.
 
 ### Pattern - `pattern`
 
-This property is valid on a definition whose selected type is the built-in
+`pattern` constrains a parsed TOML string with a regular expression.
+
+`pattern` is valid on a definition whose selected type is the built-in
 `string`, and, as a [per-member constraint](#per-member-value-constraints), on a
 non-tuple `array` or `collection` whose effective member type is the built-in
 `string`. It cannot be attached to another built-in type, an alternative
@@ -3035,7 +3056,10 @@ different defaults.
 
 ### Key Pattern - `keypattern`
 
-This property may only be used on a `collection`. It constrains the **keys** (entry names) of the
+`keypattern` constrains the keys of a collection's dynamically named entries
+with a regular expression.
+
+`keypattern` may only be used on a `collection`. It constrains the **keys** (entry names) of the
 collection's dynamic children: every dynamically keyed entry must match the provided regular
 expression. It does not validate entry *values* — that is the role of `itemtype`. It is
 therefore orthogonal to `itemtype` and may be combined with it.
@@ -3061,7 +3085,7 @@ anchored: a key validates if the regular expression matches anywhere in the key
 string. Authors who require a full-key match MUST anchor the expression with
 `^` and `$`.
 
-**Example:**
+Example:
 
 ```toml
 [types.listOfServersType]
@@ -3130,6 +3154,10 @@ or offsets differ. Implementations MUST NOT reuse instant ordering as
 
 ### Expressiveness and Validation Scope
 
+*This section is informative. It records what version 1.0 deliberately does and
+does not model; every rule it alludes to is stated normatively in the section it
+cites.*
+
 TOML Schema describes the parsed TOML value tree. It can model the structural
 patterns used by major configuration formats, including:
 
@@ -3179,7 +3207,7 @@ stated explicitly rather than left to inference.
 **No cross-file composition.** Version 1.0 defines no import, include, or
 cross-document reference mechanism. Every named reference resolves within the
 `[types]` table of the same schema document, as
-[Types table](#types-table---types) requires, and the `location` metadata
+[Types Table](#types-table---types) requires, and the `location` metadata
 described under
 [TOML Reference of a TOML Schema](#toml-reference-of-a-toml-schema) binds one
 TOML document to one schema document rather than assembling several. A shared
@@ -3199,11 +3227,11 @@ unsatisfiable so that only the fixed children remain acceptable. The companion
 [`toml-schema.tosd`](toml-schema.tosd) uses the second technique, referencing a
 `types.never` definition as an `itemtype` to emulate a closed collection. That
 idiom works, but it is a workaround for a missing capability rather than a
-language feature, and schema authors SHOULD prefer a closed `table` when the key
-set really is fixed.
+language feature; the recommendation that follows from it is stated under
+[Collection of Elements for Dynamic Keys](#collection-of-elements-for-dynamic-keys).
 
 **No open or dynamically keyed root.** The `[elements]` table is a closed,
-fixed-key table, as [Elements table](#elements-table---elements) requires. No
+fixed-key table, as [Elements Table](#elements-table---elements) requires. No
 schema property applies to `[elements]` itself, so the root cannot be declared a
 `collection`, cannot carry a `keypattern` or an `itemtype`, and cannot be left
 open to arbitrary top-level keys. A document format whose top-level keys are
@@ -3221,8 +3249,9 @@ application policies require an additional semantic-validation pass.
 Some configuration sections intentionally combine known fields with arbitrary
 future or extension-owned fields. A `collection` with fixed child definitions
 and `itemtype = "any"` models that forward-compatible shape, but unknown keys
-cannot then be distinguished from misspellings. Schema authors SHOULD prefer a
-closed `table` when the upstream format defines a stable, exhaustive key set.
+cannot then be distinguished from misspellings; the recommendation that follows
+from that trade-off is stated under
+[Collection of Elements for Dynamic Keys](#collection-of-elements-for-dynamic-keys).
 
 Version 1.0 defines `default` and `deprecated`; examples and editor-specific
 presentation hints remain outside the standard vocabulary.
@@ -3267,7 +3296,7 @@ the steps that depend on it begin:
    [Validation and Data Model](#validation-and-data-model).
 2. **Document shape.** Verify the top-level structure and reject any other
    top-level table or key/value pair, as required under
-   [Top-level Structure Conditions](#top-level-structure-conditions).
+   [Top-Level Structure Conditions](#top-level-structure-conditions).
 3. **Language version.** Verify `[toml-schema].version` as required under
    [Schema Versioning](#schema-versioning). A schema whose version is unsupported
    MUST fail to load before any keyword is interpreted, because later steps depend
@@ -3280,7 +3309,7 @@ the steps that depend on it begin:
    selector exclusivity: at most one of `type`, `oneof`, `anyof`, and the
    conditional triple, and at least one unless the definition is an implicit
    table or a [pure mixin](#composition-supplying-the-local-skeleton), both
-   described under [Types table](#types-table---types). It also includes the
+   described under [Types Table](#types-table---types). It also includes the
    exclusion between `items` and the
    [per-member value-constraint subset](#per-member-value-constraints) and the
    rejection of a per-member constraint that is also declared on the definition
@@ -3337,7 +3366,7 @@ under [Validation and Data Model](#validation-and-data-model).
 
 Validation begins with the document root. The root node is the parsed document's
 root table, and its definition is `[elements]`, applied as a closed table under
-the rules in [Elements table](#elements-table---elements). The reserved root
+the rules in [Elements Table](#elements-table---elements). The reserved root
 `[toml-schema]` table is excluded from application-data validation unless
 `[elements.toml-schema]` is declared, as described under
 [TOML Reference of a TOML Schema](#toml-reference-of-a-toml-schema).
@@ -3395,7 +3424,7 @@ distinct-alternative rule under
 Because normalization happens before lookup and built-in names are tested first,
 `type = "types.string"` denotes the built-in `string`. It is a redundant but valid
 spelling of `type = "string"`, and a schema loader MUST NOT reject it. This is the
-only defensible resolution: [Types table](#types-table---types) already forbids a
+only defensible resolution: [Types Table](#types-table---types) already forbids a
 reusable definition from being named `string`, so the competing reading — treat
 `types.string` as a lookup for a user-defined type named `string` — could never
 resolve to anything and would make a valid schema fail for no expressible reason.
@@ -4105,7 +4134,7 @@ reasons given under
 Composition failures that make a schema malformed are schema-load codes; document
 failures against the effective definition use the ordinary validation codes.
 
-#### Discovery codes
+#### Discovery Codes
 
 | Code | Severity | Condition |
 | --- | --- | --- |
@@ -4117,7 +4146,7 @@ failures against the effective definition use the ordinary validation codes.
 | `version-mismatch` | warning | The document's `[toml-schema].version` and the loaded schema's language version differ without a major-version incompatibility. |
 | `unsupported-version` | error | The document requests, or the schema declares, a language version the implementation must reject (unsupported major, greater minor, or `0.y.z`). Also a schema-load code when no discovery is involved. |
 
-#### Schema-load codes
+#### Schema-Load Codes
 
 | Code | Severity | Condition |
 | --- | --- | --- |
@@ -4138,7 +4167,7 @@ failures against the effective definition use the ordinary validation codes.
 | `schema-malformed` | error | Any other schema-load failure required by this specification: missing `[toml-schema]` or `[elements]`, an empty `oneof`, `anyof`, `allof`, `allowedvalues`, or `items` array, a reserved type name, an invalid `children` escape entry, a non-boolean `deprecated`, and similar. Implementations SHOULD prefer a more specific code from this table when one applies. |
 | `resource-limit-exceeded` | error | A configured limit was reached while loading. Also a discovery and validation code. |
 
-#### Validation codes
+#### Validation Codes
 
 | Code | Severity | Condition |
 | --- | --- | --- |
@@ -4163,7 +4192,7 @@ failures against the effective definition use the ordinary validation codes.
 | `deprecated` | warning | A present node is deprecated. An absent optional slot does not produce this code. |
 | `resource-limit-exceeded` | error | A configured limit was reached during validation. The document is not successfully validated. |
 
-### Informative examples
+### Informative Examples
 
 Unrecognized schema property, schema-load:
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -46,7 +46,7 @@ the other.
 - **Schema definition** (also **definition**). One coherent set of rules that
   governs a single position. A definition is written as a TOML table or
   key/value entry inside `[types]` or `[elements]`, or nested below one. Every
-  definition selects one type and MAY carry
+  definition has exactly one effective type and MAY carry
   [schema definition properties](#schema-definition-properties). "Definition" is
   the preferred short form; "schema definition" is the same thing spelled in
   full.
@@ -67,10 +67,13 @@ the other.
   also uses the property. Do not use "property" for a document key.
 
 - **Selector**. The property by which a definition chooses the type it governs:
-  `type`, `oneof`, `anyof`, or the `if`/`then`/`else` triple. Exactly one
-  selector applies to a definition, except that a definition with nested child
-  definitions and no explicit selector is an **implicit table**
-  (`type = "table"`). See [Types table](#types-table---types).
+  `type`, `oneof`, `anyof`, or the `if`/`then`/`else` triple. At most one
+  selector applies to a definition, and two constructs supply an omitted one: a
+  definition with nested child definitions and no explicit selector is an
+  **implicit table** (`type = "table"`), and a definition whose only applicator
+  is `allof` is a **pure mixin** whose effective type comes from its components.
+  See [Types table](#types-table---types) and
+  [Composition Supplying the Local Skeleton](#composition-supplying-the-local-skeleton).
 
 - **Schema type**. The type a definition *selects* through `type`: a built-in
   type name (`"string"`, `"integer"`, `"array"`, `"table"`, `"collection"`,
@@ -113,6 +116,27 @@ the other.
   local definition or any one of its `allof` components, as defined in place
   under [Merging by TOML Kind](#merging-by-toml-kind). An *`allof` component* is
   one referenced definition contributed to the composition.
+
+- **Pure mixin**. A definition whose only applicator is a non-empty `allof`,
+  with no selector and no nested child definition. It is valid when its
+  components resolve to exactly one TOML kind, which becomes its effective type.
+  [Composition Supplying the Local Skeleton](#composition-supplying-the-local-skeleton)
+  is authoritative.
+
+- **Per-member value-constraint subset**. The five properties `allowedvalues`,
+  `min`, `max`, `pattern`, and `format`, which MAY be written directly on an
+  `array` or a `collection` and then constrain each item or each dynamic entry
+  rather than the container. `minlength` and `maxlength` are not in the subset;
+  on a container they bound its member count.
+  [Per-Member Value Constraints](#per-member-value-constraints) is
+  authoritative.
+
+- **Local check** and **effective check**. An applicability or exclusivity check
+  that reads one definition only, versus one that reads the composed view
+  contributed by `allof` components, alternatives, or branches. Checks are local
+  unless a rule explicitly says *effective*, and
+  [Local and Effective Checks](#local-and-effective-checks) enumerates every
+  effective one.
 
 - **Assertion**, **annotation**, and **applicator**. An *assertion* is a schema
   property a document value must satisfy for the node to be valid. An
@@ -256,6 +280,7 @@ and the preferred term is the one to use in new text.
 - [Elements table - `[elements]`](#elements-table---elements)
 - [Types table - `[types]`](#types-table---types)
   - [Schema Definition Properties](#schema-definition-properties)
+    - [Local and Effective Checks](#local-and-effective-checks)
   - [Quoted and Special Keys](#quoted-and-special-keys)
   - [Scalar and Unconstrained Built-in Types](#scalar-and-unconstrained-built-in-types)
     - [Allowed Values - `allowedvalues`](#allowed-values---allowedvalues)
@@ -270,8 +295,10 @@ and the preferred term is the one to use in new text.
       - [Tuple / Positional Array Validation - `items`](#tuple--positional-array-validation---items)
       - [Array Uniqueness - `uniqueitems`](#array-uniqueness---uniqueitems)
     - [Collection of Elements for Dynamic Keys](#collection-of-elements-for-dynamic-keys)
+    - [Per-Member Value Constraints](#per-member-value-constraints)
   - [Type Reference](#type-reference)
   - [Conjunctive Composition - `allof`](#conjunctive-composition---allof)
+    - [Composition Supplying the Local Skeleton](#composition-supplying-the-local-skeleton)
     - [The Effective Definition](#the-effective-definition)
     - [Merging by TOML Kind](#merging-by-toml-kind)
     - [Determinate Fixed-Child Set](#determinate-fixed-child-set)
@@ -630,13 +657,21 @@ definitions. A named definition that declares a complete collection or selects
 `type = "any"` remains a valid reference.
 
 `type`, `oneof`, `anyof`, and the `if`/`then`/`else` triple are alternative
-ways to select the type of the current schema node. Every definition MUST
-declare exactly one selector, except that a definition with nested child
-definitions MAY omit all selectors and is then treated as `type = "table"`.
+ways to select the type of the current schema node. A definition MUST declare
+at most one selector, and two constructs supply the selection in place of one:
+
+- a definition with nested child definitions MAY omit all selectors and is then
+  treated as `type = "table"`; and
+- a definition whose only applicator is a non-empty `allof` MAY omit all
+  selectors and all nested child definitions, and then takes its effective type
+  from that composition. [Composition Supplying the Local
+  Skeleton](#composition-supplying-the-local-skeleton) is authoritative for when
+  such a definition is valid and for the code a loader reports when it is not.
+
 Schema loaders MUST reject a definition that combines selectors, contains only
-part of a conditional triple, or declares no selector and has no nested child
-definitions. `type` accepts either a built-in type name or a named reusable
-definition from `[types]`. Container member types are selected separately with
+part of a conditional triple, or declares no selector, no nested child
+definitions, and no `allof`. `type` accepts either a built-in type name or a
+named reusable definition from `[types]`. Container member types are selected separately with
 `itemtype`: it validates each member of an `array` or each dynamically keyed
 value of a `collection`. `itemtype` requires the same definition to declare the
 built-in `type = "array"` or `type = "collection"`; it cannot be attached to
@@ -708,18 +743,22 @@ detailed sections below remain authoritative.
 | `type` | Selects one built-in or named type; mutually exclusive with other selectors |
 | `oneof`, `anyof` | Select the current node from one or more alternatives; mutually exclusive with other selectors |
 | `if`, `then`, `else` | Exhaustively select one of two named table-like definitions from a direct child's parsed value |
-| `allof` | Conjunctively applies one or more compatible type references in addition to the local definition |
+| `allof` | Conjunctively applies one or more compatible type references in addition to the local definition; alone, it also supplies an omitted selector, per [Composition Supplying the Local Skeleton](#composition-supplying-the-local-skeleton) |
 | `description`, `optional`, `default`, `deprecated` | Any definition, including a named reference or alternative selector |
-| `format` | A definition with built-in `type = "string"` |
+| `format` | A definition with built-in `type = "string"`; or, as a [per-member constraint](#per-member-value-constraints), a non-tuple `array` or `collection` whose member type is `string` |
 | `itemtype` | A definition with built-in `type = "array"` or `type = "collection"` |
-| `items` | A definition with built-in `type = "array"`; mutually exclusive with `itemtype`, `allowedvalues`, `min`, `max`, `minlength`, and `maxlength` |
-| `allowedvalues` | A scalar or unconstrained built-in type, or the items of a non-tuple `array` |
-| `pattern` | A definition with built-in `type = "string"` |
-| `keypattern` | A definition with built-in `type = "collection"` |
-| `min`, `max` | A numeric or temporal built-in type, or an `array` whose `itemtype` resolves to one comparable kind |
-| `minlength`, `maxlength` | A definition with built-in `type = "string"`, `type = "array"`, or `type = "collection"` |
+| `items` | A definition with built-in `type = "array"`; mutually exclusive with `itemtype`, `minlength`, `maxlength`, and the whole [per-member value-constraint subset](#per-member-value-constraints) (`allowedvalues`, `min`, `max`, `pattern`, `format`) |
+| `allowedvalues` | A scalar or unconstrained built-in type; or, as a [per-member constraint](#per-member-value-constraints), a non-tuple `array` or `collection` |
+| `pattern` | A definition with built-in `type = "string"`; or, as a [per-member constraint](#per-member-value-constraints), a non-tuple `array` or `collection` whose member type is `string` |
+| `keypattern` | A definition with built-in `type = "collection"`; constrains dynamic entry keys, never their values |
+| `min`, `max` | A numeric or temporal built-in type; or, as a [per-member constraint](#per-member-value-constraints), a non-tuple `array` or `collection` whose member type resolves to one comparable kind |
+| `minlength`, `maxlength` | A definition with built-in `type = "string"`, `type = "array"`, or `type = "collection"`; on a container these always bound the container's own member count and are never per-member |
 | `uniqueitems` | A definition with built-in `type = "array"` |
 | `dependentrequired`, `mutuallyexclusive`, `exactlyone` | A definition with effective type `table` or `collection` and a non-empty [determinate fixed-child set](#determinate-fixed-child-set) |
+
+Every applicability and exclusivity statement in this matrix is **local** unless
+it names the effective type or an effective set, as
+[Local and Effective Checks](#local-and-effective-checks) requires.
 
 A named type reference, alternative selector, and conditional selector may
 additionally declare only `allof`, `description`, `optional`, `default`, and
@@ -763,6 +802,68 @@ name, written through the reserved `children` namespace when the same definition
 also uses the property and TOML cannot represent both spellings. Rejecting an
 unrecognized property name therefore never restricts the application data a
 schema can describe.
+
+#### Local and Effective Checks
+
+Applicability and exclusivity checks are **local** unless a rule in this
+specification explicitly says *effective*. This statement is authoritative for
+both readings, and the sections that depend on either one point here rather than
+restating it.
+
+A **local** check reads one definition only: its own selector, its own key/value
+properties, its own nested child definitions, and the definitions its own
+references resolve to. It MUST NOT read the properties, fixed children,
+`itemtype`, or `keypattern` contributed by an `allof` component, by a `oneof` or
+`anyof` alternative, or by a conditional branch.
+
+Locality is what makes these checks decidable one definition at a time, and it
+is why an exclusion such as `items` against the
+[per-member value-constraint subset](#per-member-value-constraints) binds only
+the definition that writes both. An `allof` component MAY contribute a
+constraint the local definition could not have written beside `items`. The two
+then apply conjunctively, as [Merging by TOML Kind](#merging-by-toml-kind)
+requires, and the result is an effective definition that no document value
+satisfies rather than a schema-load error. This is not a loophole in the
+exclusion: an exclusion states what one definition may write, while composition
+states what a value must satisfy, and the two questions have different answers
+by design.
+
+The checks that read the effective, composed view instead are exactly the
+following, and each says so where it is defined:
+
+1. **Composition compatibility.** Whether the participants of an `allof` agree
+   on one effective type, including the rejection of a multi-kind local union
+   combined with `allof`. See
+   [The Effective Definition](#the-effective-definition).
+2. **The effective type of a pure mixin.** A definition whose only applicator is
+   `allof` takes its effective type from its components. See
+   [Composition Supplying the Local Skeleton](#composition-supplying-the-local-skeleton).
+3. **The collection `itemtype` requirement.** A `collection` obtains its
+   mandatory dynamic-entry rule locally or from a compatible `allof` component.
+   See
+   [Collection of Elements for Dynamic Keys](#collection-of-elements-for-dynamic-keys).
+4. **Sibling-rule operands and applicability.** `dependentrequired`,
+   `mutuallyexclusive`, and `exactlyone` resolve their operands against the
+   [determinate fixed-child set](#determinate-fixed-child-set), which includes
+   the children contributed by `allof`, and their `table`-or-`collection`
+   applicability is decided from the effective type. See
+   [Sibling Presence Rules](#sibling-presence-rules).
+5. **`default` validity.** A declared `default` is checked against the full
+   effective definition. See [Default](#default---default).
+6. **Openness, closure, requiredness, and unknown keys.** Whether a table is
+   open or closed, which document keys are unknown, which fixed children are
+   required, and which definitions validate a present child are all decided from
+   the node's [effective closure set](#effective-closure-set). See
+   [Tables](#tables).
+7. **Conjunctive application of contributed assertions.** Every assertion any
+   participant contributes applies to the document value, including an
+   `itemtype` or `keypattern` contributed to a collection. See
+   [Merging by TOML Kind](#merging-by-toml-kind).
+
+Items 1 through 5 are schema-load checks and read only what is determinate at
+schema-load time. Items 6 and 7 are document-validation checks. No other rule in
+this specification reads the composed view, and an implementation MUST NOT
+extend the effective reading to a check that is not listed here.
 
 ### Quoted and Special Keys
 
@@ -898,19 +999,22 @@ The scalar built-in types are:
 #### Allowed Values - `allowedvalues`
 
 `allowedvalues` provides an enumeration for a scalar or unconstrained built-in
-type. On an
-`array`, it instead enumerates the values permitted for each item, as described
+type. On an `array` or a `collection` it is instead a
+[per-member constraint](#per-member-value-constraints) and enumerates the values
+permitted for each item or each dynamic entry, as also described
 under [Observations on Conditions to Arrays](#observations-on-conditions-to-arrays).
-It is invalid on a `table` or `collection`.
+It is invalid on a `table`.
 
 The `allowedvalues` array MUST contain at least one entry. Every entry on a
-non-array definition MUST have the TOML kind selected by that definition;
+definition that is neither an `array` nor a `collection` MUST have the TOML kind
+selected by that definition;
 `type = "any"` is the exception and permits entries of any TOML kind. Numeric
 equality between integers and floats does not make their TOML kinds
 interchangeable for this schema-load check. A malformed enumeration MUST be
 rejected at schema-load time.
 
-For a non-array definition, when `allowedvalues` is combined with `pattern`, `format`,
+For a definition that is neither an `array` nor a `collection`, when
+`allowedvalues` is combined with `pattern`, `format`,
 `min`, `max`, `minlength`, or `maxlength` on the same definition, every entry in
 `allowedvalues` MUST satisfy every applicable constraint. A schema containing an
 entry that violates one of those constraints is malformed, and schema loaders
@@ -922,11 +1026,13 @@ equality; equivalent instants with different retained local fields or offsets
 therefore compare equal for a boundary but remain distinct enumeration values.
 
 After a schema with `allowedvalues` has been loaded successfully, each document
-value governed by that definition — each item value, for an `array` definition —
+value governed by that definition — each item or dynamic-entry value, for an
+`array` or `collection` definition —
 is evaluated in the following order:
 
 1. The value's parsed TOML kind MUST be the kind the definition selects for it,
-   through `type` or, for array items, through `itemtype`. A kind mismatch is a
+   through `type` or, for container members, through `itemtype`. A kind mismatch
+   is a
    validation error regardless of `allowedvalues`, and membership in the
    enumeration never satisfies the type check. For example, a definition with
    `type = "integer"` and `allowedvalues = [ 80, 443 ]` rejects the document
@@ -991,7 +1097,9 @@ The formats use the following portable rules:
   It does not accept a URI host's brackets or a zone identifier. An embedded
   IPv4 suffix follows the `ipv4` rules above.
 
-`format` is valid only on a definition whose selected type is the built-in
+`format` is valid on a definition whose selected type is the built-in
+`string`, and, as a [per-member constraint](#per-member-value-constraints), on a
+non-tuple `array` or `collection` whose effective member type is the built-in
 `string`. It cannot be attached to another built-in type, an alternative
 selector, or a named type reference. A schema loader MUST reject an unsupported
 format name or incompatible use at schema-load time rather than ignoring it.
@@ -1022,14 +1130,16 @@ These properties define inclusive value ranges. They may only be used for:
  - `float`
  - `integer`
  - date and/or time types: `offset-date-time`, `local-date-time`, `local-date`, and `local-time`
- - `array`, when `itemtype` resolves to `integer`, `float`, or one of the temporal types above
+ - `array` or `collection`, when `itemtype` resolves to `integer`, `float`, or one of the temporal types above
 
-For arrays, `min` and `max` apply to each item. `itemtype` MUST resolve to one
+For an `array` or a `collection`, `min` and `max` are
+[per-member constraints](#per-member-value-constraints) and apply to each item
+or each dynamic entry. `itemtype` MUST resolve to one
 comparable built-in kind: `integer`, `float`, `offset-date-time`,
 `local-date-time`, `local-date`, or `local-time`. Named references and aliases
 are resolved before this rule is checked, and all alternatives of a referenced
 `oneof` or `anyof` definition MUST resolve to that same kind.
-Schema loaders MUST reject array range constraints when the item schema can resolve to
+Schema loaders MUST reject container range constraints when the member schema can resolve to
 different kinds or to a non-comparable kind. The interaction between array range
 boundaries and `allowedvalues` is defined under
 [Observations on Conditions to Arrays](#observations-on-conditions-to-arrays).
@@ -1082,6 +1192,12 @@ another built-in type, an alternative selector, or a named type reference.
 Schema loaders MUST reject an incompatible length constraint at schema-load time rather
 than silently ignoring it.
 
+On an `array` or a `collection` these two properties always bound the
+container's own member count. They are deliberately excluded from the
+[per-member value-constraint subset](#per-member-value-constraints), which
+explains why, and a per-member length bound is written on the definition the
+container's `itemtype` reaches.
+
 ### Container Types
 
 - Array: `array`
@@ -1127,7 +1243,9 @@ table value without validating its contents, including its keys. This is useful
 for representing custom data payloads. Openness is a property of the effective
 closure set, so a table is open only when neither the local definition, nor any
 `allof` component, nor the selected alternative or branch contributes a fixed
-child.
+child. Openness and unknown-key rejection are two of the checks that read the
+effective rather than the local view; the complete list is under
+[Local and Effective Checks](#local-and-effective-checks).
 
 An open table is not the same as an empty root `[elements]` table. An open table
 accepts any keys; an empty `[elements]` table accepts no application data at
@@ -1143,8 +1261,15 @@ Arrays can be defined using the following properties:
  - `maxlength`: the maximum length of the array (e.g. no more than 2 elements).
  - `min`: the minimum value allowed for each comparable array item (e.g. 80).
  - `max`: the maximum value allowed for each comparable array item (e.g. 8080).
- - `allowedvalues`: enumeration of possible values.
+ - `allowedvalues`: enumeration of the values permitted for each item.
+ - `pattern`: a regular expression each string item must match.
+ - `format`: a standardized semantic format each string item must satisfy.
  - `uniqueitems`: whether every parsed array item must be unique.
+
+`min`, `max`, `allowedvalues`, `pattern`, and `format` are the
+[per-member value-constraint subset](#per-member-value-constraints); they
+constrain each item rather than the array, and a `collection` accepts the same
+five with the same meaning. `minlength` and `maxlength` bound the array itself.
 
 Example for schema definition:
 
@@ -1167,6 +1292,10 @@ Their applicability rule, including how a named `itemtype` and its alternatives
 are resolved, and the ordering rules used for numeric and temporal items, are
 defined under
 [Minimum Value / Maximum Value](#minimum-value--maximum-value---min-and-max).
+`min`, `max`, `allowedvalues`, `pattern`, and `format` all apply per item here,
+and [Per-Member Value Constraints](#per-member-value-constraints) is
+authoritative for that shared subset and for its equivalence to the same
+constraint written on the `itemtype` definition.
 
 When `allowedvalues` is present on an array, every array item MUST be a member
 of that enumeration. The enumeration does not have to be sorted. If `min` or
@@ -1182,7 +1311,8 @@ schema-load check verifies the permitted TOML kind; constraints inside a named
 item definition still apply normally when a document array is validated.
 
 `minlength` and `maxlength` constrain the document array's item count, not the
-number of entries in `allowedvalues`.
+number of entries in `allowedvalues`, and never the length of an individual
+item; see [Per-Member Value Constraints](#per-member-value-constraints).
 
 If neither `itemtype` nor `items` is defined, array items default to `any`, so
 items of different TOML types may be mixed.
@@ -1282,10 +1412,15 @@ Semantics:
    `maxlength = 0` instead.
  - When `items` is present, the array MUST have exactly the same number of items.
  - `items` is mutually exclusive with `itemtype`.
- - `items` is also mutually exclusive with `min` and `max`.
  - `items` is also mutually exclusive with `minlength` and `maxlength`.
- - `items` is mutually exclusive with `allowedvalues`; constraints for a tuple
-   position belong in the reusable definition referenced at that position.
+ - `items` is mutually exclusive with the whole
+   [per-member value-constraint subset](#per-member-value-constraints):
+   `allowedvalues`, `min`, `max`, `pattern`, and `format`. Constraints for a
+   tuple position belong in the reusable definition referenced at that position.
+   The exclusion is local, as
+   [Local and Effective Checks](#local-and-effective-checks) states, so an
+   `allof` component MAY still contribute one of those constraints
+   conjunctively.
  - `items` MAY name the same type reference more than once. Each entry denotes a
    position rather than an alternative, so a tuple whose positions share a type,
    such as `items = [ "types.coordinate", "types.coordinate" ]`, is valid and
@@ -1320,14 +1455,19 @@ definition, including nested tables, arrays, and named types.
 
 A `collection` requires at least one effective `itemtype` constraint to define
 the type of its dynamic child values. The constraint may be declared locally or
-contributed by a compatible `allof` component. Each dynamic child must be given
+contributed by a compatible `allof` component; this is the collection instance
+of the general principle stated under
+[Composition Supplying the Local Skeleton](#composition-supplying-the-local-skeleton),
+not a rule peculiar to collections. Each dynamic child must be given
 a unique key in the TOML document. `itemtype` may reference a built-in type or a
 named reusable definition. A schema loader MUST reject an effective collection
 when neither its local definition nor any referenced or composed definition
 contributes an `itemtype`. This is a schema-load check, so it reads only the
 contributions that are determinate at schema-load time; which components make
 one is defined under
-[Determinate Fixed-Child Set](#determinate-fixed-child-set).
+[Determinate Fixed-Child Set](#determinate-fixed-child-set). It is one of the
+checks that read the effective rather than the local view, as
+[Local and Effective Checks](#local-and-effective-checks) enumerates.
 
 The built-in `collection` cannot itself be used as `itemtype` or as an entry in
 `items`, `oneof`, `anyof`, or `allof`: those bare references provide no place to declare
@@ -1353,6 +1493,12 @@ This difference in unknown-key semantics is why `table` and `collection` are not
 interchangeable for `allof` composition.
 
 A `collection` may additionally constrain the **keys** (entry names) of its dynamic children with `keypattern`. See [Key Pattern - `keypattern`](#key-pattern---keypattern).
+
+A `collection` may also constrain the **values** of its dynamic entries inline,
+with `allowedvalues`, `min`, `max`, `pattern`, or `format`, instead of pushing
+each such constraint into a named `itemtype` definition. Those five properties
+behave identically on an `array` and on a `collection`; see
+[Per-Member Value Constraints](#per-member-value-constraints).
 
 This precedence is what lets a collection validate known keys precisely while
 applying `itemtype` only to all other keys. For example, `itemtype = "any"`
@@ -1434,6 +1580,107 @@ TOML Schema:
 
 A `collection` may be represented as subtables of a common table in a TOML document.
 
+#### Per-Member Value Constraints
+
+Five value constraints form the **per-member value-constraint subset**:
+`allowedvalues`, `min`, `max`, `pattern`, and `format`. Any of them MAY be
+declared directly on a definition that selects the built-in `type = "array"` or
+the built-in `type = "collection"`. Declared there, a constraint does not
+describe the container. It applies to **each item** of the array and to **each
+dynamically keyed entry** of the collection. The subset is identical for the two
+containers, because an array item and a collection entry are the same thing: one
+member value that the container's `itemtype` governs.
+
+Declaring a per-member constraint inline is exactly equivalent to declaring that
+same constraint on the member definition the container's `itemtype` reaches. The
+two spellings MUST validate identically, and authors MAY choose either. Inline
+is the shorter spelling for a container whose members need one or two
+constraints; a named `itemtype` definition is the reusable one.
+
+```toml
+[elements.ports]
+type = "array"
+itemtype = "integer"
+min = 1
+max = 65535
+
+[elements.hosts]
+type = "collection"
+itemtype = "string"
+format = "hostname"
+keypattern = "^[a-z][a-z0-9-]*$"
+```
+
+On a `collection`, `pattern` constrains each dynamic entry's **value** while
+`keypattern` constrains each dynamic entry's **key**. The two are independent,
+apply to different subjects, and MAY be combined on the same definition.
+
+Because the two spellings are equivalent, declaring the **same** constraint both
+inline and on the resolved `itemtype` definition is a schema-load error, and
+schema loaders MUST reject it with `exclusive-properties`. This specification
+defines no precedence between them and needs none: a schema that would say the
+same thing twice says it once instead. Different constraints MAY be split across
+the two spellings and then apply conjunctively. The check compares the inline
+constraint against the constraint the resolved `itemtype` definition declares
+itself; a constraint that definition acquires from its own `allof` is not part
+of the check and merges conjunctively as
+[Merging by TOML Kind](#merging-by-toml-kind) requires.
+
+A per-member constraint obeys the same applicability rule its own section
+states, applied to the **member** type rather than to the container:
+
+- `pattern` and `format` require the effective member type to be the built-in
+  `string`, as [Pattern](#pattern---pattern) and
+  [String Format](#string-format---format) require of a string constraint.
+- `min` and `max` require the effective member type to resolve to exactly one
+  comparable kind, as
+  [Minimum Value / Maximum Value](#minimum-value--maximum-value---min-and-max)
+  requires.
+- every `allowedvalues` entry MUST have a TOML kind the effective member type
+  permits, as [Allowed Values](#allowed-values---allowedvalues) requires.
+
+The member type is the one the container's `itemtype` selects, resolved through
+named references and through the alternatives of a referenced `oneof` or
+`anyof`, which MUST all resolve to the same kind. When a container declares no
+`itemtype`, its members are unconstrained `any`: `allowedvalues` still applies
+and enumerates values of any TOML kind, while `min`, `max`, `pattern`, and
+`format` have no determinate member kind to apply to. Schema loaders MUST reject
+a per-member constraint whose member type is indeterminate or of the wrong kind
+at schema-load time.
+
+`items` is mutually exclusive with the whole subset. A tuple position is
+described by the reusable definition named at that position, so a constraint
+that would apply uniformly to every member has no meaning beside a positional
+definition.
+
+**`minlength` and `maxlength` are deliberately not in the subset.** On an
+`array` or a `collection` those two spellings are already taken: they constrain
+the **container**, bounding an array's item count and a collection's
+dynamic-entry count, as [Length](#length---minlength-and-maxlength) defines.
+That meaning is unchanged. One spelling cannot mean both "this container holds
+at least two members" and "each member is a string of at least two characters",
+and reinterpreting it per member on a container whose members happen to be
+strings would make the same keyword mean different things in two schemas that
+differ only in their `itemtype`. Per-member string length is therefore expressed
+through `itemtype`:
+
+```toml
+[types.shortName]
+type = "string"
+minlength = 1
+maxlength = 32
+
+[elements.tags]
+type = "array"
+itemtype = "types.shortName"
+minlength = 1
+```
+
+Here `minlength = 1` on `elements.tags` requires at least one tag, while the
+bounds inside `types.shortName` govern each tag's length in characters. This is
+the one exception to the symmetry above, and it exists because the spelling is
+occupied, not because container members are otherwise privileged.
+
 ### Type Reference
 
 A type reference applies a built-in type or inherits the rules of a named reusable type. Both `[types]` definitions and `[elements]` definitions may use type references. The `type` property selects the current node's type; built-in and named references use the same syntax.
@@ -1511,9 +1758,12 @@ pattern = "^[A-Z]+$" # invalid
 ### Conjunctive Composition - `allof`
 
 `allof` applies a non-empty array of type references to the current node in
-addition to its local definition. It is an applicator, not a type selector:
-the local definition must still declare one `type`, `oneof`, `anyof`, or
-conditional selector, or have fixed children that make it an implicit table.
+addition to its local definition. It is an applicator, not a type selector: it
+never chooses between alternatives and never defers a decision to a document
+value. The local definition normally declares its own `type`, `oneof`, `anyof`,
+or conditional selector, or has fixed children that make it an implicit table;
+[Composition Supplying the Local Skeleton](#composition-supplying-the-local-skeleton)
+defines the one case in which the composition supplies that skeleton instead.
 
 ```toml
 [types.packageBase]
@@ -1529,6 +1779,68 @@ allof = [ "types.packageBase" ]
     [types.package.name]
     type = "string"
 ```
+
+#### Composition Supplying the Local Skeleton
+
+One principle governs how much of a definition `allof` may supply:
+**composition MAY supply the local skeleton when it determines that skeleton
+unambiguously.** A definition need not restate a structural fact its components
+already fix beyond doubt, and it MUST state anything they leave open.
+
+A definition whose only applicator is a non-empty `allof` — one that declares no
+`type`, no `oneof`, no `anyof`, no part of the conditional triple, and no nested
+child definitions — is a **pure mixin**. A pure mixin is valid when the
+effective types of its `allof` components resolve to exactly one TOML kind. That
+kind becomes the definition's effective type, exactly as if `type` had named it:
+
+```toml
+[types.packageBase]
+type = "table"
+
+    [types.packageBase.version]
+    type = "string"
+
+[types.named]
+type = "table"
+
+    [types.named.name]
+    type = "string"
+
+[types.package]
+allof = [ "types.packageBase", "types.named" ]
+```
+
+`types.package` has the effective type `table` and the fixed children `version`
+and `name`. Writing `type = "table"` beside that `allof` remains valid and adds
+nothing.
+
+When the components resolve to more than one TOML kind, or when the kind cannot
+be determined at schema-load time, the composition determines no skeleton and
+there is nothing for the definition to inherit. Schema loaders MUST reject such
+a definition at schema-load time with `incompatible-composition`. Authors
+resolve the ambiguity by declaring the intended type with `type`, which turns an
+indeterminate composition into an ordinary compatibility failure against a
+stated kind. Determining a pure mixin's effective type is one of the checks that
+read the effective rather than the local view; see
+[Local and Effective Checks](#local-and-effective-checks).
+
+A pure mixin is still an application and never a selection. Because `allof` is
+not a selector, its components contribute their fixed children to the
+definition's [determinate fixed-child set](#determinate-fixed-child-set), and
+any `itemtype` and `keypattern` they declare are likewise determinate, exactly
+as they are for a definition that also declares `type`. Nothing about a pure
+mixin is deferred to validation time.
+
+The same principle governs the one other place a composition supplies a
+required local element: a `collection` may obtain its mandatory `itemtype` from
+a compatible `allof` component, as
+[Collection of Elements for Dynamic Keys](#collection-of-elements-for-dynamic-keys)
+describes. That allowance is a consequence of this principle rather than a
+special case for collections.
+
+A definition that declares no selector, no nested child definition, and no
+`allof` determines nothing at all, and it remains a schema-load error under
+[Types table](#types-table---types).
 
 #### The Effective Definition
 
@@ -1563,9 +1875,15 @@ table separately against `A` and against `B` would instead make `y` unknown to
 `A` and `x` unknown to `B`, rejecting every document and making mixin
 composition useless. Only the effective-definition reading is conforming.
 
+Composition compatibility is judged from the effective view, which is one of
+the checks [Local and Effective Checks](#local-and-effective-checks) lists as
+effective; every other applicability and exclusivity check remains local.
+
 A composition is well formed only when its participants agree on kind.
 Every component MUST resolve to an effective TOML kind compatible with the
-local definition. When the local selector is `oneof` or `anyof`, all of its
+local definition, or, when the local definition is a pure mixin and states no
+kind of its own, with one another. When the local selector is `oneof` or
+`anyof`, all of its
 alternatives MUST resolve to the same effective kind before `allof` can be
 applied; a multi-kind local union combined with `allof` is indeterminate and
 MUST be rejected at schema-load time. Scalar and array components must have the
@@ -2327,7 +2645,10 @@ the group still requires one choice.
 
 Every name in these three properties MUST identify a direct fixed child in the
 [determinate fixed-child set](#determinate-fixed-child-set) of the definition
-after `allof` composition. Operands are resolved when the schema is loaded, so
+after `allof` composition. Operand resolution and the `table`-or-`collection`
+applicability of these rules are therefore effective rather than local checks,
+as [Local and Effective Checks](#local-and-effective-checks) records. Operands
+are resolved when the schema is loaded, so
 they MUST NOT be resolved against the validation-time
 [effective closure set](#effective-closure-set); only the presence check itself
 happens while a document is validated. A quoted string containing a
@@ -2491,7 +2812,9 @@ Despite being an annotation, a declared default MUST validate as a present
 value against the full effective definition at schema-load time. Default
 validation applies all references, composition, alternatives, fixed children,
 sibling rules, and ordinary constraints, but does not emit a deprecation
-warning. A loader MUST reject an incompatible default.
+warning. A loader MUST reject an incompatible default. This is one of the
+schema-load checks that read the effective rather than the local view, as
+[Local and Effective Checks](#local-and-effective-checks) records.
 
 A default declared directly at a use site takes precedence over one inherited
 through its `type` reference. Without a use-site default, the referenced
@@ -2574,10 +2897,14 @@ no alternative is selected when the slot is absent.
 
 ### Pattern - `pattern`
 
-This property is only valid on a definition whose selected type is the built-in
+This property is valid on a definition whose selected type is the built-in
+`string`, and, as a [per-member constraint](#per-member-value-constraints), on a
+non-tuple `array` or `collection` whose effective member type is the built-in
 `string`. It cannot be attached to another built-in type, an alternative
 selector, or a named type reference. Schema loaders MUST reject an incompatible
-`pattern` at schema-load time rather than silently ignoring it.
+`pattern` at schema-load time rather than silently ignoring it. On a
+`collection`, `pattern` constrains dynamic entry values while
+[`keypattern`](#key-pattern---keypattern) constrains their keys.
 
 The portable TOML Schema regular-expression profile consists of literals,
 escaped metacharacters, the character escapes `\t`, `\n`, `\r`, `\f`, `\v`, and
@@ -2900,9 +3227,16 @@ the steps that depend on it begin:
    recognized property applied to a definition that does not permit it, and reject
    combinations excluded by
    [Schema Definition Properties](#schema-definition-properties). This includes
-   selector exclusivity: exactly one of `type`, `oneof`, `anyof`, and the
-   conditional triple, except for the implicit-table case described under
-   [Types table](#types-table---types).
+   selector exclusivity: at most one of `type`, `oneof`, `anyof`, and the
+   conditional triple, and at least one unless the definition is an implicit
+   table or a [pure mixin](#composition-supplying-the-local-skeleton), both
+   described under [Types table](#types-table---types). It also includes the
+   exclusion between `items` and the
+   [per-member value-constraint subset](#per-member-value-constraints) and the
+   rejection of a per-member constraint that is also declared on the definition
+   its `itemtype` resolves to. Every check in this step is local unless
+   [Local and Effective Checks](#local-and-effective-checks) lists it as
+   effective.
 5. **Reference resolution.** Resolve every type reference in the document, as
    defined under [Reference Resolution](#reference-resolution). Every reference
    MUST resolve, including references inside definitions that are optional or that
@@ -2919,9 +3253,11 @@ the steps that depend on it begin:
    `itemtype` requirement under
    [Collection of Elements for Dynamic Keys](#collection-of-elements-for-dynamic-keys).
 8. **Composition determinacy.** Verify that every `allof` composition agrees on
-   effective type, that no component is named twice, and that no local union or
-   conditional selector combined with `allof` is indeterminate, as required under
-   [Conjunctive Composition](#conjunctive-composition---allof).
+   effective type, that no component is named twice, that no local union or
+   conditional selector combined with `allof` is indeterminate, and that every
+   pure mixin resolves to exactly one TOML kind, as required under
+   [Conjunctive Composition](#conjunctive-composition---allof) and
+   [Composition Supplying the Local Skeleton](#composition-supplying-the-local-skeleton).
 9. **Single-definition consistency.** Apply the remaining schema-load consistency
    checks: `allowedvalues` entry kinds and their agreement with sibling
    constraints, `min` not greater than `max`, `minlength` not greater than
@@ -3211,8 +3547,11 @@ groups before it or governs which diagnostics the groups after it may produce.
 4. **Value assertions.** Evaluate every assertion that applies to `N`'s own value:
    `format`, `pattern`, `minlength`, `maxlength`, `uniqueitems`, and, for a scalar
    or temporal node, `min` and `max`. Every such assertion is evaluated; none gates
-   another, and a failure of one does not suppress another. On an `array`, `min`
-   and `max` are item-level assertions and belong to group 6.
+   another, and a failure of one does not suppress another. On an `array` or a
+   `collection`, `format`, `pattern`, `min`, and `max` are
+   [per-member assertions](#per-member-value-constraints) and belong to group 6,
+   while `minlength` and `maxlength` remain assertions on the container itself
+   and are evaluated here.
 5. **Allowed values.** Evaluate `allowedvalues` membership. Groups 2, 4, and 5 of
    this list are the general-case statement of the ordering that
    [Allowed Values](#allowed-values---allowedvalues) fixes for enumerations, and
@@ -3229,10 +3568,13 @@ groups before it or governs which diagnostics the groups after it may produce.
      `keypattern` and whose value MUST validate against every applicable
      `itemtype`, as required under
      [Collection of Elements for Dynamic Keys](#collection-of-elements-for-dynamic-keys).
+     Every per-member `allowedvalues`, `min`, `max`, `pattern`, and `format`
+     declared on the collection applies to each dynamic entry's value.
      A collection never produces an `unknown-key` error;
    - **array** — with `items`, check arity first and then validate each position;
      with `itemtype`, validate every item; with neither, items are unconstrained.
-     Item-level `min`, `max`, and `allowedvalues` apply to each item.
+     Per-member `allowedvalues`, `min`, `max`, `pattern`, and `format` apply to
+     each item.
 
    Each descent is itself a `validate` call and MUST apply groups 1 through 8 to
    the nested node. Results from descent combine into `N`'s result.
@@ -3730,7 +4072,7 @@ failures against the effective definition use the ordinary validation codes.
 | --- | --- | --- |
 | `unrecognized-property` | error | A key/value pair written directly inside a schema definition is not one of the closed property set for this language version, for example `patttern`. |
 | `inapplicable-property` | error | A recognized property appears on a definition to which this specification does not permit it, for example `pattern` on `integer`, `keypattern` on `table`, `minlength` on `boolean`, or a kind-specific constraint beside a named `type` reference. |
-| `exclusive-properties` | error | Two properties that this specification makes mutually exclusive appear together: the selectors `type`, `oneof`, `anyof`, and `if`; `items` with `itemtype`, `allowedvalues`, `min`, `max`, `minlength`, or `maxlength`; `if.equals` with `if.in`; or an incomplete `if`/`then`/`else` triple. |
+| `exclusive-properties` | error | Two properties that this specification makes mutually exclusive appear together: the selectors `type`, `oneof`, `anyof`, and `if`; `items` with `itemtype`, `minlength`, `maxlength`, or a member of the [per-member value-constraint subset](#per-member-value-constraints); the same per-member value constraint declared both inline on an `array` or `collection` and on the definition its `itemtype` resolves to; `if.equals` with `if.in`; or an incomplete `if`/`then`/`else` triple. |
 | `unresolved-reference` | error | A type reference in `type`, `itemtype`, `items`, `oneof`, `anyof`, `allof`, `then`, or `else` does not name a built-in type or a definition in `[types]`, as defined under [Reference Resolution](#reference-resolution). |
 | `duplicate-reference` | error | Two entries of `oneof`, `anyof`, or `allof` have the same resolved identity after the optional `types.` prefix is stripped, for example `"types.foo"` and `"foo"`. |
 | `inverted-range` | error | `min` is greater than `max`, or `minlength` is greater than `maxlength`, under the ordering this specification defines for that pair. |
@@ -3739,7 +4081,7 @@ failures against the effective definition use the ordinary validation codes.
 | `invalid-pattern` | error | A `pattern` or `keypattern` cannot be compiled under the active profile, as required under [Pattern](#pattern---pattern). |
 | `unsupported-pattern` | error | A `pattern` or `keypattern` uses syntax outside the portable profile without an explicitly enabled extension profile, as required under [Pattern](#pattern---pattern). |
 | `cyclic-reference` | error | The reference graph contains a cycle classified as illegal under [Cycle Legality](#cycle-legality). Structural recursion through a consuming edge is not this code. |
-| `incompatible-composition` | error | `allof` participants do not agree on effective type, a multi-kind local union is combined with `allof`, or a `table` is composed with a `collection`. |
+| `incompatible-composition` | error | `allof` participants do not agree on effective type, a multi-kind local union is combined with `allof`, a `table` is composed with a `collection`, or a [pure mixin](#composition-supplying-the-local-skeleton) has no single determinate effective type. |
 | `invalid-default` | error | A declared `default` does not validate against the full effective definition at schema-load time, or `allof` participants contribute unequal defaults with no local default. |
 | `unsupported-version` | error | `[toml-schema].version` is missing, is not a SemVer string, is not a TOML Schema language version, or is not supported by the implementation. |
 | `schema-malformed` | error | Any other schema-load failure required by this specification: missing `[toml-schema]` or `[elements]`, an empty `oneof`, `anyof`, `allof`, `allowedvalues`, or `items` array, a reserved type name, an invalid `children` escape entry, a non-boolean `deprecated`, and similar. Implementations SHOULD prefer a more specific code from this table when one applies. |
@@ -3752,11 +4094,11 @@ failures against the effective definition use the ordinary validation codes.
 | `unknown-key` | error | A document key of a closed table, including the document root, is not in the node's [effective closure set](#effective-closure-set). Never produced for a `collection` dynamic entry. |
 | `missing-required` | error | A fixed child that is not optional is absent. The instance path is the missing child's path even though no node is there. |
 | `type-mismatch` | error | The node's TOML kind does not match the coarse category of the effective type, including an array or collection entry whose value is not the item definition's kind. |
-| `allowedvalues` | error | The node's parsed value is not a member of `allowedvalues` under [Parsed Value Equality](#parsed-value-equality). |
-| `pattern` | error | A string does not match `pattern`. |
-| `format` | error | A string does not match the required `format`. |
-| `min` | error | A comparable value, or a comparable array item, is less than `min`, or is NaN. The instance path is the value that failed, so an array item is `$.arr[i]`. |
-| `max` | error | A comparable value, or a comparable array item, is greater than `max`, or is NaN. |
+| `allowedvalues` | error | The node's parsed value is not a member of `allowedvalues` under [Parsed Value Equality](#parsed-value-equality). For a [per-member](#per-member-value-constraints) enumeration the instance path is the member that failed, `$.arr[i]` or `$.coll.key`. |
+| `pattern` | error | A string does not match `pattern`. For a [per-member](#per-member-value-constraints) `pattern` the instance path is the member that failed, `$.arr[i]` or `$.coll.key`. |
+| `format` | error | A string does not match the required `format`. For a [per-member](#per-member-value-constraints) `format` the instance path is the member that failed, `$.arr[i]` or `$.coll.key`. |
+| `min` | error | A comparable value, or a comparable array item or collection entry, is less than `min`, or is NaN. The instance path is the value that failed, so an array item is `$.arr[i]` and a collection entry is `$.coll.key`. |
+| `max` | error | A comparable value, or a comparable array item or collection entry, is greater than `max`, or is NaN. |
 | `minlength` | error | A string, array, or collection is shorter than `minlength`. For a collection, length counts dynamic entries only. |
 | `maxlength` | error | A string, array, or collection is longer than `maxlength`. |
 | `uniqueitems` | error | An array with `uniqueitems = true` contains two items equal under [Parsed Value Equality](#parsed-value-equality). The instance path is the later duplicate, `$.arr[i]`. |

--- a/reference-implementations/dotnet/TomlSchema.Tests/Phase3StructureTests.cs
+++ b/reference-implementations/dotnet/TomlSchema.Tests/Phase3StructureTests.cs
@@ -154,4 +154,35 @@ public class Phase3StructureTests : TestBase
         Assert.False(schema.Validate(Write("phase3-inline-invalid.toml", "values = [\"a\"]\n")).IsValid);
         Assert.False(schema.Validate(Write("phase3-inherited-invalid.toml", "values = [\"c\"]\n")).IsValid);
     }
+
+    [Fact]
+    public void RejectsPerMemberAllowedValuesOnContainers()
+    {
+        var cases = new[]
+        {
+            "[elements.value]\ntype = \"array\"\nitemtype = \"integer\"\nallowedvalues = [5, 50]\nmin = 10\n",
+            "[elements.value]\ntype = \"collection\"\nitemtype = \"integer\"\nallowedvalues = [5, 50]\nmin = 10\n",
+            "[elements.value]\ntype = \"array\"\nitemtype = \"integer\"\nallowedvalues = [2, 3]\nmax = 2\n",
+            "[elements.value]\ntype = \"array\"\nitemtype = \"string\"\nallowedvalues = [\"ok@example.com\", \"nope\"]\nformat = \"email\"\n",
+            "[elements.value]\ntype = \"collection\"\nitemtype = \"string\"\nallowedvalues = [\"ok@example.com\", \"nope\"]\nformat = \"email\"\n",
+        };
+        for (var i = 0; i < cases.Length; i++)
+        {
+            var path = Write($"phase3-invalid-container-{i}.tosd",
+                "[toml-schema]\nversion = \"1.0.0\"\n" + cases[i]);
+            Assert.ThrowsAny<Exception>(() => global::TomlSchema.TomlSchema.Load(path));
+        }
+
+        var schema = global::TomlSchema.TomlSchema.Load(Write("phase3-container-length.tosd", """
+            [toml-schema]
+            version = "1.0.0"
+            [elements.value]
+            type = "array"
+            itemtype = "string"
+            allowedvalues = ["aaaa", "bbbbb"]
+            maxlength = 2
+            """));
+        Assert.True(schema.Validate(Write("phase3-container-length.toml", "value = [\"aaaa\"]\n")).IsValid);
+    }
 }
+

--- a/reference-implementations/dotnet/TomlSchema.Tests/Phase3StructureTests.cs
+++ b/reference-implementations/dotnet/TomlSchema.Tests/Phase3StructureTests.cs
@@ -1,0 +1,157 @@
+namespace TomlSchema.Tests;
+
+using Xunit;
+
+public class Phase3StructureTests : TestBase
+{
+    [Fact]
+    public void LoadsPureAllOfMixin()
+    {
+        var schema = global::TomlSchema.TomlSchema.Load(Write("phase3-pure-allof.tosd", """
+            [toml-schema]
+            version = "1.0.0"
+            [types.named]
+            type = "table"
+            [types.named.name]
+            type = "string"
+            [types.packageBase]
+            type = "table"
+            [types.packageBase.version]
+            type = "string"
+            [types.package]
+            allof = ["types.packageBase", "types.named"]
+            dependentrequired = { name = ["version"] }
+            [types.positive]
+            type = "integer"
+            min = 1
+            [types.small]
+            type = "integer"
+            max = 10
+            [types.count]
+            allof = ["types.positive", "types.small"]
+            [elements.pkg]
+            type = "types.package"
+            [elements.count]
+            type = "types.count"
+            """));
+        Assert.True(schema.Validate(Write("phase3-pure-allof.toml",
+            "pkg = { name = \"x\", version = \"1\" }\ncount = 5\n")).IsValid);
+        Assert.False(schema.Validate(Write("phase3-pure-allof-invalid.toml",
+            "pkg = { name = \"x\", version = \"1\" }\ncount = 0\n")).IsValid);
+    }
+
+    [Fact]
+    public void RejectsMixedKindPureAllOfAtLoad()
+    {
+        var path = Write("phase3-mixed-allof.tosd", """
+            [toml-schema]
+            version = "1.0.0"
+            [types.aTable]
+            type = "table"
+            [types.aTable.x]
+            type = "string"
+            [types.anArray]
+            type = "array"
+            itemtype = "string"
+            [types.bad]
+            allof = ["types.aTable", "types.anArray"]
+            [elements.value]
+            type = "types.bad"
+            """);
+        Assert.ThrowsAny<Exception>(() => global::TomlSchema.TomlSchema.Load(path));
+    }
+
+    [Fact]
+    public void ValidatesInlineArrayPattern()
+    {
+        var schema = global::TomlSchema.TomlSchema.Load(Write("phase3-array-pattern.tosd", """
+            [toml-schema]
+            version = "1.0.0"
+            [elements.tags]
+            type = "array"
+            itemtype = "string"
+            pattern = '^[a-z]+$'
+            """));
+        Assert.True(schema.Validate(Write("phase3-array-pattern-valid.toml",
+            "tags = [\"alpha\", \"beta\"]\n")).IsValid);
+        Assert.False(schema.Validate(Write("phase3-array-pattern-invalid.toml",
+            "tags = [\"alpha\", \"Beta\"]\n")).IsValid);
+    }
+
+    [Fact]
+    public void ValidatesInlineCollectionMemberConstraints()
+    {
+        var schema = global::TomlSchema.TomlSchema.Load(Write("phase3-collection-constraints.tosd", """
+            [toml-schema]
+            version = "1.0.0"
+            [elements.ports]
+            type = "collection"
+            itemtype = "integer"
+            min = 1
+            max = 65535
+            [elements.roles]
+            type = "collection"
+            itemtype = "string"
+            allowedvalues = ["admin", "reader"]
+            [elements.tags]
+            type = "collection"
+            itemtype = "string"
+            pattern = '^[a-z]+@example\.com$'
+            [elements.emails]
+            type = "collection"
+            itemtype = "string"
+            format = "email"
+            """));
+        Assert.True(schema.Validate(Write("phase3-collection-valid.toml",
+            "[ports]\nhttp = 80\n[roles]\nowner = \"admin\"\n[tags]\nrelease = \"stable@example.com\"\n[emails]\nowner = \"admin@example.com\"\n")).IsValid);
+        Assert.False(schema.Validate(Write("phase3-collection-min-invalid.toml",
+            "[ports]\nhttp = 0\n[roles]\nowner = \"admin\"\n[tags]\nrelease = \"stable@example.com\"\n[emails]\nowner = \"admin@example.com\"\n")).IsValid);
+        Assert.False(schema.Validate(Write("phase3-collection-max-invalid.toml",
+            "[ports]\nhttp = 70000\n[roles]\nowner = \"admin\"\n[tags]\nrelease = \"stable@example.com\"\n[emails]\nowner = \"admin@example.com\"\n")).IsValid);
+        Assert.False(schema.Validate(Write("phase3-collection-allowed-invalid.toml",
+            "[ports]\nhttp = 80\n[roles]\nowner = \"root\"\n[tags]\nrelease = \"stable@example.com\"\n[emails]\nowner = \"admin@example.com\"\n")).IsValid);
+        Assert.False(schema.Validate(Write("phase3-collection-pattern-invalid.toml",
+            "[ports]\nhttp = 80\n[roles]\nowner = \"admin\"\n[tags]\nrelease = \"Stable\"\n[emails]\nowner = \"admin@example.com\"\n")).IsValid);
+        Assert.False(schema.Validate(Write("phase3-collection-format-invalid.toml",
+            "[ports]\nhttp = 80\n[roles]\nowner = \"admin\"\n[tags]\nrelease = \"stable@example.com\"\n[emails]\nowner = \"not-an-email\"\n")).IsValid);
+    }
+
+    [Fact]
+    public void RejectsDuplicateInlineAndItemTypeConstraintAtLoad()
+    {
+        var path = Write("phase3-duplicate-constraint.tosd", """
+            [toml-schema]
+            version = "1.0.0"
+            [types.item]
+            type = "integer"
+            min = 0
+            [elements.values]
+            type = "array"
+            itemtype = "types.item"
+            min = -10
+            """);
+        Assert.ThrowsAny<Exception>(() => global::TomlSchema.TomlSchema.Load(path));
+    }
+
+    [Fact]
+    public void AllowsInlineConstraintMatchingItemTypeAllOfConstraint()
+    {
+        var schema = global::TomlSchema.TomlSchema.Load(Write("phase3-inherited-constraint.tosd", """
+            [toml-schema]
+            version = "1.0.0"
+            [types.mixin]
+            type = "string"
+            allowedvalues = ["a", "b"]
+            [types.item]
+            type = "string"
+            allof = ["types.mixin"]
+            [elements.values]
+            type = "array"
+            itemtype = "types.item"
+            allowedvalues = ["b", "c"]
+            """));
+        Assert.True(schema.Validate(Write("phase3-intersection-valid.toml", "values = [\"b\"]\n")).IsValid);
+        Assert.False(schema.Validate(Write("phase3-inline-invalid.toml", "values = [\"a\"]\n")).IsValid);
+        Assert.False(schema.Validate(Write("phase3-inherited-invalid.toml", "values = [\"c\"]\n")).IsValid);
+    }
+}

--- a/reference-implementations/dotnet/TomlSchema/SchemaLoader.cs
+++ b/reference-implementations/dotnet/TomlSchema/SchemaLoader.cs
@@ -124,6 +124,10 @@ public class SchemaLoader
         }
 
         ValidateRangeSemantics(types, elements);
+        ValidateDefinitionKinds(types, types);
+        ValidateDefinitionKinds(types, elements);
+        ValidateMemberConstraintSemantics(types, types);
+        ValidateMemberConstraintSemantics(types, elements);
         ValidateSiblingRuleSemantics(types, elements);
         ValidateConditionalSemantics(types, elements);
         return new TomlSchema(version, types, elements);
@@ -158,7 +162,8 @@ public class SchemaLoader
         var format = GetString(table, "format");
         if (format != null)
         {
-            if (type != SchemaType.String || reference != null)
+            if (type is not (SchemaType.String or SchemaType.Array or SchemaType.Collection)
+                || reference != null)
                 throw new InvalidOperationException($"{location} format is valid only with a locally selected built-in string type");
             if (!StringFormatValidator.IsSupported(format))
                 throw new InvalidOperationException($"{location} contains unknown string format: {format}");
@@ -269,12 +274,12 @@ public class SchemaLoader
                             $"{location}.allowedvalues contains a value that does not satisfy format {format}");
                 }
             }
-            if (table.ContainsKey("default")
+            if (type == SchemaType.String && table.ContainsKey("default")
                 && (defaultValue is not string defaultText
                     || !StringFormatValidator.IsValid(format, defaultText)))
                 throw new InvalidOperationException(
                     $"{location}.default does not satisfy format {format}");
-            if (defaultValue is string formattedDefault
+            if (type == SchemaType.String && defaultValue is string formattedDefault
                 && allowedValues != null
                 && !allowedValues.OfType<string>().Contains(formattedDefault, StringComparer.Ordinal))
                 throw new InvalidOperationException(
@@ -295,6 +300,14 @@ public class SchemaLoader
         if (minLength.HasValue && maxLength.HasValue && minLength > maxLength)
             throw new InvalidOperationException(
                 $"{location} minlength must not be greater than maxlength");
+        if (children.Count == 0 && type == null && reference == null
+            && !hasOneOf && !hasAnyOf && !hasConditional && (allOf?.Count ?? 0) == 0)
+            throw new InvalidOperationException(
+                $"{location} must define type, oneof, anyof, if/then/else, or child definitions");
+        if ((table.TryGetValue("items", out var tupleItems) && tupleItems is TomlArray)
+            && (allowedValues != null || min != null || max != null || pattern != null || format != null))
+            throw new InvalidOperationException(
+                $"{location} cannot combine items with per-member constraints");
 
         return new SchemaDefinition
         {
@@ -575,7 +588,7 @@ public class SchemaLoader
     {
         if (definition.Min != null || definition.Max != null)
         {
-            var comparableKind = definition.Type == SchemaType.Array
+            var comparableKind = definition.Type is SchemaType.Array or SchemaType.Collection
                 ? ResolveItemKind(definition.ItemType, types)
                 : definition.Type;
             if (comparableKind is not (SchemaType.Integer or SchemaType.Float
@@ -734,7 +747,23 @@ public class SchemaLoader
                     ? null
                     : [definition.Condition.ThenType!, definition.Condition.ElseType!];
         if (references == null)
-            return null;
+        {
+            if ((definition.AllOf?.Count ?? 0) == 0)
+                return null;
+            var componentKinds = definition.AllOf!.Select(reference =>
+            {
+                if (SchemaTypeExtensions.AllTypeNames.Contains(reference))
+                    return SchemaTypeExtensions.FromSchemaName(reference);
+                var normalized = NormalizeReference(reference);
+                return types.TryGetValue(normalized, out var target)
+                    ? EffectiveKind(target, types, new HashSet<string>(visiting))
+                    : throw new InvalidOperationException($"unknown type reference: {reference}");
+            }).Distinct().ToList();
+            if (componentKinds.Count != 1 || componentKinds[0] is null or SchemaType.Any)
+                throw new InvalidOperationException(
+                    $"{definition.Name} allof components must resolve to one determinate effective kind");
+            return componentKinds[0];
+        }
         var kinds = references.Select(reference =>
         {
             if (SchemaTypeExtensions.AllTypeNames.Contains(reference))
@@ -745,6 +774,110 @@ public class SchemaLoader
                 : throw new InvalidOperationException($"unknown type reference: {reference}");
         }).Distinct().ToList();
         return kinds.Count == 1 ? kinds[0] : null;
+    }
+
+    private static void ValidateDefinitionKinds(
+        IReadOnlyDictionary<string, SchemaDefinition> types,
+        IReadOnlyDictionary<string, SchemaDefinition> definitions)
+    {
+        foreach (var definition in definitions.Values)
+        {
+            if ((definition.AllOf?.Count ?? 0) > 0)
+            {
+                var kind = EffectiveKind(definition, types, new HashSet<string>());
+                foreach (var reference in definition.AllOf!)
+                {
+                    var component = SchemaTypeExtensions.AllTypeNames.Contains(reference)
+                        ? SchemaTypeExtensions.FromSchemaName(reference)
+                        : types.TryGetValue(NormalizeReference(reference), out var target)
+                            ? EffectiveKind(target, types, new HashSet<string>())
+                            : throw new InvalidOperationException($"unknown type reference: {reference}");
+                    if (kind == null || component == null || component == SchemaType.Any || component != kind)
+                        throw new InvalidOperationException(
+                            $"{definition.Name} allof components must resolve to one determinate effective kind");
+                }
+            }
+            ValidateDefinitionKinds(types, definition.Children);
+        }
+    }
+
+    private static void ValidateMemberConstraintSemantics(
+        IReadOnlyDictionary<string, SchemaDefinition> types,
+        IReadOnlyDictionary<string, SchemaDefinition> definitions)
+    {
+        foreach (var definition in definitions.Values)
+        {
+            if (definition.Type is SchemaType.Array or SchemaType.Collection)
+            {
+                if (definition.Pattern != null || definition.Format != null)
+                {
+                    if (ResolveItemKind(definition.ItemType, types) != SchemaType.String)
+                        throw new InvalidOperationException(
+                            $"{definition.Name} can only define pattern or format when itemtype resolves to string");
+                }
+                foreach (var (property, present) in new[]
+                {
+                    ("allowedvalues", definition.AllowedValues?.Count > 0),
+                    ("min", definition.Min != null),
+                    ("max", definition.Max != null),
+                    ("pattern", definition.Pattern != null),
+                    ("format", definition.Format != null)
+                })
+                {
+                    if (present && definition.ItemType != null
+                        && ReferenceHasConstraint(
+                            definition.ItemType, property, types, new HashSet<string>()))
+                        throw new InvalidOperationException(
+                            $"{definition.Name} defines {property} both inline and on its resolved itemtype");
+                }
+            }
+            ValidateMemberConstraintSemantics(types, definition.Children);
+        }
+    }
+
+    private static bool ReferenceHasConstraint(
+        string reference,
+        string property,
+        IReadOnlyDictionary<string, SchemaDefinition> types,
+        HashSet<string> visiting)
+    {
+        if (SchemaTypeExtensions.AllTypeNames.Contains(reference))
+            return false;
+        var normalized = NormalizeReference(reference);
+        if (!visiting.Add(normalized))
+            throw new InvalidOperationException($"cyclic type reference: {normalized}");
+        try
+        {
+            var definition = types.TryGetValue(normalized, out var target)
+                ? target
+                : throw new InvalidOperationException($"unknown type reference: {reference}");
+            var local = property switch
+            {
+                "allowedvalues" => definition.AllowedValues?.Count > 0,
+                "min" => definition.Min != null,
+                "max" => definition.Max != null,
+                "pattern" => definition.Pattern != null,
+                "format" => definition.Format != null,
+                _ => false
+            };
+            if (local)
+                return true;
+            var references = new List<string>();
+            if (definition.Reference != null) references.Add(definition.Reference);
+            references.AddRange(definition.OneOf ?? []);
+            references.AddRange(definition.AnyOf ?? []);
+            if (definition.Condition != null)
+            {
+                references.Add(definition.Condition.ThenType!);
+                references.Add(definition.Condition.ElseType!);
+            }
+            return references.Any(nested =>
+                ReferenceHasConstraint(nested, property, types, visiting));
+        }
+        finally
+        {
+            visiting.Remove(normalized);
+        }
     }
 
     private static string NormalizeReference(string reference) =>

--- a/reference-implementations/dotnet/TomlSchema/SchemaLoader.cs
+++ b/reference-implementations/dotnet/TomlSchema/SchemaLoader.cs
@@ -265,15 +265,6 @@ public class SchemaLoader
 
         if (format != null)
         {
-            if (allowedValues != null)
-            {
-                foreach (var allowedValue in allowedValues)
-                {
-                    if (allowedValue is not string text || !StringFormatValidator.IsValid(format, text))
-                        throw new InvalidOperationException(
-                            $"{location}.allowedvalues contains a value that does not satisfy format {format}");
-                }
-            }
             if (type == SchemaType.String && table.ContainsKey("default")
                 && (defaultValue is not string defaultText
                     || !StringFormatValidator.IsValid(format, defaultText)))
@@ -300,6 +291,8 @@ public class SchemaLoader
         if (minLength.HasValue && maxLength.HasValue && minLength > maxLength)
             throw new InvalidOperationException(
                 $"{location} minlength must not be greater than maxlength");
+        ValidateAllowedValuesConstraints(
+            location, type, allowedValues, pattern, format, min, max, minLength, maxLength);
         if (children.Count == 0 && type == null && reference == null
             && !hasOneOf && !hasAnyOf && !hasConditional && (allOf?.Count ?? 0) == 0)
             throw new InvalidOperationException(
@@ -619,6 +612,49 @@ public class SchemaLoader
         return types.TryGetValue(normalized, out var target)
             ? EffectiveKind(target, types, new HashSet<string>())
             : null;
+    }
+
+    private static void ValidateAllowedValuesConstraints(
+        string location,
+        SchemaType? type,
+        List<object?>? allowedValues,
+        string? pattern,
+        string? format,
+        object? min,
+        object? max,
+        long? minLength,
+        long? maxLength)
+    {
+        if (allowedValues == null || allowedValues.Count == 0)
+            return;
+        var isContainer = type is SchemaType.Array or SchemaType.Collection;
+        for (var index = 0; index < allowedValues.Count; index++)
+        {
+            var allowed = allowedValues[index];
+            var entry = $"{location} allowedvalues[{index}]";
+            if (pattern != null
+                && (allowed is not string patternText || !Regex.IsMatch(patternText, pattern)))
+                throw new InvalidOperationException($"{entry} does not satisfy pattern");
+            if (format != null
+                && (allowed is not string formatText || !StringFormatValidator.IsValid(format, formatText)))
+                throw new InvalidOperationException($"{entry} does not satisfy format {format}");
+            if ((min != null || max != null) && allowed is double nan && double.IsNaN(nan))
+                throw new InvalidOperationException($"{entry} does not satisfy min or max");
+            if (min != null && allowed != null && ValueSemantics.Compare(allowed, min) < 0)
+                throw new InvalidOperationException($"{entry} is less than min");
+            if (max != null && allowed != null && ValueSemantics.Compare(allowed, max) > 0)
+                throw new InvalidOperationException($"{entry} is greater than max");
+            if (!isContainer && (minLength.HasValue || maxLength.HasValue))
+            {
+                if (allowed is not string lengthText)
+                    throw new InvalidOperationException($"{entry} does not satisfy string length constraints");
+                var length = lengthText.EnumerateRunes().Count();
+                if (minLength.HasValue && length < minLength)
+                    throw new InvalidOperationException($"{entry} is shorter than minlength");
+                if (maxLength.HasValue && length > maxLength)
+                    throw new InvalidOperationException($"{entry} is longer than maxlength");
+            }
+        }
     }
 
     private static void ValidateBoundary(

--- a/reference-implementations/dotnet/TomlSchema/SchemaValidator.cs
+++ b/reference-implementations/dotnet/TomlSchema/SchemaValidator.cs
@@ -181,7 +181,8 @@ internal class SchemaValidator
         }
 
         // Allowed values
-        if (effectiveSchema.AllowedValues != null && effectiveSchema.AllowedValues.Count > 0)
+        if (effectiveSchema.Type is not (SchemaType.Array or SchemaType.Collection)
+            && effectiveSchema.AllowedValues != null && effectiveSchema.AllowedValues.Count > 0)
         {
             if (!effectiveSchema.AllowedValues.Any(av => ValueEquals(av, value)))
                 _errors.Add(new ValidationError(path, "value not in allowed values", "invalid-value"));
@@ -434,15 +435,13 @@ internal class SchemaValidator
             for (int i = 0; i < array.Count; i++)
             {
                 ValidateType(array[i], itemSchema, $"{path}[{i}]");
-                if (schema.Min != null
-                    && ValueSemantics.AreComparable(array[i]!, schema.Min)
-                    && ValueSemantics.Compare(array[i]!, schema.Min) < 0)
-                    _errors.Add(new ValidationError($"{path}[{i}]", "value below minimum", "min"));
-                if (schema.Max != null
-                    && ValueSemantics.AreComparable(array[i]!, schema.Max)
-                    && ValueSemantics.Compare(array[i]!, schema.Max) > 0)
-                    _errors.Add(new ValidationError($"{path}[{i}]", "value above maximum", "max"));
+                ValidateMemberValueConstraints(array[i], schema, $"{path}[{i}]");
             }
+        }
+        else
+        {
+            for (int i = 0; i < array.Count; i++)
+                ValidateMemberValueConstraints(array[i], schema, $"{path}[{i}]");
         }
     }
 
@@ -488,6 +487,30 @@ internal class SchemaValidator
             // Validate value type
             if (valueSchema != null)
                 ValidateType(value, valueSchema, keyPath);
+            ValidateMemberValueConstraints(value, schema, keyPath);
+        }
+    }
+
+    private void ValidateMemberValueConstraints(object? value, SchemaDefinition schema, string path)
+    {
+        if (schema.AllowedValues?.Count > 0
+            && !schema.AllowedValues.Any(allowed => ValueEquals(allowed, value)))
+            _errors.Add(new ValidationError(path, "value not in allowed values", "invalid-value"));
+        if ((schema.AllowedValues?.Count ?? 0) == 0 && value != null)
+        {
+            if (schema.Min != null && ValueSemantics.AreComparable(value, schema.Min)
+                && ValueSemantics.Compare(value, schema.Min) < 0)
+                _errors.Add(new ValidationError(path, "value below minimum", "min"));
+            if (schema.Max != null && ValueSemantics.AreComparable(value, schema.Max)
+                && ValueSemantics.Compare(value, schema.Max) > 0)
+                _errors.Add(new ValidationError(path, "value above maximum", "max"));
+        }
+        if (value is string text)
+        {
+            if (schema.Pattern != null && !Regex.IsMatch(text, schema.Pattern))
+                _errors.Add(new ValidationError(path, "string does not match pattern", "pattern-mismatch"));
+            if (schema.Format != null && !StringFormatValidator.IsValid(schema.Format, text))
+                _errors.Add(new ValidationError(path, $"string is not a valid {schema.Format}", "format"));
         }
     }
 

--- a/reference-implementations/go/schema.go
+++ b/reference-implementations/go/schema.go
@@ -1643,9 +1643,10 @@ func validateAllowedValuesConstraints(
 	min, max any,
 	minLength, maxLength *int,
 ) error {
-	if len(allowedValues) == 0 || typeName == TypeArray || typeName == TypeCollection {
+	if len(allowedValues) == 0 {
 		return nil
 	}
+	isContainer := typeName == TypeArray || typeName == TypeCollection
 	for index, allowed := range allowedValues {
 		entry := fmt.Sprintf("%s allowedvalues[%d]", name, index)
 		if pattern != nil {
@@ -1681,7 +1682,7 @@ func validateAllowedValuesConstraints(
 				return fmt.Errorf("%s is greater than max", entry)
 			}
 		}
-		if minLength != nil || maxLength != nil {
+		if !isContainer && (minLength != nil || maxLength != nil) {
 			stringValue, ok := allowed.(string)
 			if !ok {
 				return fmt.Errorf("%s does not satisfy string length constraints", entry)

--- a/reference-implementations/go/schema.go
+++ b/reference-implementations/go/schema.go
@@ -226,7 +226,7 @@ func LoadSchema(path string) (*Schema, error) {
 	if err := schema.validateSemantics(); err != nil {
 		return nil, err
 	}
-	if err := schema.validateArrayRanges(); err != nil {
+	if err := schema.validateMemberConstraints(); err != nil {
 		return nil, err
 	}
 	if err := schema.validateDefaults(); err != nil {
@@ -428,9 +428,6 @@ func (s *Schema) effectiveKind(definition Definition, visiting map[string]bool) 
 	if len(definition.allOf) == 0 {
 		return kind, resolved, nil
 	}
-	if !resolved || kind == TypeAny {
-		return "", false, fmt.Errorf("allof requires a determinate effective kind")
-	}
 	for _, reference := range definition.allOf {
 		component, err := s.definitionForReference(reference)
 		if err != nil {
@@ -440,8 +437,14 @@ func (s *Schema) effectiveKind(definition Definition, visiting map[string]bool) 
 		if err != nil {
 			return "", false, err
 		}
-		if !ok || componentKind == TypeAny || componentKind != kind {
+		if !ok || componentKind == TypeAny {
+			return "", false, fmt.Errorf("allof component %s has indeterminate effective kind", reference)
+		}
+		if resolved && componentKind != kind {
 			return "", false, fmt.Errorf("allof component %s has incompatible effective kind", reference)
+		}
+		if !resolved {
+			kind, resolved = componentKind, true
 		}
 	}
 	return kind, true, nil
@@ -1035,9 +1038,12 @@ func parseDefinition(name string, path []string, table map[string]any, source *s
 	}
 	if typeName == "" && reference == "" && !hasOneOf && !hasAnyOf && condition == nil {
 		if len(children) == 0 {
-			return Definition{}, fmt.Errorf("%s must define type, oneof, anyof, or child definitions", name)
+			if len(allOf) == 0 {
+				return Definition{}, fmt.Errorf("%s must define type, oneof, anyof, or child definitions", name)
+			}
+		} else {
+			typeName = TypeTable
 		}
-		typeName = TypeTable
 	}
 	if len(children) > 0 && typeName != TypeTable && typeName != TypeCollection {
 		return Definition{}, fmt.Errorf("%s can only define children when type is table or collection", name)
@@ -1061,6 +1067,9 @@ func parseDefinition(name string, path []string, table map[string]any, source *s
 		if propertyValue(table, "min") != nil || propertyValue(table, "max") != nil {
 			return Definition{}, fmt.Errorf("%s cannot define min or max together with items", name)
 		}
+		if pattern != nil || format != "" {
+			return Definition{}, fmt.Errorf("%s cannot define pattern or format together with items", name)
+		}
 	}
 	min := propertyValue(table, "min")
 	max := propertyValue(table, "max")
@@ -1070,13 +1079,13 @@ func parseDefinition(name string, path []string, table map[string]any, source *s
 	if keyPattern != nil && typeName != TypeCollection {
 		return Definition{}, fmt.Errorf("%s can only define keypattern when type is collection", name)
 	}
-	if pattern != nil && typeName != TypeString {
+	if pattern != nil && typeName != TypeString && typeName != TypeArray && typeName != TypeCollection {
 		return Definition{}, fmt.Errorf("%s can only define pattern when type is string", name)
 	}
-	if format != "" && typeName != TypeString {
+	if format != "" && typeName != TypeString && typeName != TypeArray && typeName != TypeCollection {
 		return Definition{}, fmt.Errorf("%s can only define format when type is string", name)
 	}
-	if hasAllowedValues && (typeName == TypeTable || typeName == TypeCollection) {
+	if hasAllowedValues && typeName == TypeTable {
 		return Definition{}, fmt.Errorf("%s can only define allowedvalues for scalar, unconstrained, or array types", name)
 	}
 	if (minLength != nil || maxLength != nil) &&
@@ -1264,7 +1273,7 @@ func validateRangeConstraints(name string, typeName SchemaType, min, max any) er
 	if typeName == TypeAny {
 		return fmt.Errorf("%s cannot define min or max when type is any", name)
 	}
-	if typeName == TypeArray {
+	if typeName == TypeArray || typeName == TypeCollection {
 		return nil
 	}
 	if typeName != "" && !isRangeComparable(typeName) {
@@ -1304,24 +1313,42 @@ func validateOrderedRange(name string, min, max any, comparableKind SchemaType) 
 	return nil
 }
 
-func (s *Schema) validateArrayRanges() error {
+func (s *Schema) validateMemberConstraints() error {
 	var validateDefinition func(Definition) error
 	validateDefinition = func(definition Definition) error {
-		if definition.typeName == TypeArray && (definition.min != nil || definition.max != nil) {
-			itemType, ok, err := s.resolveItemKind(definition.itemReference, map[string]bool{})
-			if err != nil {
-				return fmt.Errorf("%s has invalid itemtype: %w", definition.name, err)
+		if definition.typeName == TypeArray || definition.typeName == TypeCollection {
+			hasRange := definition.min != nil || definition.max != nil
+			hasStringConstraint := definition.pattern != nil || definition.format != ""
+			if hasRange || hasStringConstraint {
+				itemType, ok, err := s.resolveItemKind(definition.itemReference, map[string]bool{})
+				if err != nil {
+					return fmt.Errorf("%s has invalid itemtype: %w", definition.name, err)
+				}
+				if !ok {
+					if hasRange {
+						return fmt.Errorf("%s can only define min or max when itemtype resolves to one comparable built-in type", definition.name)
+					}
+					return fmt.Errorf("%s per-member constraints require a determinate itemtype", definition.name)
+				}
+				if hasStringConstraint && itemType != TypeString {
+					return fmt.Errorf("%s can only define pattern or format when itemtype resolves to string", definition.name)
+				}
+				if hasRange && !isRangeComparable(itemType) {
+					return fmt.Errorf("%s can only define min or max when itemtype resolves to one comparable built-in type", definition.name)
+				}
+				if hasRange {
+					if err := validateBoundaryMatchesType(definition.name, "min", definition.min, itemType); err != nil {
+						return err
+					}
+					if err := validateBoundaryMatchesType(definition.name, "max", definition.max, itemType); err != nil {
+						return err
+					}
+					if err := validateOrderedRange(definition.name, definition.min, definition.max, itemType); err != nil {
+						return err
+					}
+				}
 			}
-			if !ok || !isRangeComparable(itemType) {
-				return fmt.Errorf("%s can only define min or max when itemtype resolves to one comparable built-in type", definition.name)
-			}
-			if err := validateBoundaryMatchesType(definition.name, "min", definition.min, itemType); err != nil {
-				return err
-			}
-			if err := validateBoundaryMatchesType(definition.name, "max", definition.max, itemType); err != nil {
-				return err
-			}
-			if err := validateOrderedRange(definition.name, definition.min, definition.max, itemType); err != nil {
+			if err := s.validateDuplicateMemberConstraints(definition); err != nil {
 				return err
 			}
 		}
@@ -1342,12 +1369,80 @@ func (s *Schema) validateArrayRanges() error {
 	return nil
 }
 
+func (s *Schema) validateDuplicateMemberConstraints(definition Definition) error {
+	if definition.itemReference == "" {
+		return nil
+	}
+	constraints := map[string]bool{
+		"allowedvalues": len(definition.allowedValues) > 0,
+		"min":           definition.min != nil, "max": definition.max != nil,
+		"pattern": definition.pattern != nil, "format": definition.format != "",
+	}
+	for property, present := range constraints {
+		if present {
+			found, err := s.referenceHasConstraint(
+				definition.itemReference, property, map[string]bool{})
+			if err != nil {
+				return err
+			}
+			if found {
+				return fmt.Errorf("%s defines %s both inline and on its resolved itemtype", definition.name, property)
+			}
+		}
+	}
+	return nil
+}
+
+func (s *Schema) referenceHasConstraint(
+	reference string,
+	property string,
+	seen map[string]bool,
+) (bool, error) {
+	if _, builtin := parseSchemaType(reference); builtin {
+		return false, nil
+	}
+	if seen[reference] {
+		return false, fmt.Errorf("cyclic type reference: %s", reference)
+	}
+	definition, ok := s.types[reference]
+	if !ok {
+		return false, fmt.Errorf("unknown type reference: %s", reference)
+	}
+	seen[reference] = true
+	defer delete(seen, reference)
+	local := map[string]bool{
+		"allowedvalues": len(definition.allowedValues) > 0,
+		"min":           definition.min != nil,
+		"max":           definition.max != nil,
+		"pattern":       definition.pattern != nil,
+		"format":        definition.format != "",
+	}[property]
+	if local {
+		return true, nil
+	}
+	references := append([]string{}, definition.oneOf...)
+	references = append(references, definition.anyOf...)
+	if definition.reference != "" {
+		references = append(references, definition.reference)
+	}
+	if definition.condition != nil {
+		references = append(references, definition.thenReference, definition.elseReference)
+	}
+	for _, nested := range references {
+		found, err := s.referenceHasConstraint(nested, property, seen)
+		if err != nil || found {
+			return found, err
+		}
+	}
+	return false, nil
+}
+
 func (s *Schema) validateAllowedValueTypes() error {
 	var validateDefinition func(Definition) error
 	validateDefinition = func(definition Definition) error {
 		permittedTypes := map[SchemaType]bool{}
 		if len(definition.allowedValues) > 0 {
-			if definition.typeName == TypeArray {
+			if definition.typeName == TypeArray || definition.typeName == TypeCollection {
 				if definition.itemReference != "" {
 					if err := s.collectReferenceTypes(
 						definition.itemReference,
@@ -1548,7 +1643,7 @@ func validateAllowedValuesConstraints(
 	min, max any,
 	minLength, maxLength *int,
 ) error {
-	if len(allowedValues) == 0 || typeName == TypeArray {
+	if len(allowedValues) == 0 || typeName == TypeArray || typeName == TypeCollection {
 		return nil
 	}
 	for index, allowed := range allowedValues {
@@ -1829,6 +1924,10 @@ func (v *validator) validateComposedStructure(
 	definition Definition,
 	inheritedKeys map[string]bool,
 ) {
+	if definition.typeName == "" && definition.reference == "" &&
+		len(definition.oneOf) == 0 && len(definition.anyOf) == 0 && definition.condition == nil {
+		definition.typeName = kind
+	}
 	parts, err := v.compositionParts(definition, map[string]bool{})
 	if err != nil {
 		v.add(path, err.Error())
@@ -1989,6 +2088,7 @@ func (v *validator) validateComposedParts(
 				if component.keyPattern != nil && !matchesPattern(component.keyPattern, key) {
 					v.add(childPath, "key does not match keypattern "+component.keyPattern.String())
 				}
+				v.validateMemberValueConstraints(childPath, entry, component)
 				// A composed collection may take its dynamic-entry constraint
 				// entirely from another contributor.
 				if component.itemReference == "" {
@@ -2201,6 +2301,7 @@ func (v *validator) validateCollection(path string, table map[string]any, defini
 			continue
 		}
 		v.validateValue(childPath, value, referenced)
+		v.validateMemberValueConstraints(childPath, value, definition)
 	}
 	v.validateLength(path, dynamicEntries, definition)
 	for key, child := range definition.children {
@@ -2247,16 +2348,10 @@ func (v *validator) validateArray(path string, array []any, definition Definitio
 		v.add(path, err.Error())
 		return
 	}
-	rangeType, hasRangeType, _ := v.schema.resolveItemKind(definition.itemReference, map[string]bool{})
 	for i, item := range array {
 		itemPath := fmt.Sprintf("%s[%d]", path, i)
 		v.validateValue(itemPath, item, itemDefinition)
-		if len(definition.allowedValues) > 0 {
-			v.validateAllowedValues(itemPath, item, definition)
-		}
-		if hasRangeType && isType(item, rangeType) {
-			v.validateRange(itemPath, item, definition)
-		}
+		v.validateMemberValueConstraints(itemPath, item, definition)
 	}
 }
 
@@ -2328,6 +2423,9 @@ func (v *validator) validateCommonConstraints(path string, value any, definition
 		v.validateLength(path, len(array), definition)
 		return
 	}
+	if _, ok := value.(map[string]any); ok && definition.typeName == TypeCollection {
+		return
+	}
 	v.validateAllowedValues(path, value, definition)
 	if len(definition.allowedValues) > 0 {
 		return
@@ -2335,6 +2433,21 @@ func (v *validator) validateCommonConstraints(path string, value any, definition
 	v.validateRange(path, value, definition)
 	if stringValue, ok := value.(string); ok {
 		v.validateLength(path, utf8.RuneCountInString(stringValue), definition)
+		if definition.pattern != nil && !matchesPattern(definition.pattern, stringValue) {
+			v.add(path, "does not match pattern "+definition.pattern.String())
+		}
+		if definition.format != "" && !validateStringFormat(definition.format, stringValue) {
+			v.add(path, "invalid string for format "+definition.format)
+		}
+	}
+}
+
+func (v *validator) validateMemberValueConstraints(path string, value any, definition Definition) {
+	v.validateAllowedValues(path, value, definition)
+	if len(definition.allowedValues) == 0 {
+		v.validateRange(path, value, definition)
+	}
+	if stringValue, ok := value.(string); ok {
 		if definition.pattern != nil && !matchesPattern(definition.pattern, stringValue) {
 			v.add(path, "does not match pattern "+definition.pattern.String())
 		}

--- a/reference-implementations/go/schema_phase3_test.go
+++ b/reference-implementations/go/schema_phase3_test.go
@@ -1,0 +1,160 @@
+package tomlschema
+
+import "testing"
+
+func TestLoadsPureAllOfMixin(t *testing.T) {
+	dir := t.TempDir()
+	schema := loadSemanticsSchema(t, `
+[types.named]
+type = "table"
+[types.named.name]
+type = "string"
+[types.packageBase]
+type = "table"
+[types.packageBase.version]
+type = "string"
+[types.package]
+allof = ["types.packageBase", "types.named"]
+dependentrequired = { name = ["version"] }
+[types.positive]
+type = "integer"
+min = 1
+[types.small]
+type = "integer"
+max = 10
+[types.count]
+allof = ["types.positive", "types.small"]
+[elements.pkg]
+type = "types.package"
+[elements.count]
+type = "types.count"
+`)
+	document := write(t, dir, "valid.toml", "pkg = { name = \"x\", version = \"1\" }\ncount = 5")
+	invalid := write(t, dir, "invalid.toml", "pkg = { name = \"x\", version = \"1\" }\ncount = 0")
+	if result := schema.ValidateFile(document); !result.Valid() {
+		t.Fatalf("pure allof mixin should validate: %#v", result.Errors)
+	}
+	if result := schema.ValidateFile(invalid); result.Valid() {
+		t.Fatal("pure scalar allof constraints were not applied")
+	}
+}
+
+func TestRejectsMixedKindPureAllOf(t *testing.T) {
+	dir := t.TempDir()
+	path := write(t, dir, "schema.tosd", `
+[toml-schema]
+version = "1.0.0"
+[types.aTable]
+type = "table"
+[types.aTable.x]
+type = "string"
+[types.anArray]
+type = "array"
+itemtype = "string"
+[types.bad]
+allof = ["types.aTable", "types.anArray"]
+[elements.value]
+type = "types.bad"
+`)
+	if _, err := LoadSchema(path); err == nil {
+		t.Fatal("mixed-kind pure allof must fail at load")
+	}
+}
+
+func TestValidatesInlineArrayPattern(t *testing.T) {
+	dir := t.TempDir()
+	schema := loadSemanticsSchema(t, `
+[elements.tags]
+type = "array"
+itemtype = "string"
+pattern = '^[a-z]+$'
+`)
+	valid := write(t, dir, "valid.toml", `tags = ["alpha", "beta"]`)
+	invalid := write(t, dir, "invalid.toml", `tags = ["alpha", "Beta"]`)
+	if result := schema.ValidateFile(valid); !result.Valid() {
+		t.Fatalf("valid tags rejected: %#v", result.Errors)
+	}
+	if result := schema.ValidateFile(invalid); !hasPath(result, "$.tags[1]") {
+		t.Fatalf("invalid tag was not rejected: %#v", result.Errors)
+	}
+}
+
+func TestValidatesInlineCollectionMemberConstraints(t *testing.T) {
+	dir := t.TempDir()
+	schema := loadSemanticsSchema(t, `
+[elements.ports]
+type = "collection"
+itemtype = "integer"
+min = 1
+max = 65535
+[elements.roles]
+type = "collection"
+itemtype = "string"
+allowedvalues = ["admin", "reader"]
+[elements.tags]
+type = "collection"
+itemtype = "string"
+pattern = '^[a-z]+@example\.com$'
+[elements.emails]
+type = "collection"
+itemtype = "string"
+format = "email"
+`)
+	valid := write(t, dir, "valid.toml", "[ports]\nhttp = 80\n[roles]\nowner = \"admin\"\n[tags]\nrelease = \"stable@example.com\"\n[emails]\nowner = \"admin@example.com\"\n")
+	invalid := write(t, dir, "invalid.toml", "[ports]\nlow = 0\nhigh = 70000\n[roles]\nowner = \"root\"\n[tags]\nrelease = \"Stable\"\n[emails]\nowner = \"not-an-email\"\n")
+	if result := schema.ValidateFile(valid); !result.Valid() {
+		t.Fatalf("valid collection members rejected: %#v", result.Errors)
+	}
+	result := schema.ValidateFile(invalid)
+	for _, path := range []string{"$.ports.low", "$.ports.high", "$.roles.owner", "$.tags.release", "$.emails.owner"} {
+		if !hasPath(result, path) {
+			t.Fatalf("invalid collection member at %s was not rejected: %#v", path, result.Errors)
+		}
+	}
+}
+
+func TestRejectsDuplicateInlineAndItemtypeConstraint(t *testing.T) {
+	dir := t.TempDir()
+	path := write(t, dir, "schema.tosd", `
+[toml-schema]
+version = "1.0.0"
+[types.item]
+type = "integer"
+min = 0
+[elements.values]
+type = "array"
+itemtype = "types.item"
+min = -10
+`)
+	if _, err := LoadSchema(path); err == nil {
+		t.Fatal("duplicate member constraint must fail at load")
+	}
+}
+
+func TestAllowsInlineConstraintMatchingItemtypeAllOfConstraint(t *testing.T) {
+	dir := t.TempDir()
+	schema := loadSemanticsSchema(t, `
+[types.mixin]
+type = "string"
+allowedvalues = ["a", "b"]
+[types.item]
+type = "string"
+allof = ["types.mixin"]
+[elements.values]
+type = "array"
+itemtype = "types.item"
+allowedvalues = ["b", "c"]
+`)
+	valid := write(t, dir, "valid.toml", `values = ["b"]`)
+	inlineInvalid := write(t, dir, "inline-invalid.toml", `values = ["a"]`)
+	inheritedInvalid := write(t, dir, "inherited-invalid.toml", `values = ["c"]`)
+	if result := schema.ValidateFile(valid); !result.Valid() {
+		t.Fatalf("intersection value should validate: %#v", result.Errors)
+	}
+	if result := schema.ValidateFile(inlineInvalid); result.Valid() {
+		t.Fatal("inline allowedvalues constraint was not applied")
+	}
+	if result := schema.ValidateFile(inheritedInvalid); result.Valid() {
+		t.Fatal("allof-inherited allowedvalues constraint was not applied")
+	}
+}

--- a/reference-implementations/go/schema_phase3_test.go
+++ b/reference-implementations/go/schema_phase3_test.go
@@ -1,6 +1,9 @@
 package tomlschema
 
-import "testing"
+import (
+	"strconv"
+	"testing"
+)
 
 func TestLoadsPureAllOfMixin(t *testing.T) {
 	dir := t.TempDir()
@@ -128,6 +131,37 @@ min = -10
 `)
 	if _, err := LoadSchema(path); err == nil {
 		t.Fatal("duplicate member constraint must fail at load")
+	}
+}
+
+func TestRejectsPerMemberAllowedValuesOnContainers(t *testing.T) {
+	dir := t.TempDir()
+	cases := []string{
+		"[elements.value]\ntype = \"array\"\nitemtype = \"integer\"\nallowedvalues = [5, 50]\nmin = 10\n",
+		"[elements.value]\ntype = \"collection\"\nitemtype = \"integer\"\nallowedvalues = [5, 50]\nmin = 10\n",
+		"[elements.value]\ntype = \"array\"\nitemtype = \"integer\"\nallowedvalues = [2, 3]\nmax = 2\n",
+		"[elements.value]\ntype = \"array\"\nitemtype = \"string\"\nallowedvalues = [\"ok@example.com\", \"nope\"]\nformat = \"email\"\n",
+		"[elements.value]\ntype = \"collection\"\nitemtype = \"string\"\nallowedvalues = [\"ok@example.com\", \"nope\"]\nformat = \"email\"\n",
+	}
+	for i, def := range cases {
+		path := write(t, dir, "invalid-container-"+strconv.Itoa(i)+".tosd", "[toml-schema]\nversion = \"1.0.0\"\n"+def)
+		if _, err := LoadSchema(path); err == nil {
+			t.Fatalf("case %d: container enumeration violating a per-member constraint must fail at load", i)
+		}
+	}
+
+	// minlength/maxlength bound the container, not its members, so an
+	// enumeration of longer strings must still load.
+	schema := loadSemanticsSchema(t, `
+[elements.value]
+type = "array"
+itemtype = "string"
+allowedvalues = ["aaaa", "bbbbb"]
+maxlength = 2
+`)
+	valid := write(t, dir, "container-length.toml", `value = ["aaaa"]`)
+	if result := schema.ValidateFile(valid); !result.Valid() {
+		t.Fatalf("container with maxlength enumeration rejected: %#v", result.Errors)
 	}
 }
 

--- a/reference-implementations/go/schema_test.go
+++ b/reference-implementations/go/schema_test.go
@@ -436,16 +436,14 @@ version = "1.0.0"
 
 [types.boundedInteger]
 type = "integer"
-min = 10
-max = 20
 
 [types.smallInteger]
 type = "integer"
-max = 5
+allowedvalues = [1, 2, 3, 4, 5]
 
 [types.largeInteger]
 type = "integer"
-min = 6
+allowedvalues = [6, 7, 8, 9, 10]
 
 [types.integerAlternative]
 oneof = [ "types.smallInteger", "types.largeInteger" ]
@@ -459,8 +457,8 @@ max = 4
 [elements.named]
 type = "array"
 itemtype = "types.boundedInteger"
-min = 5
-max = 25
+min = 10
+max = 20
 
 [elements.alternatives]
 type = "array"

--- a/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
@@ -929,9 +929,10 @@ final class SchemaLoader {
             Integer minLength,
             Integer maxLength
     ) {
-        if (allowedValues.isEmpty() || type == SchemaType.ARRAY) {
+        if (allowedValues.isEmpty()) {
             return;
         }
+        boolean isContainer = type == SchemaType.ARRAY || type == SchemaType.COLLECTION;
         for (int i = 0; i < allowedValues.size(); i++) {
             Object allowed = allowedValues.get(i);
             String entry = name + " allowedvalues[" + i + "]";
@@ -950,7 +951,7 @@ final class SchemaLoader {
             if (max != null && ValueSemantics.compare(allowed, max) > 0) {
                 throw new SchemaException(entry + " is greater than max");
             }
-            if (minLength != null || maxLength != null) {
+            if (!isContainer && (minLength != null || maxLength != null)) {
                 if (!(allowed instanceof String stringValue)) {
                     throw new SchemaException(entry + " does not satisfy string length constraints");
                 }

--- a/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/SchemaLoader.java
@@ -256,10 +256,13 @@ final class SchemaLoader {
         if (type == null && normalizedReference == null && !hasOneOf && !hasAnyOf
                 && conditional == null) {
             if (children.isEmpty()) {
-                throw new SchemaException(
-                        name + " must define type, oneof, anyof, if/then/else, or child definitions");
+                if (allOf.isEmpty()) {
+                    throw new SchemaException(
+                            name + " must define type, oneof, anyof, if/then/else, or child definitions");
+                }
+            } else {
+                type = SchemaType.TABLE;
             }
-            type = SchemaType.TABLE;
         }
         if (!children.isEmpty() && type != SchemaType.TABLE && type != SchemaType.COLLECTION) {
             throw new SchemaException(name + " can only define children when type is table or collection");
@@ -283,6 +286,9 @@ final class SchemaLoader {
             if (getPropertyValue(table, "min") != null || getPropertyValue(table, "max") != null) {
                 throw new SchemaException(name + " cannot define min or max together with items");
             }
+            if (pattern != null || format != null) {
+                throw new SchemaException(name + " cannot define pattern or format together with items");
+            }
         }
         if (minLength != null && maxLength != null && minLength > maxLength) {
             throw new SchemaException(name + " minlength must not be greater than maxlength");
@@ -290,13 +296,15 @@ final class SchemaLoader {
         if (keyPattern != null && type != SchemaType.COLLECTION) {
             throw new SchemaException(name + " can only define keypattern when type is collection");
         }
-        if (pattern != null && type != SchemaType.STRING) {
+        if (pattern != null && type != SchemaType.STRING
+                && type != SchemaType.ARRAY && type != SchemaType.COLLECTION) {
             throw new SchemaException(name + " can only define pattern when type is string");
         }
-        if (format != null && type != SchemaType.STRING) {
+        if (format != null && type != SchemaType.STRING
+                && type != SchemaType.ARRAY && type != SchemaType.COLLECTION) {
             throw new SchemaException(name + " can only define format when type is string");
         }
-        if (hasAllowedValues && (type == SchemaType.TABLE || type == SchemaType.COLLECTION)) {
+        if (hasAllowedValues && type == SchemaType.TABLE) {
             throw new SchemaException(name + " can only define allowedvalues for scalar, unconstrained, or array types");
         }
         if ((minLength != null || maxLength != null)
@@ -731,7 +739,7 @@ final class SchemaLoader {
         if (type == SchemaType.ANY) {
             throw new SchemaException(name + " cannot define min or max when type is any");
         }
-        if (type == SchemaType.ARRAY) {
+        if (type == SchemaType.ARRAY || type == SchemaType.COLLECTION) {
             if (itemReference == null) {
                 throw new SchemaException(name + " can only define min or max when itemtype resolves to one comparable built-in type");
             }
@@ -766,7 +774,8 @@ final class SchemaLoader {
             Map<String, SchemaDefinition> definitions
     ) {
         for (SchemaDefinition definition : definitions.values()) {
-            if (definition.type() == SchemaType.ARRAY && (definition.min() != null || definition.max() != null)) {
+            if ((definition.type() == SchemaType.ARRAY || definition.type() == SchemaType.COLLECTION)
+                    && (definition.min() != null || definition.max() != null)) {
                 Set<SchemaType> itemTypes = resolveItemTypes(definition.itemReference(), types, new HashSet<>());
                 if (itemTypes.size() != 1 || !isRangeComparable(itemTypes.iterator().next())) {
                     throw new SchemaException(definition.name()
@@ -788,9 +797,11 @@ final class SchemaLoader {
         for (SchemaDefinition definition : definitions.values()) {
             Set<SchemaType> permittedTypes = Set.of();
             if (!definition.allowedValues().isEmpty()) {
-                if (definition.type() == SchemaType.ARRAY && definition.itemReference() != null) {
+                if ((definition.type() == SchemaType.ARRAY || definition.type() == SchemaType.COLLECTION)
+                        && definition.itemReference() != null) {
                     permittedTypes = resolveItemTypes(definition.itemReference(), types, new HashSet<>());
-                } else if (definition.type() != SchemaType.ARRAY) {
+                } else if (definition.type() != SchemaType.ARRAY
+                        && definition.type() != SchemaType.COLLECTION) {
                     permittedTypes = Set.of(definition.type());
                 }
                 for (int index = 0; index < definition.allowedValues().size(); index++) {
@@ -1015,10 +1026,23 @@ final class SchemaLoader {
                 throw new SchemaException(definition.name()
                         + " effective collection must define at least one itemtype");
             }
+            if (definition.type() == SchemaType.ARRAY || definition.type() == SchemaType.COLLECTION) {
+                boolean hasStringConstraint = definition.pattern() != null || definition.format() != null;
+                if (hasStringConstraint) {
+                    Set<SchemaType> itemTypes =
+                            resolveItemTypes(definition.itemReference(), types, new HashSet<>());
+                    if (!itemTypes.equals(Set.of(SchemaType.STRING))) {
+                        throw new SchemaException(definition.name()
+                                + " can only define pattern or format when itemtype resolves to string");
+                    }
+                }
+                validateDuplicateMemberConstraints(definition, types);
+            }
             if (hasPresenceRules) {
                 Set<String> fixedChildren = determinateFixedChildren(definition, types, new HashSet<>());
                 validateRuleNames(definition, fixedChildren);
             }
+
             if (definition.condition() != null) {
                 for (Map.Entry<String, String> branchEntry : Map.of(
                         "then", definition.thenReference(),
@@ -1037,8 +1061,71 @@ final class SchemaLoader {
                                 + definition.condition().key());
                     }
                 }
+
             }
             validateDefinitionSemantics(types, definition.children());
+        }
+    }
+
+    private void validateDuplicateMemberConstraints(
+            SchemaDefinition definition,
+            Map<String, SchemaDefinition> types
+    ) {
+        if (definition.itemReference() == null) {
+            return;
+        }
+        Map<String, Boolean> constraints = Map.of(
+                "allowedvalues", !definition.allowedValues().isEmpty(),
+                "min", definition.min() != null,
+                "max", definition.max() != null,
+                "pattern", definition.pattern() != null,
+                "format", definition.format() != null);
+        for (Map.Entry<String, Boolean> entry : constraints.entrySet()) {
+            if (entry.getValue() && referenceHasConstraint(
+                    definition.itemReference(), entry.getKey(), types, new HashSet<>())) {
+                throw new SchemaException(definition.name() + " defines " + entry.getKey()
+                        + " both inline and on its resolved itemtype");
+            }
+        }
+    }
+
+    private boolean referenceHasConstraint(
+            String reference,
+            String property,
+            Map<String, SchemaDefinition> types,
+            Set<String> visiting
+    ) {
+        if (SchemaType.fromSchemaNameOptional(reference).isPresent()) {
+            return false;
+        }
+        if (!visiting.add(reference)) {
+            throw new SchemaException("Cyclic schema reference involving types." + reference);
+        }
+        try {
+            SchemaDefinition definition = referenceDefinition(reference, types);
+            boolean local = switch (property) {
+                case "allowedvalues" -> !definition.allowedValues().isEmpty();
+                case "min" -> definition.min() != null;
+                case "max" -> definition.max() != null;
+                case "pattern" -> definition.pattern() != null;
+                case "format" -> definition.format() != null;
+                default -> false;
+            };
+            if (local) {
+                return true;
+            }
+            List<String> references = new ArrayList<>();
+            if (definition.reference() != null) references.add(definition.reference());
+            references.addAll(definition.oneOf());
+            references.addAll(definition.anyOf());
+            if (definition.condition() != null) {
+                references.add(definition.thenReference());
+                references.add(definition.elseReference());
+            }
+            return references.stream().anyMatch(
+                    nested -> referenceHasConstraint(nested, property, types, visiting));
+        } finally {
+            visiting.remove(reference);
         }
     }
 
@@ -1080,10 +1167,14 @@ final class SchemaLoader {
         for (String reference : definition.allOf()) {
             Set<SchemaType> componentKinds = effectiveKinds(referenceDefinition(reference, types), types,
                     addVisit(reference, visiting));
-            if (localKinds.size() != 1 || componentKinds.size() != 1
-                    || !localKinds.equals(componentKinds)) {
+            if (componentKinds.size() != 1 || componentKinds.contains(SchemaType.ANY)
+                    || (!localKinds.isEmpty()
+                    && (localKinds.size() != 1 || !localKinds.equals(componentKinds)))) {
                 throw new SchemaException(definition.name()
                         + " allof components must resolve to compatible effective TOML kinds");
+            }
+            if (localKinds.isEmpty()) {
+                localKinds.addAll(componentKinds);
             }
         }
         return localKinds;

--- a/reference-implementations/java/src/main/java/org/tomlschema/TomlSchemaValidator.java
+++ b/reference-implementations/java/src/main/java/org/tomlschema/TomlSchemaValidator.java
@@ -347,6 +347,7 @@ final class TomlSchemaValidator {
                 validateNode(childPath, entry.getValue(),
                         reference(definition.itemReference(), new HashSet<>()));
             }
+            validateMemberValueConstraints(childPath, entry.getValue(), definition);
         }
         validateLength(path, dynamicEntries, definition);
     }
@@ -411,6 +412,17 @@ final class TomlSchemaValidator {
                     && boundariesAreComparableWith(item, definition)) {
                 validateRange(itemPath, item, definition);
             }
+            if (item instanceof String stringValue) {
+                if (definition.pattern() != null
+                        && !definition.pattern().matcher(stringValue).find()) {
+                    add("pattern", itemPath,
+                            "does not match pattern " + definition.pattern().pattern());
+                }
+                if (definition.format() != null && !definition.format().isValid(stringValue)) {
+                    add("format", itemPath,
+                            "does not match format " + definition.format().schemaName());
+                }
+            }
         }
     }
 
@@ -428,6 +440,9 @@ final class TomlSchemaValidator {
 
     private void validateCommonConstraints(String path, Object value, SchemaDefinition definition) {
         if (value instanceof TomlArray) {
+            return;
+        }
+        if (value instanceof TomlTable && definition.type() == SchemaType.COLLECTION) {
             return;
         }
         validateAllowedValues(path, value, definition);
@@ -453,6 +468,30 @@ final class TomlSchemaValidator {
                 && definition.allowedValues().stream()
                 .noneMatch(allowed -> ValueSemantics.valuesEqual(allowed, value))) {
             add("allowedvalues", path, "value is not in allowedvalues");
+        }
+    }
+
+    private void validateMemberValueConstraints(
+            String path,
+            Object value,
+            SchemaDefinition definition
+    ) {
+        validateAllowedValues(path, value, definition);
+        if (definition.allowedValues().isEmpty()
+                && (definition.min() != null || definition.max() != null)
+                && boundariesAreComparableWith(value, definition)) {
+            validateRange(path, value, definition);
+        }
+        if (value instanceof String stringValue) {
+            if (definition.pattern() != null
+                    && !definition.pattern().matcher(stringValue).find()) {
+                add("pattern", path,
+                        "does not match pattern " + definition.pattern().pattern());
+            }
+            if (definition.format() != null && !definition.format().isValid(stringValue)) {
+                add("format", path,
+                        "does not match format " + definition.format().schemaName());
+            }
         }
     }
 
@@ -578,7 +617,14 @@ final class TomlSchemaValidator {
             }
             return kind == null ? SchemaType.ANY : kind;
         }
-        return definition.type() == null ? SchemaType.ANY : definition.type();
+        if (definition.type() != null) {
+            return definition.type();
+        }
+        if (!definition.allOf().isEmpty()) {
+            return effectiveKind(
+                    reference(definition.allOf().getFirst(), visiting), new HashSet<>(visiting));
+        }
+        return SchemaType.ANY;
     }
 
     private boolean resolvesToUnionSelector(SchemaDefinition definition, Set<String> visiting) {

--- a/reference-implementations/java/src/test/java/org/tomlschema/Phase3StructureTest.java
+++ b/reference-implementations/java/src/test/java/org/tomlschema/Phase3StructureTest.java
@@ -1,0 +1,159 @@
+package org.tomlschema;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class Phase3StructureTest {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void loadsPureAllofMixin() throws IOException {
+        TomlSchema schema = TomlSchema.load(write("pure-allof.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+                [types.named]
+                type = "table"
+                [types.named.name]
+                type = "string"
+                [types.packageBase]
+                type = "table"
+                [types.packageBase.version]
+                type = "string"
+                [types.package]
+                allof = ["types.packageBase", "types.named"]
+                dependentrequired = { name = ["version"] }
+                [types.positive]
+                type = "integer"
+                min = 1
+                [types.small]
+                type = "integer"
+                max = 10
+                [types.count]
+                allof = ["types.positive", "types.small"]
+                [elements.pkg]
+                type = "types.package"
+                [elements.count]
+                type = "types.count"
+                """));
+        assertTrue(schema.validate(write("valid.toml",
+                "pkg = { name = \"x\", version = \"1\" }\ncount = 5\n")).isValid());
+        assertFalse(schema.validate(write("invalid.toml",
+                "pkg = { name = \"x\", version = \"1\" }\ncount = 0\n")).isValid());
+    }
+
+    @Test
+    void rejectsMixedKindPureAllofAtLoad() throws IOException {
+        Path schema = write("mixed-allof.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+                [types.aTable]
+                type = "table"
+                [types.aTable.x]
+                type = "string"
+                [types.anArray]
+                type = "array"
+                itemtype = "string"
+                [types.bad]
+                allof = ["types.aTable", "types.anArray"]
+                [elements.value]
+                type = "types.bad"
+                """);
+        assertThrows(SchemaException.class, () -> TomlSchema.load(schema));
+    }
+
+    @Test
+    void validatesInlineArrayPattern() throws IOException {
+        TomlSchema schema = TomlSchema.load(write("array-pattern.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+                [elements.tags]
+                type = "array"
+                itemtype = "string"
+                pattern = '^[a-z]+$'
+                """));
+        assertTrue(schema.validate(write("valid.toml", "tags = [\"alpha\", \"beta\"]\n")).isValid());
+        assertFalse(schema.validate(write("invalid.toml", "tags = [\"alpha\", \"Beta\"]\n")).isValid());
+    }
+
+    @Test
+    void validatesInlineCollectionMemberConstraints() throws IOException {
+        TomlSchema schema = TomlSchema.load(write("collection-constraints.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+                [elements.ports]
+                type = "collection"
+                itemtype = "integer"
+                min = 1
+                max = 65535
+                [elements.roles]
+                type = "collection"
+                itemtype = "string"
+                allowedvalues = ["admin", "reader"]
+                [elements.tags]
+                type = "collection"
+                itemtype = "string"
+                pattern = '^[a-z]+@example\\.com$'
+                [elements.emails]
+                type = "collection"
+                itemtype = "string"
+                format = "email"
+                """));
+        assertTrue(schema.validate(write("valid.toml",
+                "[ports]\nhttp = 80\n[roles]\nowner = \"admin\"\n[tags]\nrelease = \"stable@example.com\"\n[emails]\nowner = \"admin@example.com\"\n")).isValid());
+        assertFalse(schema.validate(write("min-invalid.toml", "[ports]\nhttp = 0\n[roles]\nowner = \"admin\"\n[tags]\nrelease = \"stable@example.com\"\n[emails]\nowner = \"admin@example.com\"\n")).isValid());
+        assertFalse(schema.validate(write("max-invalid.toml", "[ports]\nhttp = 70000\n[roles]\nowner = \"admin\"\n[tags]\nrelease = \"stable@example.com\"\n[emails]\nowner = \"admin@example.com\"\n")).isValid());
+        assertFalse(schema.validate(write("allowed-invalid.toml", "[ports]\nhttp = 80\n[roles]\nowner = \"root\"\n[tags]\nrelease = \"stable@example.com\"\n[emails]\nowner = \"admin@example.com\"\n")).isValid());
+        assertFalse(schema.validate(write("pattern-invalid.toml", "[ports]\nhttp = 80\n[roles]\nowner = \"admin\"\n[tags]\nrelease = \"Stable\"\n[emails]\nowner = \"admin@example.com\"\n")).isValid());
+        assertFalse(schema.validate(write("format-invalid.toml", "[ports]\nhttp = 80\n[roles]\nowner = \"admin\"\n[tags]\nrelease = \"stable@example.com\"\n[emails]\nowner = \"not-an-email\"\n")).isValid());
+    }
+
+    @Test
+    void rejectsDuplicateInlineAndItemtypeConstraintAtLoad() throws IOException {
+        Path schema = write("duplicate-constraint.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+                [types.item]
+                type = "integer"
+                min = 0
+                [elements.values]
+                type = "array"
+                itemtype = "types.item"
+                min = -10
+                """);
+        assertThrows(SchemaException.class, () -> TomlSchema.load(schema));
+    }
+
+    @Test
+    void allowsInlineConstraintMatchingItemtypeAllofConstraint() throws IOException {
+        TomlSchema schema = TomlSchema.load(write("inherited-constraint.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+                [types.mixin]
+                type = "string"
+                allowedvalues = ["a", "b"]
+                [types.item]
+                type = "string"
+                allof = ["types.mixin"]
+                [elements.values]
+                type = "array"
+                itemtype = "types.item"
+                allowedvalues = ["b", "c"]
+                """));
+        assertTrue(schema.validate(write("intersection-valid.toml", "values = [\"b\"]\n")).isValid());
+        assertFalse(schema.validate(write("inline-invalid.toml", "values = [\"a\"]\n")).isValid());
+        assertFalse(schema.validate(write("inherited-invalid.toml", "values = [\"c\"]\n")).isValid());
+    }
+
+    private Path write(String name, String content) throws IOException {
+        return Files.writeString(tempDir.resolve(name), content);
+    }
+}

--- a/reference-implementations/java/src/test/java/org/tomlschema/Phase3StructureTest.java
+++ b/reference-implementations/java/src/test/java/org/tomlschema/Phase3StructureTest.java
@@ -133,6 +133,33 @@ class Phase3StructureTest {
     }
 
     @Test
+    void rejectsPerMemberAllowedValuesOnContainers() throws IOException {
+        String[] cases = {
+            "[elements.value]\ntype = \"array\"\nitemtype = \"integer\"\nallowedvalues = [5, 50]\nmin = 10\n",
+            "[elements.value]\ntype = \"collection\"\nitemtype = \"integer\"\nallowedvalues = [5, 50]\nmin = 10\n",
+            "[elements.value]\ntype = \"array\"\nitemtype = \"integer\"\nallowedvalues = [2, 3]\nmax = 2\n",
+            "[elements.value]\ntype = \"array\"\nitemtype = \"string\"\nallowedvalues = [\"ok@example.com\", \"nope\"]\nformat = \"email\"\n",
+            "[elements.value]\ntype = \"collection\"\nitemtype = \"string\"\nallowedvalues = [\"ok@example.com\", \"nope\"]\nformat = \"email\"\n",
+        };
+        for (int i = 0; i < cases.length; i++) {
+            Path schema = write("invalid-container-" + i + ".tosd",
+                    "[toml-schema]\nversion = \"1.0.0\"\n" + cases[i]);
+            assertThrows(SchemaException.class, () -> TomlSchema.load(schema));
+        }
+
+        TomlSchema container = TomlSchema.load(write("container-length.tosd", """
+                [toml-schema]
+                version = "1.0.0"
+                [elements.value]
+                type = "array"
+                itemtype = "string"
+                allowedvalues = ["aaaa", "bbbbb"]
+                maxlength = 2
+                """));
+        assertTrue(container.validate(write("container-length.toml", "value = [\"aaaa\"]\n")).isValid());
+    }
+
+    @Test
     void allowsInlineConstraintMatchingItemtypeAllofConstraint() throws IOException {
         TomlSchema schema = TomlSchema.load(write("inherited-constraint.tosd", """
                 [toml-schema]

--- a/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
+++ b/reference-implementations/java/src/test/java/org/tomlschema/TomlSchemaTest.java
@@ -1542,13 +1542,11 @@ class TomlSchemaTest {
 
                 [types.constrainedInteger]
                 type = "integer"
-                min = 0
-                max = 100
 
                 [elements.values]
                 type = "array"
                 itemtype = "types.constrainedInteger"
-                min = -10
+                min = 0
                 max = 10
                 """);
         Path validDocument = write("array-member-boundaries-valid.toml", "values = [ 0, 10 ]");

--- a/reference-implementations/python/src/toml_schema/_schema.py
+++ b/reference-implementations/python/src/toml_schema/_schema.py
@@ -408,7 +408,7 @@ def _validate_range_constraints(
         raise SchemaError(f"{name} cannot use NaN as max")
     if type_name == SchemaType.ANY:
         raise SchemaError(f"{name} cannot define min or max when type is any")
-    if type_name == SchemaType.ARRAY:
+    if type_name in (SchemaType.ARRAY, SchemaType.COLLECTION):
         return
     if type_name is not None and not is_range_comparable(type_name):
         raise SchemaError(
@@ -444,7 +444,7 @@ def _validate_allowed_values_constraints(
 ) -> None:
     from ._compare import IncomparableError, compare
 
-    if not allowed_values or type_name == SchemaType.ARRAY:
+    if not allowed_values or type_name in (SchemaType.ARRAY, SchemaType.COLLECTION):
         return
     for index, allowed in enumerate(allowed_values):
         entry = f"{name} allowedvalues[{index}]"
@@ -639,8 +639,10 @@ def parse_definition(name: str, path: Path, table: dict, source: SchemaSource) -
 
     if type_name is None and not reference and not has_one_of and not has_any_of and condition is None:
         if not children:
-            raise SchemaError(f"{name} must define type, oneof, anyof, or child definitions")
-        type_name = SchemaType.TABLE
+            if not all_of:
+                raise SchemaError(f"{name} must define type, oneof, anyof, or child definitions")
+        else:
+            type_name = SchemaType.TABLE
 
     if children and type_name not in (SchemaType.TABLE, SchemaType.COLLECTION):
         raise SchemaError(f"{name} can only define children when type is table or collection")
@@ -658,6 +660,8 @@ def parse_definition(name: str, path: Path, table: dict, source: SchemaSource) -
             raise SchemaError(f"{name} cannot define allowedvalues together with items")
         if _property_value(table, "min") is not None or _property_value(table, "max") is not None:
             raise SchemaError(f"{name} cannot define min or max together with items")
+        if pattern is not None or format_name:
+            raise SchemaError(f"{name} cannot define pattern or format together with items")
 
     min_value = _property_value(table, "min")
     max_value = _property_value(table, "max")
@@ -665,13 +669,21 @@ def parse_definition(name: str, path: Path, table: dict, source: SchemaSource) -
         raise SchemaError(f"{name} minlength must not be greater than maxlength")
     if key_pattern is not None and type_name != SchemaType.COLLECTION:
         raise SchemaError(f"{name} can only define keypattern when type is collection")
-    if pattern is not None and type_name != SchemaType.STRING:
+    if pattern is not None and type_name not in (
+        SchemaType.STRING,
+        SchemaType.ARRAY,
+        SchemaType.COLLECTION,
+    ):
         raise SchemaError(f"{name} can only define pattern when type is string")
-    if format_name and type_name != SchemaType.STRING:
+    if format_name and type_name not in (
+        SchemaType.STRING,
+        SchemaType.ARRAY,
+        SchemaType.COLLECTION,
+    ):
         raise SchemaError(
             f"{name} can only define format when locally selecting built-in type string"
         )
-    if has_allowed_values and type_name in (SchemaType.TABLE, SchemaType.COLLECTION):
+    if has_allowed_values and type_name == SchemaType.TABLE:
         raise SchemaError(f"{name} can only define allowedvalues for scalar, unconstrained, or array types")
     if (min_length is not None or max_length is not None) and type_name not in (
         SchemaType.STRING,
@@ -913,13 +925,15 @@ class Schema:
 
         if not definition.all_of:
             return kind, resolved
-        if not resolved or kind == SchemaType.ANY:
-            raise SchemaError("allof requires a determinate effective kind")
         for reference in definition.all_of:
             component = self.definition_for_reference(reference)
             component_kind, ok = self.effective_kind(component, visiting)
-            if not ok or component_kind == SchemaType.ANY or component_kind != kind:
+            if not ok or component_kind == SchemaType.ANY:
+                raise SchemaError(f"allof component {reference} has indeterminate effective kind")
+            if resolved and component_kind != kind:
                 raise SchemaError(f"allof component {reference} has incompatible effective kind")
+            if not resolved:
+                kind, resolved = component_kind, True
         return kind, True
 
     def determinate_fixed_children(self, definition: Definition, visiting: Set[str]) -> Set[str]:
@@ -1099,7 +1113,7 @@ class Schema:
         def validate_definition(definition: Definition) -> None:
             permitted: Set[SchemaType] = set()
             if definition.allowed_values:
-                if definition.type_name == SchemaType.ARRAY:
+                if definition.type_name in (SchemaType.ARRAY, SchemaType.COLLECTION):
                     if definition.item_reference:
                         self.collect_reference_types(definition.item_reference, set(), permitted)
                 elif definition.type_name is not None:
@@ -1197,26 +1211,100 @@ class Schema:
 
     def validate_array_ranges(self) -> None:
         def validate_definition(definition: Definition) -> None:
-            if definition.type_name == SchemaType.ARRAY and (
-                definition.min is not None or definition.max is not None
-            ):
-                try:
-                    item_type, ok = self.resolve_item_kind(definition.item_reference, set())
-                except SchemaError as exc:
-                    raise SchemaError(f"{definition.name} has invalid itemtype: {exc}") from exc
-                if not ok or not is_range_comparable(item_type):
-                    raise SchemaError(
-                        f"{definition.name} can only define min or max when itemtype resolves to one comparable built-in type"
-                    )
-                _validate_boundary_matches_type(definition.name, "min", definition.min, item_type)
-                _validate_boundary_matches_type(definition.name, "max", definition.max, item_type)
-                _validate_ordered_range(definition.name, definition.min, definition.max, item_type)
+            if definition.type_name in (SchemaType.ARRAY, SchemaType.COLLECTION):
+                has_range = definition.min is not None or definition.max is not None
+                has_string_constraint = definition.pattern is not None or bool(definition.format)
+                if has_range or has_string_constraint:
+                    try:
+                        item_type, ok = self.resolve_item_kind(definition.item_reference, set())
+                    except SchemaError as exc:
+                        raise SchemaError(f"{definition.name} has invalid itemtype: {exc}") from exc
+                    if not ok:
+                        message = (
+                            "can only define min or max when itemtype resolves to one comparable built-in type"
+                            if has_range
+                            else "per-member constraints require a determinate itemtype"
+                        )
+                        raise SchemaError(f"{definition.name} {message}")
+                    if has_range and not is_range_comparable(item_type):
+                        raise SchemaError(
+                            f"{definition.name} can only define min or max when itemtype resolves to one comparable built-in type"
+                        )
+                    if has_string_constraint and item_type != SchemaType.STRING:
+                        raise SchemaError(
+                            f"{definition.name} can only define pattern or format when itemtype resolves to string"
+                        )
+                    if has_range:
+                        _validate_boundary_matches_type(
+                            definition.name, "min", definition.min, item_type
+                        )
+                        _validate_boundary_matches_type(
+                            definition.name, "max", definition.max, item_type
+                        )
+                        _validate_ordered_range(
+                            definition.name, definition.min, definition.max, item_type
+                        )
+                self.validate_duplicate_member_constraints(definition)
             for child in definition.children.values():
                 validate_definition(child)
 
         for definitions in (self.types, self.elements):
             for definition in definitions.values():
                 validate_definition(definition)
+
+    def validate_duplicate_member_constraints(self, definition: Definition) -> None:
+        if not definition.item_reference:
+            return
+        constraints = (
+            ("allowedvalues", bool(definition.allowed_values)),
+            ("min", definition.min is not None),
+            ("max", definition.max is not None),
+            ("pattern", definition.pattern is not None),
+            ("format", bool(definition.format)),
+        )
+        for property_name, present in constraints:
+            if present and self.reference_has_constraint(
+                definition.item_reference, property_name, set()
+            ):
+                raise SchemaError(
+                    f"{definition.name} defines {property_name} both inline and on its resolved itemtype"
+                )
+
+    def reference_has_constraint(
+        self,
+        reference: str,
+        property_name: str,
+        visiting: Set[str],
+    ) -> bool:
+        if parse_schema_type(reference) is not None:
+            return False
+        if reference in visiting:
+            raise SchemaError(f"cyclic type reference: {reference}")
+        definition = self.types.get(reference)
+        if definition is None:
+            raise SchemaError(f"unknown type reference: {reference}")
+        visiting.add(reference)
+        try:
+            local = {
+                "allowedvalues": bool(definition.allowed_values),
+                "min": definition.min is not None,
+                "max": definition.max is not None,
+                "pattern": definition.pattern is not None,
+                "format": bool(definition.format),
+            }[property_name]
+            if local:
+                return True
+            references = list(definition.one_of + definition.any_of)
+            if definition.reference:
+                references.append(definition.reference)
+            if definition.condition is not None:
+                references.extend((definition.then_reference, definition.else_reference))
+            return any(
+                self.reference_has_constraint(nested, property_name, visiting)
+                for nested in references
+            )
+        finally:
+            visiting.discard(reference)
 
     def validate_defaults(self) -> None:
         def validate_definition(definition: Definition) -> None:

--- a/reference-implementations/python/src/toml_schema/_schema.py
+++ b/reference-implementations/python/src/toml_schema/_schema.py
@@ -437,6 +437,7 @@ def _validate_allowed_values_constraints(
     type_name: Optional[SchemaType],
     allowed_values: List[Any],
     pattern: Optional[re.Pattern],
+    format_name: str,
     min_value: Any,
     max_value: Any,
     min_length: Optional[int],
@@ -444,13 +445,17 @@ def _validate_allowed_values_constraints(
 ) -> None:
     from ._compare import IncomparableError, compare
 
-    if not allowed_values or type_name in (SchemaType.ARRAY, SchemaType.COLLECTION):
+    if not allowed_values:
         return
+    is_container = type_name in (SchemaType.ARRAY, SchemaType.COLLECTION)
     for index, allowed in enumerate(allowed_values):
         entry = f"{name} allowedvalues[{index}]"
         if pattern is not None:
             if not isinstance(allowed, str) or not pattern.search(allowed):
                 raise SchemaError(f"{entry} does not satisfy pattern")
+        if format_name:
+            if not isinstance(allowed, str) or not matches_format(allowed, format_name):
+                raise SchemaError(f"{entry} does not satisfy format {format_name}")
         if (min_value is not None or max_value is not None) and is_nan(allowed):
             raise SchemaError(f"{entry} does not satisfy min or max")
         if min_value is not None:
@@ -467,7 +472,7 @@ def _validate_allowed_values_constraints(
                 raise SchemaError(f"{entry} cannot be compared with max: {exc}") from exc
             if comparison > 0:
                 raise SchemaError(f"{entry} is greater than max")
-        if min_length is not None or max_length is not None:
+        if not is_container and (min_length is not None or max_length is not None):
             if not isinstance(allowed, str):
                 raise SchemaError(f"{entry} does not satisfy string length constraints")
             length = len(allowed)
@@ -698,14 +703,8 @@ def parse_definition(name: str, path: Path, table: dict, source: SchemaSource) -
 
     _validate_range_constraints(name, type_name, min_value, max_value)
     _validate_allowed_values_constraints(
-        name, type_name, allowed_values, pattern, min_value, max_value, min_length, max_length
+        name, type_name, allowed_values, pattern, format_name, min_value, max_value, min_length, max_length
     )
-    if format_name:
-        for index, allowed in enumerate(allowed_values):
-            if not isinstance(allowed, str) or not matches_format(allowed, format_name):
-                raise SchemaError(
-                    f"{name} allowedvalues[{index}] does not satisfy format {format_name}"
-                )
 
     dependent_required = _get_dependent_required(name, path, table, source)
     mutually_exclusive = _get_key_groups(name, path, table, "mutuallyexclusive", source)

--- a/reference-implementations/python/src/toml_schema/_validator.py
+++ b/reference-implementations/python/src/toml_schema/_validator.py
@@ -193,6 +193,14 @@ class Validator:
             self.add(path, "allof has no determinate effective kind")
             return
         if kind in (SchemaType.TABLE, SchemaType.COLLECTION):
+            if (
+                definition.type_name is None
+                and not definition.reference
+                and not definition.one_of
+                and not definition.any_of
+                and definition.condition is None
+            ):
+                definition = dataclasses.replace(definition, type_name=kind)
             self.validate_composed_structure(path, value, kind, definition, None)
             return
         local = dataclasses.replace(definition, all_of=())
@@ -352,6 +360,7 @@ class Validator:
                             child_path,
                             f"key does not match keypattern {component.key_pattern.pattern}",
                         )
+                    self.validate_member_value_constraints(child_path, entry, component)
                     if not component.item_reference:
                         continue
                     try:
@@ -501,6 +510,7 @@ class Validator:
                 self.add(child_path, str(exc))
                 continue
             self.validate_value(child_path, value, referenced)
+            self.validate_member_value_constraints(child_path, value, definition)
         self.validate_length(path, dynamic_entries, definition)
         for key, child in definition.children.items():
             try:
@@ -537,17 +547,10 @@ class Validator:
         except SchemaError as exc:
             self.add(path, str(exc))
             return
-        try:
-            range_type, has_range_type = self.schema.resolve_item_kind(definition.item_reference, set())
-        except SchemaError:
-            range_type, has_range_type = None, False
         for i, item in enumerate(array):
             item_path = f"{path}[{i}]"
             self.validate_value(item_path, item, item_definition)
-            if definition.allowed_values:
-                self.validate_allowed_values(item_path, item, definition)
-            if has_range_type and is_type(item, range_type):
-                self.validate_range(item_path, item, definition)
+            self.validate_member_value_constraints(item_path, item, definition)
 
     def validate_sibling_rules(self, path: str, table: dict, definition: Definition) -> None:
         # dependentrequired is evaluated on direct presence only: a mapping
@@ -601,6 +604,8 @@ class Validator:
         if isinstance(value, list):
             self.validate_length(path, len(value), definition)
             return
+        if isinstance(value, dict) and definition.type_name == SchemaType.COLLECTION:
+            return
         self.validate_allowed_values(path, value, definition)
         if definition.allowed_values:
             return
@@ -619,6 +624,18 @@ class Validator:
             if values_equal(allowed, value):
                 return
         self.add(path, "value is not in allowedvalues")
+
+    def validate_member_value_constraints(
+        self, path: str, value: Any, definition: Definition
+    ) -> None:
+        self.validate_allowed_values(path, value, definition)
+        if not definition.allowed_values:
+            self.validate_range(path, value, definition)
+        if isinstance(value, str):
+            if definition.pattern is not None and not definition.pattern.search(value):
+                self.add(path, f"does not match pattern {definition.pattern.pattern}")
+            if definition.format and not matches_format(value, definition.format):
+                self.add(path, f"does not match format {definition.format}")
 
     def validate_range(self, path: str, value: Any, definition: Definition) -> None:
         if definition.min is not None:

--- a/reference-implementations/python/tests/test_diagnostics.py
+++ b/reference-implementations/python/tests/test_diagnostics.py
@@ -143,16 +143,14 @@ version = "1.0.0"
 
 [types.boundedInteger]
 type = "integer"
-min = 10
-max = 20
 
 [types.smallInteger]
 type = "integer"
-max = 5
+allowedvalues = [1, 2, 3, 4, 5]
 
 [types.largeInteger]
 type = "integer"
-min = 6
+allowedvalues = [6, 7, 8, 9, 10]
 
 [types.integerAlternative]
 oneof = [ "types.smallInteger", "types.largeInteger" ]
@@ -166,8 +164,8 @@ max = 4
 [elements.named]
 type = "array"
 itemtype = "types.boundedInteger"
-min = 5
-max = 25
+min = 10
+max = 20
 
 [elements.alternatives]
 type = "array"

--- a/reference-implementations/python/tests/test_phase3_structure.py
+++ b/reference-implementations/python/tests/test_phase3_structure.py
@@ -145,6 +145,38 @@ min = -10
             with self.assertRaises(SchemaError):
                 load_schema(path)
 
+    def test_rejects_per_member_allowed_values_on_containers(self):
+        cases = [
+            '[elements.value]\ntype = "array"\nitemtype = "integer"\nallowedvalues = [5, 50]\nmin = 10\n',
+            '[elements.value]\ntype = "collection"\nitemtype = "integer"\nallowedvalues = [5, 50]\nmin = 10\n',
+            '[elements.value]\ntype = "array"\nitemtype = "integer"\nallowedvalues = [2, 3]\nmax = 2\n',
+            '[elements.value]\ntype = "array"\nitemtype = "string"\nallowedvalues = ["ok@example.com", "nope"]\nformat = "email"\n',
+            '[elements.value]\ntype = "collection"\nitemtype = "string"\nallowedvalues = ["ok@example.com", "nope"]\nformat = "email"\n',
+        ]
+        for index, definition in enumerate(cases):
+            with tempfile.TemporaryDirectory() as tmp:
+                path = helpers.write_file(
+                    tmp,
+                    f"invalid-container-{index}.tosd",
+                    '[toml-schema]\nversion = "1.0.0"\n' + definition,
+                )
+                with self.assertRaises(SchemaError):
+                    load_schema(path)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            schema = helpers.load_semantics_schema(
+                tmp,
+                """
+[elements.value]
+type = "array"
+itemtype = "string"
+allowedvalues = ["aaaa", "bbbbb"]
+maxlength = 2
+""",
+            )
+            valid = helpers.write_file(tmp, "valid.toml", 'value = ["aaaa"]\n')
+            self.assertTrue(schema.validate_file(valid).valid)
+
     def test_allows_inline_constraint_matching_itemtype_allof_constraint(self):
         with tempfile.TemporaryDirectory() as tmp:
             schema = helpers.load_semantics_schema(

--- a/reference-implementations/python/tests/test_phase3_structure.py
+++ b/reference-implementations/python/tests/test_phase3_structure.py
@@ -1,0 +1,178 @@
+import tempfile
+import unittest
+
+import helpers
+from toml_schema import SchemaError, load_schema
+
+
+class Phase3StructureTests(unittest.TestCase):
+    def test_loads_pure_allof_mixin(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema = helpers.load_semantics_schema(
+                tmp,
+                """
+[types.named]
+type = "table"
+[types.named.name]
+type = "string"
+[types.packageBase]
+type = "table"
+[types.packageBase.version]
+type = "string"
+[types.package]
+allof = ["types.packageBase", "types.named"]
+dependentrequired = { name = ["version"] }
+[types.positive]
+type = "integer"
+min = 1
+[types.small]
+type = "integer"
+max = 10
+[types.count]
+allof = ["types.positive", "types.small"]
+[elements.pkg]
+type = "types.package"
+[elements.count]
+type = "types.count"
+""",
+            )
+            document = helpers.write_file(
+                tmp, "valid.toml", 'pkg = { name = "x", version = "1" }\ncount = 5\n'
+            )
+            self.assertTrue(schema.validate_file(document).valid)
+            invalid = helpers.write_file(
+                tmp, "invalid.toml", 'pkg = { name = "x", version = "1" }\ncount = 0\n'
+            )
+            self.assertFalse(schema.validate_file(invalid).valid)
+
+    def test_rejects_mixed_kind_pure_allof(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = helpers.write_file(
+                tmp,
+                "schema.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+[types.aTable]
+type = "table"
+[types.aTable.x]
+type = "string"
+[types.anArray]
+type = "array"
+itemtype = "string"
+[types.bad]
+allof = ["types.aTable", "types.anArray"]
+[elements.value]
+type = "types.bad"
+""",
+            )
+            with self.assertRaises(SchemaError):
+                load_schema(path)
+
+    def test_validates_inline_array_pattern(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema = helpers.load_semantics_schema(
+                tmp,
+                """
+[elements.tags]
+type = "array"
+itemtype = "string"
+pattern = '^[a-z]+$'
+""",
+            )
+            valid = helpers.write_file(tmp, "valid.toml", 'tags = ["alpha", "beta"]\n')
+            invalid = helpers.write_file(tmp, "invalid.toml", 'tags = ["alpha", "Beta"]\n')
+            self.assertTrue(schema.validate_file(valid).valid)
+            self.assertTrue(helpers.has_path(schema.validate_file(invalid), "$.tags[1]"))
+
+    def test_validates_inline_collection_member_constraints(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema = helpers.load_semantics_schema(
+                tmp,
+                """
+[elements.ports]
+type = "collection"
+itemtype = "integer"
+min = 1
+max = 65535
+[elements.roles]
+type = "collection"
+itemtype = "string"
+allowedvalues = ["admin", "reader"]
+[elements.tags]
+type = "collection"
+itemtype = "string"
+pattern = '^[a-z]+@example\\.com$'
+[elements.emails]
+type = "collection"
+itemtype = "string"
+format = "email"
+""",
+            )
+            valid = helpers.write_file(
+                tmp,
+                "valid.toml",
+                '[ports]\nhttp = 80\n[roles]\nowner = "admin"\n[tags]\nrelease = "stable@example.com"\n[emails]\nowner = "admin@example.com"\n',
+            )
+            invalid = helpers.write_file(
+                tmp,
+                "invalid.toml",
+                '[ports]\nlow = 0\nhigh = 70000\n[roles]\nowner = "root"\n[tags]\nrelease = "Stable"\n[emails]\nowner = "not-an-email"\n',
+            )
+            self.assertTrue(schema.validate_file(valid).valid)
+            result = schema.validate_file(invalid)
+            for path in ("$.ports.low", "$.ports.high", "$.roles.owner",
+                         "$.tags.release", "$.emails.owner"):
+                self.assertTrue(helpers.has_path(result, path), path)
+
+    def test_rejects_duplicate_inline_and_itemtype_constraint(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = helpers.write_file(
+                tmp,
+                "schema.tosd",
+                """
+[toml-schema]
+version = "1.0.0"
+[types.item]
+type = "integer"
+min = 0
+[elements.values]
+type = "array"
+itemtype = "types.item"
+min = -10
+""",
+            )
+            with self.assertRaises(SchemaError):
+                load_schema(path)
+
+    def test_allows_inline_constraint_matching_itemtype_allof_constraint(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            schema = helpers.load_semantics_schema(
+                tmp,
+                """
+[types.mixin]
+type = "string"
+allowedvalues = ["a", "b"]
+[types.item]
+type = "string"
+allof = ["types.mixin"]
+[elements.values]
+type = "array"
+itemtype = "types.item"
+allowedvalues = ["b", "c"]
+""",
+            )
+            valid = helpers.write_file(tmp, "valid.toml", 'values = ["b"]\n')
+            inline_invalid = helpers.write_file(
+                tmp, "inline-invalid.toml", 'values = ["a"]\n'
+            )
+            inherited_invalid = helpers.write_file(
+                tmp, "inherited-invalid.toml", 'values = ["c"]\n'
+            )
+            self.assertTrue(schema.validate_file(valid).valid)
+            self.assertFalse(schema.validate_file(inline_invalid).valid)
+            self.assertFalse(schema.validate_file(inherited_invalid).valid)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/reference-implementations/rust/src/schema.rs
+++ b/reference-implementations/rust/src/schema.rs
@@ -447,7 +447,7 @@ impl Schema {
         schema.validate_selector_cycles()?;
         schema.validate_allowed_value_types()?;
         schema.validate_definition_semantics()?;
-        schema.validate_array_range_definitions()?;
+        schema.validate_member_constraints()?;
         schema.validate_defaults()?;
         Ok(schema)
     }
@@ -500,13 +500,6 @@ impl Schema {
         Ok(())
     }
 
-    fn validate_array_range_definitions(&self) -> Result<(), String> {
-        for definition in self.types.values().chain(self.elements.values()) {
-            self.validate_array_range_definition(definition)?;
-        }
-        Ok(())
-    }
-
     fn validate_allowed_value_types(&self) -> Result<(), String> {
         for definition in self.types.values().chain(self.elements.values()) {
             self.validate_allowed_value_definition(definition)?;
@@ -517,7 +510,10 @@ impl Schema {
     fn validate_allowed_value_definition(&self, definition: &Definition) -> Result<(), String> {
         let mut permitted_types = HashSet::new();
         if !definition.allowed_values.is_empty() {
-            if definition.type_name == Some(SchemaType::Array) {
+            if matches!(
+                definition.type_name,
+                Some(SchemaType::Array | SchemaType::Collection)
+            ) {
                 if let Some(reference) = definition.item_reference.as_deref() {
                     self.collect_reference_types(
                         reference,
@@ -806,9 +802,9 @@ impl Schema {
         seen: &mut HashSet<String>,
     ) -> Result<SchemaType, String> {
         let base_kind = if let Some(type_name) = definition.type_name {
-            type_name
+            Some(type_name)
         } else if let Some(reference) = definition.reference.as_deref() {
-            self.reference_kind(reference, seen)?
+            Some(self.reference_kind(reference, seen)?)
         } else if let Some(selector) = &definition.conditional {
             let then_kind = self.reference_kind(&selector.then_reference, seen)?;
             let else_kind = self.reference_kind(&selector.else_reference, seen)?;
@@ -824,8 +820,8 @@ impl Schema {
                     definition.name
                 ));
             }
-            then_kind
-        } else {
+            Some(then_kind)
+        } else if !definition.one_of.is_empty() || !definition.any_of.is_empty() {
             let alternatives = if !definition.one_of.is_empty() {
                 &definition.one_of
             } else {
@@ -841,26 +837,39 @@ impl Schema {
                     definition.name
                 ));
             }
-            *kinds.iter().next().expect("one alternative kind")
+            Some(*kinds.iter().next().expect("one alternative kind"))
+        } else {
+            None
         };
         if !definition.all_of.is_empty() {
-            if matches!(base_kind, SchemaType::Any) {
-                return Err(format!(
-                    "{} cannot compose an indeterminate any type with allof",
-                    definition.name
-                ));
-            }
+            let mut effective = base_kind;
             for reference in &definition.all_of {
                 let component_kind = self.reference_kind(reference, seen)?;
-                if component_kind == SchemaType::Any || component_kind != base_kind {
+                if component_kind == SchemaType::Any {
                     return Err(format!(
-                        "{} allof component {reference} has incompatible effective type",
+                        "{} allof component {reference} has indeterminate effective type",
                         definition.name
                     ));
                 }
+                if let Some(base_kind) = effective {
+                    if component_kind != base_kind {
+                        return Err(format!(
+                            "{} allof component {reference} has incompatible effective type",
+                            definition.name
+                        ));
+                    }
+                } else {
+                    effective = Some(component_kind);
+                }
             }
+            return effective.ok_or_else(|| {
+                format!("{} allof has no determinate effective type", definition.name)
+            });
         }
-        Ok(base_kind)
+        if matches!(base_kind, Some(SchemaType::Any)) {
+            return Ok(SchemaType::Any);
+        }
+        base_kind.ok_or_else(|| format!("{} has no effective type", definition.name))
     }
 
     fn reference_kind(
@@ -1008,40 +1017,71 @@ impl Schema {
         Ok(())
     }
 
-    fn validate_array_range_definition(&self, definition: &Definition) -> Result<(), String> {
-        if definition.type_name == Some(SchemaType::Array)
-            && (definition.min.is_some() || definition.max.is_some())
-        {
-            let item_type = self.array_range_item_type(definition)?;
-            validate_boundary_matches_type(
-                &definition.name,
-                "min",
-                definition.min.as_ref(),
-                item_type,
-            )?;
-            validate_boundary_matches_type(
-                &definition.name,
-                "max",
-                definition.max.as_ref(),
-                item_type,
-            )?;
-            validate_ordered_range(
-                &definition.name,
-                definition.min.as_ref(),
-                definition.max.as_ref(),
-                item_type,
-            )?;
-        }
-        for child in definition.children.values() {
-            self.validate_array_range_definition(child)?;
+    fn validate_member_constraints(&self) -> Result<(), String> {
+        for definition in self.types.values().chain(self.elements.values()) {
+            self.validate_member_constraint_definition(definition)?;
         }
         Ok(())
     }
 
-    fn array_range_item_type(&self, definition: &Definition) -> Result<SchemaType, String> {
+    fn validate_member_constraint_definition(
+        &self,
+        definition: &Definition,
+    ) -> Result<(), String> {
+        if matches!(
+            definition.type_name,
+            Some(SchemaType::Array | SchemaType::Collection)
+        ) {
+            let has_range = definition.min.is_some() || definition.max.is_some();
+            let has_string_constraint =
+                definition.pattern.is_some() || definition.string_format.is_some();
+            if has_range || has_string_constraint {
+                let item_type = self.member_item_type(definition)?;
+                if has_string_constraint && item_type != SchemaType::String {
+                    return Err(format!(
+                        "{} can only define pattern or format when itemtype resolves to string",
+                        definition.name
+                    ));
+                }
+                if has_range && !item_type.is_range_comparable() {
+                    return Err(format!(
+                        "{} can only define min or max when itemtype resolves to one comparable built-in type",
+                        definition.name
+                    ));
+                }
+                if has_range {
+                    validate_boundary_matches_type(
+                        &definition.name,
+                        "min",
+                        definition.min.as_ref(),
+                        item_type,
+                    )?;
+                    validate_boundary_matches_type(
+                        &definition.name,
+                        "max",
+                        definition.max.as_ref(),
+                        item_type,
+                    )?;
+                    validate_ordered_range(
+                        &definition.name,
+                        definition.min.as_ref(),
+                        definition.max.as_ref(),
+                        item_type,
+                    )?;
+                }
+            }
+            self.validate_duplicate_member_constraints(definition)?;
+        }
+        for child in definition.children.values() {
+            self.validate_member_constraint_definition(child)?;
+        }
+        Ok(())
+    }
+
+    fn member_item_type(&self, definition: &Definition) -> Result<SchemaType, String> {
         let Some(reference) = definition.item_reference.as_deref() else {
             return Err(format!(
-                "{} can only define min or max when itemtype resolves to one comparable built-in type",
+                "{} per-member constraints require a determinate itemtype",
                 definition.name
             ));
         };
@@ -1054,13 +1094,80 @@ impl Schema {
             ));
         }
         let item_type = *types.iter().next().expect("one item type");
-        if !item_type.is_range_comparable() {
-            return Err(format!(
-                "{} can only define min or max when itemtype resolves to one comparable built-in type",
-                definition.name
-            ));
-        }
         Ok(item_type)
+    }
+
+    fn validate_duplicate_member_constraints(
+        &self,
+        definition: &Definition,
+    ) -> Result<(), String> {
+        let Some(reference) = definition.item_reference.as_deref() else {
+            return Ok(());
+        };
+        for (property, present) in [
+            ("allowedvalues", !definition.allowed_values.is_empty()),
+            ("min", definition.min.is_some()),
+            ("max", definition.max.is_some()),
+            ("pattern", definition.pattern.is_some()),
+            ("format", definition.string_format.is_some()),
+        ] {
+            if present
+                && self.reference_has_constraint(reference, property, &mut HashSet::new())?
+            {
+                return Err(format!(
+                    "{} defines {property} both inline and on its resolved itemtype",
+                    definition.name
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn reference_has_constraint(
+        &self,
+        reference: &str,
+        property: &str,
+        seen: &mut HashSet<String>,
+    ) -> Result<bool, String> {
+        let normalized = normalize_reference(reference.to_string());
+        if SchemaType::parse(&normalized).is_some() {
+            return Ok(false);
+        }
+        if !seen.insert(normalized.clone()) {
+            return Err(format!("cyclic type reference: {normalized}"));
+        }
+        let definition = self
+            .types
+            .get(&normalized)
+            .ok_or_else(|| format!("unknown type reference: {reference}"))?;
+        let local = match property {
+            "allowedvalues" => !definition.allowed_values.is_empty(),
+            "min" => definition.min.is_some(),
+            "max" => definition.max.is_some(),
+            "pattern" => definition.pattern.is_some(),
+            "format" => definition.string_format.is_some(),
+            _ => false,
+        };
+        if local {
+            seen.remove(&normalized);
+            return Ok(true);
+        }
+        let mut references = Vec::new();
+        references.extend(definition.reference.iter().cloned());
+        references.extend(definition.one_of.iter().cloned());
+        references.extend(definition.any_of.iter().cloned());
+        if let Some(selector) = &definition.conditional {
+            references.push(selector.then_reference.clone());
+            references.push(selector.else_reference.clone());
+        }
+        for nested in references {
+            if self.reference_has_constraint(&nested, property, seen)? {
+                seen.remove(&normalized);
+                return Ok(true);
+            }
+        }
+        seen.remove(&normalized);
+        Ok(false)
     }
 
     fn collect_reference_types(
@@ -1511,11 +1618,14 @@ fn parse_definition(
         && conditional.is_none()
     {
         if children.is_empty() {
-            return Err(format!(
-                "{name} must define type, oneof, anyof, if/then/else, or child definitions"
-            ));
+            if all_of.is_empty() {
+                return Err(format!(
+                    "{name} must define type, oneof, anyof, if/then/else, or child definitions"
+                ));
+            }
+        } else {
+            type_name = Some(SchemaType::Table);
         }
-        type_name = Some(SchemaType::Table);
     }
     if !children.is_empty()
         && !matches!(type_name, Some(SchemaType::Table | SchemaType::Collection))
@@ -1553,23 +1663,38 @@ fn parse_definition(
                 "{name} cannot define min or max together with items"
             ));
         }
+        if pattern.is_some() || string_format.is_some() {
+            return Err(format!(
+                "{name} cannot define pattern or format together with items"
+            ));
+        }
     }
     if key_pattern.is_some() && type_name != Some(SchemaType::Collection) {
         return Err(format!(
             "{name} can only define keypattern when type is collection"
         ));
     }
-    if pattern.is_some() && type_name != Some(SchemaType::String) {
+    if pattern.is_some()
+        && !matches!(
+            type_name,
+            Some(SchemaType::String | SchemaType::Array | SchemaType::Collection)
+        )
+    {
         return Err(format!(
             "{name} can only define pattern when type is string"
         ));
     }
-    if string_format.is_some() && type_name != Some(SchemaType::String) {
+    if string_format.is_some()
+        && !matches!(
+            type_name,
+            Some(SchemaType::String | SchemaType::Array | SchemaType::Collection)
+        )
+    {
         return Err(format!(
             "{name} can only define format when type is string"
         ));
     }
-    if has_allowed_values && matches!(type_name, Some(SchemaType::Table | SchemaType::Collection)) {
+    if has_allowed_values && type_name == Some(SchemaType::Table) {
         return Err(format!(
             "{name} can only define allowedvalues for scalar, unconstrained, or array types"
         ));
@@ -1863,7 +1988,10 @@ fn validate_range_constraints(
     if type_name == Some(SchemaType::Any) {
         return Err(format!("{name} cannot define min or max when type is any"));
     }
-    if type_name == Some(SchemaType::Array) {
+    if matches!(
+        type_name,
+        Some(SchemaType::Array | SchemaType::Collection)
+    ) {
         return Ok(());
     }
     if let Some(type_name) = type_name {
@@ -1967,7 +2095,12 @@ fn validate_allowed_values_constraints(
     min_length: Option<i64>,
     max_length: Option<i64>,
 ) -> Result<(), String> {
-    if allowed_values.is_empty() || type_name == Some(SchemaType::Array) {
+    if allowed_values.is_empty()
+        || matches!(
+            type_name,
+            Some(SchemaType::Array | SchemaType::Collection)
+        )
+    {
         return Ok(());
     }
     for (index, allowed) in allowed_values.iter().enumerate() {
@@ -2083,6 +2216,15 @@ impl<'schema> Validator<'schema> {
         seen: &mut HashSet<String>,
     ) -> Result<Vec<Definition>, String> {
         let mut resolved = self.resolve(definition, &mut HashSet::new())?;
+        if resolved.type_name.is_none()
+            && resolved.reference.is_none()
+            && resolved.one_of.is_empty()
+            && resolved.any_of.is_empty()
+            && resolved.conditional.is_none()
+            && !resolved.all_of.is_empty()
+        {
+            resolved.type_name = Some(self.schema.effective_kind(definition, &mut HashSet::new())?);
+        }
         let all_of = std::mem::take(&mut resolved.all_of);
         let mut components = vec![resolved];
         for reference in all_of {
@@ -2366,6 +2508,9 @@ impl<'schema> Validator<'schema> {
             if !item_definitions.is_empty() {
                 self.validate_definitions(&child_path, value, &item_definitions);
             }
+            for definition in components {
+                self.validate_member_value_constraints(&child_path, value, definition);
+            }
         }
         for definition in components {
             self.validate_length(path, dynamic_entries, definition);
@@ -2402,26 +2547,12 @@ impl<'schema> Validator<'schema> {
         if item_definition.is_none() && definition.allowed_values.is_empty() {
             return;
         }
-        let range_type = if definition.min.is_some() || definition.max.is_some() {
-            match self.schema.array_range_item_type(definition) {
-                Ok(item_type) => Some(item_type),
-                Err(error) => {
-                    self.add(path, &error);
-                    return;
-                }
-            }
-        } else {
-            None
-        };
         for (index, item) in array.iter().enumerate() {
             let item_path = format!("{path}[{index}]");
             if let Some(item_definition) = &item_definition {
                 self.validate_value(&item_path, item, item_definition);
             }
-            self.validate_allowed_values(&item_path, item, definition);
-            if range_type.is_some_and(|item_type| value_matches_type(item, item_type)) {
-                self.validate_range(&item_path, item, definition);
-            }
+            self.validate_member_value_constraints(&item_path, item, definition);
         }
     }
 
@@ -2469,6 +2600,11 @@ impl<'schema> Validator<'schema> {
             self.validate_length(path, array.len(), definition);
             return;
         }
+        if matches!(value, Value::Table(_))
+            && definition.type_name == Some(SchemaType::Collection)
+        {
+            return;
+        }
         self.validate_allowed_values(path, value, definition);
         if !definition.allowed_values.is_empty() {
             return;
@@ -2482,6 +2618,33 @@ impl<'schema> Validator<'schema> {
                         path,
                         &format!("does not match pattern {}", pattern.as_str()),
                     );
+                }
+            }
+            if let Some(string_format) = definition.string_format {
+                if !string_format.matches(string_value) {
+                    self.add(
+                        path,
+                        &format!("does not satisfy format {}", string_format.name()),
+                    );
+                }
+            }
+        }
+    }
+
+    fn validate_member_value_constraints(
+        &mut self,
+        path: &str,
+        value: &Value,
+        definition: &Definition,
+    ) {
+        self.validate_allowed_values(path, value, definition);
+        if definition.allowed_values.is_empty() {
+            self.validate_range(path, value, definition);
+        }
+        if let Value::String(string_value) = value {
+            if let Some(pattern) = &definition.pattern {
+                if !matches_pattern(pattern, string_value) {
+                    self.add(path, &format!("does not match pattern {}", pattern.as_str()));
                 }
             }
             if let Some(string_format) = definition.string_format {

--- a/reference-implementations/rust/src/schema.rs
+++ b/reference-implementations/rust/src/schema.rs
@@ -2095,14 +2095,13 @@ fn validate_allowed_values_constraints(
     min_length: Option<i64>,
     max_length: Option<i64>,
 ) -> Result<(), String> {
-    if allowed_values.is_empty()
-        || matches!(
-            type_name,
-            Some(SchemaType::Array | SchemaType::Collection)
-        )
-    {
+    if allowed_values.is_empty() {
         return Ok(());
     }
+    let is_container = matches!(
+        type_name,
+        Some(SchemaType::Array | SchemaType::Collection)
+    );
     for (index, allowed) in allowed_values.iter().enumerate() {
         let entry = format!("{name} allowedvalues[{index}]");
         if let Some(pattern) = pattern {
@@ -2138,7 +2137,7 @@ fn validate_allowed_values_constraints(
                 return Err(format!("{entry} is greater than max"));
             }
         }
-        if min_length.is_some() || max_length.is_some() {
+        if !is_container && (min_length.is_some() || max_length.is_some()) {
             let Some(string_value) = allowed.as_str() else {
                 return Err(format!(
                     "{entry} does not satisfy string length constraints"

--- a/reference-implementations/rust/tests/integration.rs
+++ b/reference-implementations/rust/tests/integration.rs
@@ -1078,12 +1078,11 @@ version = "1.0.0"
 
 [types.boundedInteger]
 type = "integer"
-min = 3
-max = 8
+allowedvalues = [3, 4, 5, 6, 7, 8]
 
 [types.lowInteger]
 type = "integer"
-max = 6
+allowedvalues = [1, 2, 3, 4, 5, 6]
 
 [types.integerAlternative]
 anyof = [ "types.boundedInteger", "types.lowInteger" ]
@@ -1097,8 +1096,8 @@ max = 4
 [elements.named]
 type = "array"
 itemtype = "types.boundedInteger"
-min = 0
-max = 20
+min = 3
+max = 8
 
 [elements.alternative]
 type = "array"
@@ -4117,6 +4116,162 @@ fn rejects_non_table_conditional_defaults_at_schema_load_time() {
          then = \"types.selected\"\nelse = \"types.fallback\"\ndefault = \"sqlite\"\n",
     );
     Schema::load(schema_path).expect_err("conditional default must be a table");
+}
+
+#[test]
+fn loads_pure_allof_mixin_and_uses_determinate_children() {
+    let directory = tempfile_dir("pure-allof");
+    let schema_path = write_file(&directory, "schema.tosd", r#"
+[toml-schema]
+version = "1.0.0"
+[types.named]
+type = "table"
+[types.named.name]
+type = "string"
+[types.packageBase]
+type = "table"
+[types.packageBase.version]
+type = "string"
+[types.package]
+allof = ["types.packageBase", "types.named"]
+dependentrequired = { name = ["version"] }
+[types.positive]
+type = "integer"
+min = 1
+[types.small]
+type = "integer"
+max = 10
+[types.count]
+allof = ["types.positive", "types.small"]
+[elements.pkg]
+type = "types.package"
+[elements.count]
+type = "types.count"
+"#);
+    let valid = write_file(&directory, "valid.toml", "pkg = { name = \"x\", version = \"1\" }\ncount = 5\n");
+    let invalid = write_file(&directory, "invalid.toml", "pkg = { name = \"x\", version = \"1\" }\ncount = 0\n");
+    let schema = Schema::load(schema_path).expect("pure allof mixin must load");
+    assert!(schema.validate_file(valid).valid());
+    assert!(!schema.validate_file(invalid).valid());
+}
+
+#[test]
+fn rejects_mixed_kind_pure_allof_at_load() {
+    let directory = tempfile_dir("mixed-pure-allof");
+    let schema_path = write_file(&directory, "schema.tosd", r#"
+[toml-schema]
+version = "1.0.0"
+[types.aTable]
+type = "table"
+[types.aTable.x]
+type = "string"
+[types.anArray]
+type = "array"
+itemtype = "string"
+[types.bad]
+allof = ["types.aTable", "types.anArray"]
+[elements.value]
+type = "types.bad"
+"#);
+    Schema::load(schema_path).expect_err("mixed-kind pure allof must fail at load");
+}
+
+#[test]
+fn validates_inline_array_pattern() {
+    let directory = tempfile_dir("array-pattern");
+    let schema_path = write_file(&directory, "schema.tosd", r#"
+[toml-schema]
+version = "1.0.0"
+[elements.tags]
+type = "array"
+itemtype = "string"
+pattern = '^[a-z]+$'
+"#);
+    let valid = write_file(&directory, "valid.toml", "tags = [\"alpha\", \"beta\"]\n");
+    let invalid = write_file(&directory, "invalid.toml", "tags = [\"alpha\", \"Beta\"]\n");
+    let schema = Schema::load(schema_path).expect("array pattern must load");
+    assert!(schema.validate_file(valid).valid());
+    assert!(has_path(&schema.validate_file(invalid), "$.tags[1]"));
+}
+
+#[test]
+fn validates_inline_collection_member_constraints() {
+    let directory = tempfile_dir("collection-constraints");
+    let schema_path = write_file(&directory, "schema.tosd", r#"
+[toml-schema]
+version = "1.0.0"
+[elements.ports]
+type = "collection"
+itemtype = "integer"
+min = 1
+max = 65535
+[elements.roles]
+type = "collection"
+itemtype = "string"
+allowedvalues = ["admin", "reader"]
+[elements.tags]
+type = "collection"
+itemtype = "string"
+pattern = '^[a-z]+@example\.com$'
+[elements.emails]
+type = "collection"
+itemtype = "string"
+format = "email"
+"#);
+    let valid = write_file(&directory, "valid.toml", "[ports]\nhttp = 80\n[roles]\nowner = \"admin\"\n[tags]\nrelease = \"stable@example.com\"\n[emails]\nowner = \"admin@example.com\"\n");
+    let invalid = write_file(&directory, "invalid.toml", "[ports]\nlow = 0\nhigh = 70000\n[roles]\nowner = \"root\"\n[tags]\nrelease = \"Stable\"\n[emails]\nowner = \"not-an-email\"\n");
+    let schema = Schema::load(schema_path).expect("collection constraints must load");
+    assert!(schema.validate_file(valid).valid());
+    let result = schema.validate_file(invalid);
+    assert!(has_path(&result, "$.ports.low"));
+    assert!(has_path(&result, "$.ports.high"));
+    assert!(has_path(&result, "$.roles.owner"));
+    assert!(has_path(&result, "$.tags.release"));
+    assert!(has_path(&result, "$.emails.owner"));
+}
+
+#[test]
+fn rejects_duplicate_inline_and_itemtype_constraint_at_load() {
+    let directory = tempfile_dir("duplicate-member-constraint");
+    let schema_path = write_file(&directory, "schema.tosd", r#"
+[toml-schema]
+version = "1.0.0"
+[types.item]
+type = "integer"
+min = 0
+[elements.values]
+type = "array"
+itemtype = "types.item"
+min = -10
+"#);
+    Schema::load(schema_path).expect_err("duplicate member constraint must fail at load");
+}
+
+#[test]
+fn allows_inline_constraint_matching_itemtype_allof_constraint() {
+    let directory = tempfile_dir("inherited-member-constraint");
+    let schema_path = write_file(&directory, "schema.tosd", r#"
+[toml-schema]
+version = "1.0.0"
+[types.mixin]
+type = "string"
+allowedvalues = ["a", "b"]
+[types.item]
+type = "string"
+allof = ["types.mixin"]
+[elements.values]
+type = "array"
+itemtype = "types.item"
+allowedvalues = ["b", "c"]
+"#);
+    let schema = Schema::load(schema_path).expect("allof-acquired constraint must not conflict");
+    let valid = write_file(&directory, "valid.toml", "values = [\"b\"]\n");
+    let inline_invalid = write_file(&directory, "inline-invalid.toml", "values = [\"a\"]\n");
+    let inherited_invalid =
+        write_file(&directory, "inherited-invalid.toml", "values = [\"c\"]\n");
+    assert!(schema.validate_file(valid).valid());
+    assert!(!schema.validate_file(inline_invalid).valid());
+    assert!(!schema.validate_file(inherited_invalid).valid());
 }
 
 fn tempfile_dir(name: &str) -> PathBuf {

--- a/reference-implementations/rust/tests/integration.rs
+++ b/reference-implementations/rust/tests/integration.rs
@@ -868,6 +868,82 @@ maxlength = 2
 }
 
 #[test]
+fn enforces_per_member_allowed_values_on_containers_at_schema_load_time() {
+    let directory = tempfile_dir("container-allowedvalues");
+    let malformed_definitions = [
+        r#"
+type = "array"
+itemtype = "integer"
+allowedvalues = [ 5, 50 ]
+min = 10
+"#,
+        r#"
+type = "collection"
+itemtype = "integer"
+allowedvalues = [ 5, 50 ]
+min = 10
+"#,
+        r#"
+type = "array"
+itemtype = "integer"
+allowedvalues = [ 2, 3 ]
+max = 2
+"#,
+        r#"
+type = "array"
+itemtype = "string"
+allowedvalues = [ "ok@example.com", "nope" ]
+format = "email"
+"#,
+        r#"
+type = "collection"
+itemtype = "string"
+allowedvalues = [ "ok@example.com", "nope" ]
+format = "email"
+"#,
+    ];
+
+    for (index, definition) in malformed_definitions.iter().enumerate() {
+        let content = format!(
+            r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+{definition}
+"#
+        );
+        let schema_path = write_file(
+            &directory,
+            &format!("invalid-container-allowedvalues-{index}.tosd"),
+            &content,
+        );
+        Schema::load(&schema_path)
+            .expect_err("expected malformed container allowedvalues schema");
+    }
+
+    // `minlength`/`maxlength` bound the container, not its members, so an
+    // enumeration of longer strings must still load successfully.
+    let schema_path = write_file(
+        &directory,
+        "container-length.tosd",
+        r#"
+[toml-schema]
+version = "1.0.0"
+
+[elements.value]
+type = "array"
+itemtype = "string"
+allowedvalues = [ "aaaa", "bbbbb" ]
+maxlength = 2
+"#,
+    );
+    let schema = Schema::load(&schema_path).expect("load container with maxlength enumeration");
+    let valid_document = write_file(&directory, "container-length.toml", r#"value = [ "aaaa" ]"#);
+    assert!(schema.validate_file(valid_document).valid());
+}
+
+#[test]
 fn validates_array_allowedvalues_without_itemtype() {
     let directory = tempfile_dir("array-allowedvalues");
     let schema_path = write_file(

--- a/reference-implementations/typescript/src/schemaParser.ts
+++ b/reference-implementations/typescript/src/schemaParser.ts
@@ -250,7 +250,7 @@ function validateRangeConstraints(
   if (typeName === "any") {
     throw new SchemaError(`${name} cannot define min or max when type is any`);
   }
-  if (typeName === "array") return;
+  if (typeName === "array" || typeName === "collection") return;
   if (typeName !== undefined && !isRangeComparable(typeName)) {
     throw new SchemaError(
       `${name} can only define min or max for integer, float, date/time, or compatible array types`,
@@ -293,7 +293,7 @@ function validateAllowedValuesConstraints(
   minLength: number | undefined,
   maxLength: number | undefined,
 ): void {
-  if (allowedValues.length === 0 || typeName === "array") return;
+  if (allowedValues.length === 0 || typeName === "array" || typeName === "collection") return;
   allowedValues.forEach((allowed, index) => {
     const entry = `${name} allowedvalues[${index}]`;
     if (pattern !== undefined) {
@@ -701,9 +701,12 @@ export function parseDefinition(
   }
   if (typeName === undefined && reference === "" && !hasOneOf && !hasAnyOf && condition === undefined) {
     if (Object.keys(children).length === 0) {
-      throw new SchemaError(`${name} must define type, oneof, anyof, or child definitions`);
+      if (allOf.length === 0) {
+        throw new SchemaError(`${name} must define type, oneof, anyof, or child definitions`);
+      }
+    } else {
+      typeName = "table";
     }
-    typeName = "table";
   }
   if (Object.keys(children).length > 0 && typeName !== "table" && typeName !== "collection") {
     throw new SchemaError(`${name} can only define children when type is table or collection`);
@@ -727,6 +730,9 @@ export function parseDefinition(
     if (propertyValue(table, "min") !== undefined || propertyValue(table, "max") !== undefined) {
       throw new SchemaError(`${name} cannot define min or max together with items`);
     }
+    if (patternResult !== undefined || format !== undefined) {
+      throw new SchemaError(`${name} cannot define pattern or format together with items`);
+    }
   }
   const min = propertyValue(table, "min");
   const max = propertyValue(table, "max");
@@ -736,13 +742,18 @@ export function parseDefinition(
   if (keyPatternResult !== undefined && typeName !== "collection") {
     throw new SchemaError(`${name} can only define keypattern when type is collection`);
   }
-  if (patternResult !== undefined && typeName !== "string") {
+  if (
+    patternResult !== undefined &&
+    typeName !== "string" &&
+    typeName !== "array" &&
+    typeName !== "collection"
+  ) {
     throw new SchemaError(`${name} can only define pattern when type is string`);
   }
-  if (format !== undefined && typeName !== "string") {
+  if (format !== undefined && typeName !== "string" && typeName !== "array" && typeName !== "collection") {
     throw new SchemaError(`${name} can only define format when type is string`);
   }
-  if (hasAllowedValues && (typeName === "table" || typeName === "collection")) {
+  if (hasAllowedValues && typeName === "table") {
     throw new SchemaError(`${name} can only define allowedvalues for scalar, unconstrained, or array types`);
   }
   if (

--- a/reference-implementations/typescript/src/schemaParser.ts
+++ b/reference-implementations/typescript/src/schemaParser.ts
@@ -293,7 +293,8 @@ function validateAllowedValuesConstraints(
   minLength: number | undefined,
   maxLength: number | undefined,
 ): void {
-  if (allowedValues.length === 0 || typeName === "array" || typeName === "collection") return;
+  if (allowedValues.length === 0) return;
+  const isContainer = typeName === "array" || typeName === "collection";
   allowedValues.forEach((allowed, index) => {
     const entry = `${name} allowedvalues[${index}]`;
     if (pattern !== undefined) {
@@ -331,7 +332,7 @@ function validateAllowedValuesConstraints(
       }
       if (comparison > 0) throw new SchemaError(`${entry} is greater than max`);
     }
-    if (minLength !== undefined || maxLength !== undefined) {
+    if (!isContainer && (minLength !== undefined || maxLength !== undefined)) {
       if (typeof allowed !== "string") {
         throw new SchemaError(`${entry} does not satisfy string length constraints`);
       }

--- a/reference-implementations/typescript/src/semantics.ts
+++ b/reference-implementations/typescript/src/semantics.ts
@@ -100,15 +100,16 @@ export function effectiveKind(
   }
   const allOf = definition.allOf ?? [];
   if (allOf.length === 0) return result;
-  if (!result.resolved || result.kind === "any") {
-    throw new SchemaError("allof requires a determinate effective kind");
-  }
   for (const reference of allOf) {
     const component = definitionForReference(data, reference);
     const componentResult = effectiveKind(data, component, visiting);
-    if (!componentResult.resolved || componentResult.kind === "any" || componentResult.kind !== result.kind) {
+    if (!componentResult.resolved || componentResult.kind === "any") {
+      throw new SchemaError(`allof component ${reference} has indeterminate effective kind`);
+    }
+    if (result.resolved && componentResult.kind !== result.kind) {
       throw new SchemaError(`allof component ${reference} has incompatible effective kind`);
     }
+    if (!result.resolved) result = componentResult;
   }
   return { kind: result.kind, resolved: true };
 }
@@ -341,6 +342,9 @@ function validateDefinitionSemantics(data: SchemaData, definition: RawDefinition
       throw new SchemaError(`${definition.name} effective collection must define at least one itemtype`);
     }
   }
+  if (definition.typeName === "array" || definition.typeName === "collection") {
+    validateMemberConstraints(data, definition);
+  }
   if (definition.condition && (!resolved || (kind !== "table" && kind !== "collection"))) {
     throw new SchemaError(
       `${definition.name} conditional selector requires compatible table or collection branches`,
@@ -364,9 +368,81 @@ function validateDefinitionSemantics(data: SchemaData, definition: RawDefinition
         );
       }
     }
+
   }
   for (const child of Object.values(definition.children)) {
     validateDefinitionSemantics(data, child);
+  }
+}
+
+function validateMemberConstraints(data: SchemaData, definition: RawDefinition): void {
+  const hasRange = definition.min !== undefined || definition.max !== undefined;
+  const hasStringConstraint = definition.pattern !== undefined || definition.format !== undefined;
+  if (hasRange || hasStringConstraint) {
+    const itemResult = resolveItemKind(data, definition.itemReference, new Set());
+    if (!itemResult.resolved) {
+      throw new SchemaError(
+        hasRange
+          ? `${definition.name} can only define min or max when itemtype resolves to one comparable built-in type`
+          : `${definition.name} per-member constraints require a determinate itemtype`,
+      );
+    }
+    if (hasRange && !isRangeComparable(itemResult.kind)) {
+      throw new SchemaError(
+        `${definition.name} can only define min or max when itemtype resolves to one comparable built-in type`,
+      );
+    }
+    if (hasStringConstraint && itemResult.kind !== "string") {
+      throw new SchemaError(`${definition.name} can only define pattern or format when itemtype resolves to string`);
+    }
+  }
+  for (const [property, present] of [
+    ["allowedvalues", (definition.allowedValues?.length ?? 0) > 0],
+    ["min", definition.min !== undefined],
+    ["max", definition.max !== undefined],
+    ["pattern", definition.pattern !== undefined],
+    ["format", definition.format !== undefined],
+  ] as const) {
+    if (
+      present &&
+      definition.itemReference &&
+      referenceHasConstraint(data, definition.itemReference, property, new Set())
+    ) {
+      throw new SchemaError(
+        `${definition.name} defines ${property} both inline and on its resolved itemtype`,
+      );
+    }
+  }
+}
+
+function referenceHasConstraint(
+  data: SchemaData,
+  reference: string,
+  property: string,
+  visiting: Set<string>,
+): boolean {
+  if (isBuiltIn(reference)) return false;
+  if (visiting.has(reference)) throw new SchemaError(`cyclic type reference: ${reference}`);
+  const definition = data.types[reference];
+  if (!definition) throw new SchemaError(`unknown type reference: ${reference}`);
+  visiting.add(reference);
+  try {
+    const local =
+      (property === "allowedvalues" && (definition.allowedValues?.length ?? 0) > 0) ||
+      (property === "min" && definition.min !== undefined) ||
+      (property === "max" && definition.max !== undefined) ||
+      (property === "pattern" && definition.pattern !== undefined) ||
+      (property === "format" && definition.format !== undefined);
+    if (local) return true;
+    const references = [
+      ...(definition.reference ? [definition.reference] : []),
+      ...(definition.oneOf ?? []),
+      ...(definition.anyOf ?? []),
+      ...(definition.condition ? [definition.thenReference ?? "", definition.elseReference ?? ""] : []),
+    ];
+    return references.some((nested) => nested !== "" && referenceHasConstraint(data, nested, property, visiting));
+  } finally {
+    visiting.delete(reference);
   }
 }
 
@@ -432,7 +508,10 @@ function validateSelectorCycle(
 
 export function validateArrayRanges(data: SchemaData): void {
   const validateDefinition = (definition: RawDefinition): void => {
-    if (definition.typeName === "array" && (definition.min !== undefined || definition.max !== undefined)) {
+    if (
+      (definition.typeName === "array" || definition.typeName === "collection") &&
+      (definition.min !== undefined || definition.max !== undefined)
+    ) {
       let itemResult: EffectiveKindResult;
       try {
         itemResult = resolveItemKind(data, definition.itemReference, new Set());
@@ -465,7 +544,7 @@ export function validateAllowedValueTypes(data: SchemaData): void {
     const allowedValues = definition.allowedValues ?? [];
     if (allowedValues.length > 0) {
       const permittedTypes = new Set<SchemaType>();
-      if (definition.typeName === "array") {
+      if (definition.typeName === "array" || definition.typeName === "collection") {
         if (definition.itemReference) {
           collectReferenceTypes(data, definition.itemReference, new Set(), permittedTypes);
         }

--- a/reference-implementations/typescript/src/validator.ts
+++ b/reference-implementations/typescript/src/validator.ts
@@ -11,7 +11,6 @@ import { isValidStringFormat } from "./formats.js";
 import { appendPath } from "./paths.js";
 import {
   effectiveKind,
-  resolveItemKind,
   type SchemaData,
 } from "./semantics.js";
 import {
@@ -298,6 +297,15 @@ export class DocumentValidator {
     definition: RawDefinition,
     inheritedKeys: ReadonlySet<string> | undefined,
   ): void {
+    if (
+      definition.typeName === undefined &&
+      !definition.reference &&
+      (definition.oneOf?.length ?? 0) === 0 &&
+      (definition.anyOf?.length ?? 0) === 0 &&
+      !definition.condition
+    ) {
+      definition = cloneDefinition(definition, { typeName: kind });
+    }
     let parts: CompositionParts;
     try {
       parts = this.compositionParts(definition, new Set());
@@ -432,6 +440,7 @@ export class DocumentValidator {
           if (component.keyPattern && !component.keyPattern.test(key)) {
             this.add(childPath, `key does not match keypattern ${component.keyPatternSource}`);
           }
+          this.validateMemberValueConstraints(childPath, entry, component);
           // A composed collection may take its dynamic-entry constraint
           // entirely from another contributor.
           if (!component.itemReference) continue;
@@ -606,6 +615,7 @@ export class DocumentValidator {
       try {
         const referenced = this.resolveReference(definition.itemReference, new Set());
         this.validateValue(childPath, value, referenced);
+        this.validateMemberValueConstraints(childPath, value, definition);
       } catch (cause) {
         this.add(childPath, errorMessage(cause));
       }
@@ -654,22 +664,10 @@ export class DocumentValidator {
       this.add(path, errorMessage(cause));
       return;
     }
-    let rangeType: SchemaType | undefined;
-    let hasRangeType = false;
-    try {
-      ({ kind: rangeType, resolved: hasRangeType } = resolveItemKind(this.#data, definition.itemReference, new Set()));
-    } catch {
-      hasRangeType = false;
-    }
     array.forEach((item, index) => {
       const itemPath = `${path}[${index}]`;
       this.validateValue(itemPath, item, itemDefinition);
-      if ((definition.allowedValues?.length ?? 0) > 0) {
-        this.validateAllowedValues(itemPath, item, definition);
-      }
-      if (hasRangeType && rangeType !== undefined && isType(item, rangeType)) {
-        this.validateRange(itemPath, item, definition);
-      }
+      this.validateMemberValueConstraints(itemPath, item, definition);
     });
   }
 
@@ -729,6 +727,7 @@ export class DocumentValidator {
       this.validateLength(path, value.length, definition);
       return;
     }
+    if (isTomlTable(value) && definition.typeName === "collection") return;
     this.validateAllowedValues(path, value, definition);
     if ((definition.allowedValues?.length ?? 0) > 0) return;
     this.validateRange(path, value, definition);
@@ -748,6 +747,19 @@ export class DocumentValidator {
     if (allowedValues.length === 0) return;
     if (allowedValues.some((allowed) => valuesEqual(allowed, value))) return;
     this.add(path, "value is not in allowedvalues");
+  }
+
+  private validateMemberValueConstraints(path: string, value: TomlValue, definition: RawDefinition): void {
+    this.validateAllowedValues(path, value, definition);
+    if ((definition.allowedValues?.length ?? 0) === 0) this.validateRange(path, value, definition);
+    if (typeof value === "string") {
+      if (definition.pattern && !definition.pattern.test(value)) {
+        this.add(path, `does not match pattern ${definition.patternSource}`);
+      }
+      if (definition.format && !isValidStringFormat(definition.format, value)) {
+        this.add(path, `is not a valid ${definition.format}`);
+      }
+    }
   }
 
   private validateRange(path: string, value: TomlValue, definition: RawDefinition): void {

--- a/reference-implementations/typescript/test/phase3-structure.test.ts
+++ b/reference-implementations/typescript/test/phase3-structure.test.ts
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { loadSchemaFromSource } from "../src/index.js";
+
+test("loads a pure allof mixin and validates its determinate children", () => {
+  const schema = loadSchemaFromSource("pure-allof.tosd", `
+[toml-schema]
+version = "1.0.0"
+[types.named]
+type = "table"
+[types.named.name]
+type = "string"
+[types.packageBase]
+type = "table"
+[types.packageBase.version]
+type = "string"
+[types.package]
+allof = ["types.packageBase", "types.named"]
+dependentrequired = { name = ["version"] }
+[types.positive]
+type = "integer"
+min = 1
+[types.small]
+type = "integer"
+max = 10
+[types.count]
+allof = ["types.positive", "types.small"]
+[elements.pkg]
+type = "types.package"
+[elements.count]
+type = "types.count"
+`);
+  assert.equal(schema.validate({ pkg: { name: "x", version: "1" }, count: 5n }).valid, true);
+  assert.equal(schema.validate({ pkg: { name: "x", version: "1" }, count: 0n }).valid, false);
+});
+
+test("rejects a mixed-kind pure allof at load time", () => {
+  assert.throws(() => loadSchemaFromSource("mixed-allof.tosd", `
+[toml-schema]
+version = "1.0.0"
+[types.aTable]
+type = "table"
+[types.aTable.x]
+type = "string"
+[types.anArray]
+type = "array"
+itemtype = "string"
+[types.bad]
+allof = ["types.aTable", "types.anArray"]
+[elements.value]
+type = "types.bad"
+`));
+});
+
+test("validates inline array patterns", () => {
+  const schema = loadSchemaFromSource("array-pattern.tosd", `
+[toml-schema]
+version = "1.0.0"
+[elements.tags]
+type = "array"
+itemtype = "string"
+pattern = '^[a-z]+$'
+`);
+  assert.equal(schema.validate({ tags: ["alpha", "beta"] }).valid, true);
+  assert.equal(schema.validate({ tags: ["alpha", "Beta"] }).valid, false);
+});
+
+test("validates inline collection member constraints", () => {
+  const schema = loadSchemaFromSource("collection-constraints.tosd", `
+[toml-schema]
+version = "1.0.0"
+[elements.ports]
+type = "collection"
+itemtype = "integer"
+min = 1
+max = 65535
+[elements.roles]
+type = "collection"
+itemtype = "string"
+allowedvalues = ["admin", "reader"]
+[elements.tags]
+type = "collection"
+itemtype = "string"
+pattern = '^[a-z]+@example\\.com$'
+[elements.emails]
+type = "collection"
+itemtype = "string"
+format = "email"
+`);
+  assert.equal(schema.validate({
+    ports: { http: 80n },
+    roles: { owner: "admin" },
+    tags: { release: "stable@example.com" },
+    emails: { owner: "admin@example.com" },
+  }).valid, true);
+  for (const invalid of [
+    { ports: { http: 0n }, roles: { owner: "admin" }, tags: { release: "stable@example.com" }, emails: { owner: "admin@example.com" } },
+    { ports: { http: 70000n }, roles: { owner: "admin" }, tags: { release: "stable@example.com" }, emails: { owner: "admin@example.com" } },
+    { ports: { http: 80n }, roles: { owner: "root" }, tags: { release: "stable@example.com" }, emails: { owner: "admin@example.com" } },
+    { ports: { http: 80n }, roles: { owner: "admin" }, tags: { release: "Stable" }, emails: { owner: "admin@example.com" } },
+    { ports: { http: 80n }, roles: { owner: "admin" }, tags: { release: "stable@example.com" }, emails: { owner: "not-an-email" } },
+  ]) assert.equal(schema.validate(invalid).valid, false);
+});
+
+test("rejects duplicate inline and itemtype constraints at load time", () => {
+  assert.throws(() => loadSchemaFromSource("duplicate-constraint.tosd", `
+[toml-schema]
+version = "1.0.0"
+[types.item]
+type = "integer"
+min = 0
+[elements.values]
+type = "array"
+itemtype = "types.item"
+min = -10
+`));
+});
+
+test("allows an inline constraint matching one acquired by itemtype allof", () => {
+  const schema = loadSchemaFromSource("inherited-constraint.tosd", `
+[toml-schema]
+version = "1.0.0"
+[types.mixin]
+type = "string"
+allowedvalues = ["a", "b"]
+[types.item]
+type = "string"
+allof = ["types.mixin"]
+[elements.values]
+type = "array"
+itemtype = "types.item"
+allowedvalues = ["b", "c"]
+`);
+  assert.equal(schema.validate({ values: ["b"] }).valid, true);
+  assert.equal(schema.validate({ values: ["a"] }).valid, false);
+  assert.equal(schema.validate({ values: ["c"] }).valid, false);
+});

--- a/reference-implementations/typescript/test/phase3-structure.test.ts
+++ b/reference-implementations/typescript/test/phase3-structure.test.ts
@@ -116,6 +116,36 @@ min = -10
 `));
 });
 
+test("rejects a container enumeration that violates a per-member constraint", () => {
+  const cases = [
+    `[elements.value]\ntype = "array"\nitemtype = "integer"\nallowedvalues = [5, 50]\nmin = 10\n`,
+    `[elements.value]\ntype = "collection"\nitemtype = "integer"\nallowedvalues = [5, 50]\nmin = 10\n`,
+    `[elements.value]\ntype = "array"\nitemtype = "integer"\nallowedvalues = [2, 3]\nmax = 2\n`,
+    `[elements.value]\ntype = "array"\nitemtype = "string"\nallowedvalues = ["ok@example.com", "nope"]\nformat = "email"\n`,
+    `[elements.value]\ntype = "collection"\nitemtype = "string"\nallowedvalues = ["ok@example.com", "nope"]\nformat = "email"\n`,
+  ];
+  cases.forEach((definition, index) => {
+    assert.throws(() =>
+      loadSchemaFromSource(
+        `invalid-container-${index}.tosd`,
+        `[toml-schema]\nversion = "1.0.0"\n${definition}`,
+      ),
+    );
+  });
+
+  // minlength/maxlength bound the container, not its members.
+  const schema = loadSchemaFromSource("container-length.tosd", `
+[toml-schema]
+version = "1.0.0"
+[elements.value]
+type = "array"
+itemtype = "string"
+allowedvalues = ["aaaa", "bbbbb"]
+maxlength = 2
+`);
+  assert.equal(schema.validate({ value: ["aaaa"] }).valid, true);
+});
+
 test("allows an inline constraint matching one acquired by itemtype allof", () => {
   const schema = loadSchemaFromSource("inherited-constraint.tosd", `
 [toml-schema]

--- a/toml-schema.tosd
+++ b/toml-schema.tosd
@@ -220,6 +220,16 @@ itemtype = "types.never"
     type = "string"
     optional = true
 
+# `allowedvalues`, `min`, `max`, `pattern`, and `format` are the per-member
+# value-constraint subset: on an array they constrain each item, not the array.
+    [types.arrayDefinition.format]
+    type = "types.stringFormat"
+    optional = true
+
+    [types.arrayDefinition.pattern]
+    type = "string"
+    optional = true
+
     [types.arrayDefinition.allowedvalues]
     type = "types.nonEmptyValues"
     optional = true
@@ -357,6 +367,29 @@ itemtype = "types.schemaDef"
 
     [types.collectionDefinition.children.keypattern]
     oneof = [ "string", "types.schemaDef" ]
+    optional = true
+
+# `allowedvalues`, `min`, `max`, `pattern`, and `format` are the per-member
+# value-constraint subset: on a collection they constrain each dynamic entry's
+# value, not the collection. `keypattern` above constrains the entry key.
+    [types.collectionDefinition.children.format]
+    oneof = [ "types.stringFormat", "types.schemaDef" ]
+    optional = true
+
+    [types.collectionDefinition.children.pattern]
+    oneof = [ "string", "types.schemaDef" ]
+    optional = true
+
+    [types.collectionDefinition.children.allowedvalues]
+    oneof = [ "types.nonEmptyValues", "types.schemaDef" ]
+    optional = true
+
+    [types.collectionDefinition.children.min]
+    oneof = [ "integer", "float", "offset-date-time", "local-date-time", "local-date", "local-time", "types.schemaDef" ]
+    optional = true
+
+    [types.collectionDefinition.children.max]
+    oneof = [ "integer", "float", "offset-date-time", "local-date-time", "local-date", "local-time", "types.schemaDef" ]
     optional = true
 
     [types.collectionDefinition.children.minlength]
@@ -548,6 +581,32 @@ itemtype = "types.schemaDef"
     anyof = [ "types.escapedChildren", "types.literalChildren" ]
     optional = true
 
+# A pure mixin: a non-empty `allof` is the only applicator, so the composition
+# supplies the effective type. It declares no selector and no nested child
+# definitions, which is why dynamic entries validate against `never`.
+[types.mixinDefinition]
+type = "collection"
+itemtype = "types.never"
+
+    [types.mixinDefinition.allof]
+    type = "types.uniqueTypeReferences"
+
+    [types.mixinDefinition.description]
+    type = "string"
+    optional = true
+
+    [types.mixinDefinition.optional]
+    type = "boolean"
+    optional = true
+
+    [types.mixinDefinition.default]
+    type = "any"
+    optional = true
+
+    [types.mixinDefinition.deprecated]
+    type = "boolean"
+    optional = true
+
 [types.schemaDef]
 anyof = [
     "types.stringDefinition",
@@ -561,6 +620,7 @@ anyof = [
     "types.unionDefinition",
     "types.conditionalDefinition",
     "types.implicitTableDefinition",
+    "types.mixinDefinition",
 ]
 
 [types.escapedChildren]


### PR DESCRIPTION
Third phase of the multi-model specification review. Phase 1 (#167) fixed correctness blockers and Phase 2 (#168) supplied the missing normative algorithms. Both left the document correct but hard to navigate: rules were stated in several places at once, requirements hid in prose, and 55% of the spec had accumulated under a heading that only promised to describe the `[types]` table.

This phase closes two language gaps and then makes four cohesion passes over the result.

## Two language decisions

**Pure `allof` mixins.** A definition whose only applicator is a non-empty `allof`, with no selector of its own, is now valid; its components supply the effective type. They MUST resolve to exactly one TOML kind, and a mixed-kind composition is a schema-load error.

**Per-member value constraints.** `allowedvalues`, `min`, `max`, `pattern`, and `format` may now be written inline on `array` and `collection` to constrain each member. This is purely additive. `minlength`/`maxlength` are deliberately excluded, because on a container those spellings already mean container length. Declaring the same constraint both inline and on the resolved `itemtype` is a load error, keyed on the constraint appearing in both places rather than on the two values being equal.

Worth a careful look: a constraint that the `itemtype` definition acquires from its *own* `allof` is excluded from that collision check and merges conjunctively. Without the exclusion, adding a mixin could break an unrelated schema that never referenced it.

I originally scoped the second decision as `itemtype`-only routing, then measured the blast radius and found both worked examples in the repository use the concise inline form. The symmetric model is what's implemented here.

## Four cohesion passes

- **Single authority.** Added a type-reference restriction matrix and collapsed restated rules into cross-references. Every restriction now has exactly one home.
- **Normative language.** Requirements stated as prose became BCP 14 keywords, and informative sections are now labeled as such.
- **Consistent shape.** Every keyword section follows one template.
- **Structure.** `## Types Table` had grown to 2482 lines, 55% of the document; nearly the whole definition vocabulary sat under a heading a reader had no reason to open. It is now 29 lines, covering only the `[types]` table itself, with the vocabulary promoted into a new `## Schema Definitions` ordered selectors, annotations, constraints, containers, composition.

`optional` moved to Constraints rather than Annotations. The document defines an annotation as a property that never decides validity and names exactly three; a missing required key is invalid, so `optional` is an assertion. Grouping it with the annotations would have contradicted the document's own taxonomy.

That structural pass ran last, after content was final, so it could be a pure move. Verified as one: comparing the multiset of non-heading body lines before and after, the only differences are nine retargeted cross-references and a single transitional word.

## A contradiction the cohesion work exposed

Adversarial verification of the finished branch found that the `allowedvalues` consistency check was stated twice, in disagreeing forms. `Allowed Values` exempted arrays and collections; `Observations on Conditions to Arrays` required the check for arrays. Both clauses are on `main` already, so the contradiction is not new, but it was unreachable and nobody had hit it.

This phase made it reachable, by extending per-member constraints to collections, and made it provable, by adding the guarantee that the inline and `itemtype` spellings MUST validate identically. Measured before the fix, the same author error was rejected on a scalar and on an `itemtype` definition but silently accepted inline on a container, so the two spellings disagreed against an explicit MUST.

The exemption could not just be deleted, because it was not arbitrary: on a container, `minlength`/`maxlength` bound the container, so an unscoped check would compare an enumerated item against a container length. The rule is now scoped to the constraints that describe the same values the enumeration does.

All six loaders disagreed here, each honoring a different clause. Java skipped only arrays and so alone rejected the collection case; Python and .NET carried a separate unconditional `format` check that fired where their own early return said it should not; .NET had no `pattern`/`min`/`max` consistency check at all and accepted even the scalar case. All six now agree.

Both regressions are now covered: a container enumeration that violates a sibling constraint (untested before, because every existing fixture used an enumeration that already satisfied its siblings), and `maxlength` on a container staying a container bound.

## Verification

All six implementations updated and passing: Rust 91, Go ok, Java 133, Python 104, .NET 119, TypeScript 90.

Spec integrity checked mechanically: 105 headings, 383 link occurrences, zero broken anchors and zero duplicate slugs (the real hazard when promoting headings), and 55 of 57 fenced `toml` blocks parse, the two failures being the known intentional templates. BCP 14 keyword counts moved only where a pass intended them to.

One deliberate non-fix: the self-schema accepts a definition declaring no selector, no child, and no `allof`. A faithful fix takes self-validation from 0.4s to over 120s, so it is documented in the spec instead.